### PR TITLE
Add an AVX2 version of the BLEND_PREMULTIPLIED blend mode

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -581,6 +581,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
+                        src->format->Amask == 0xFF000000 &&
                         info.src_blend != SDL_BLENDMODE_NONE &&
                         pg_HasSSE_NEON() && (src != dst)) {
                         blit_blend_premultiplied_sse2(&info);

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -109,10 +109,6 @@ blit_blend_rgba_max(SDL_BlitInfo *info);
 
 static void
 blit_blend_premultiplied(SDL_BlitInfo *info);
-#ifdef __MMX__
-static void
-blit_blend_premultiplied_mmx(SDL_BlitInfo *info);
-#endif /*  __MMX__ */
 
 static int
 SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
@@ -567,27 +563,32 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                     break;
                 }
                 case PYGAME_BLEND_PREMULTIPLIED: {
+#if !defined(__EMSCRIPTEN__)
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
                     if (src->format->BytesPerPixel == 4 &&
                         dst->format->BytesPerPixel == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
-                        info.src_blend != SDL_BLENDMODE_NONE) {
-#if defined(__MMX__) || defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)
-#if PG_ENABLE_SSE_NEON
-                        if (pg_HasSSE_NEON()) {
-                            blit_blend_premultiplied_sse2(&info);
-                            break;
-                        }
-#endif /* PG_ENABLE_SSE_NEON */
-#ifdef __MMX__
-                        if (SDL_HasMMX() == SDL_TRUE) {
-                            blit_blend_premultiplied_mmx(&info);
-                            break;
-                        }
-#endif /*__MMX__*/
-#endif /*__MMX__ || __SSE2__ || PG_ENABLE_ARM_NEON*/
+                        info.src_blend != SDL_BLENDMODE_NONE &&
+                        pg_has_avx2() && (src != dst)) {
+                        blit_blend_premultiplied_avx2(&info);
+                        break;
                     }
+#if PG_ENABLE_SSE_NEON
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        info.src_blend != SDL_BLENDMODE_NONE &&
+                        pg_HasSSE_NEON() && (src != dst)) {
+                        blit_blend_premultiplied_sse2(&info);
+                        break;
+                    }
+#endif /* PG_ENABLE_SSE_NEON */
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
+#endif /* __EMSCRIPTEN__ */
 
                     blit_blend_premultiplied(&info);
                     break;
@@ -1261,83 +1262,6 @@ blit_blend_rgba_max(SDL_BlitInfo *info)
         }
     }
 }
-
-#ifdef __MMX__
-/* fast ARGB888->(A)RGB888 blending with pixel alpha */
-static void
-blit_blend_premultiplied_mmx(SDL_BlitInfo *info)
-{
-    int n;
-    int width = info->width;
-    int height = info->height;
-    Uint32 *srcp = (Uint32 *)info->s_pixels;
-    int srcskip = info->s_skip >> 2;
-    Uint32 *dstp = (Uint32 *)info->d_pixels;
-    int dstskip = info->d_skip >> 2;
-    SDL_PixelFormat *srcfmt = info->src;
-    Uint32 amask = srcfmt->Amask;
-    Uint32 ashift = srcfmt->Ashift;
-    Uint64 multmask2;
-
-    __m64 src1, dst1, mm_alpha, mm_zero, mm_alpha2;
-
-    mm_zero = _mm_setzero_si64(); /* 0 -> mm_zero */
-    multmask2 = 0x00FF00FF00FF00FFULL;
-
-    while (height--) {
-        /* *INDENT-OFF* */
-        LOOP_UNROLLED4(
-            {
-                Uint32 alpha = *srcp & amask;
-                if (alpha == 0) {
-                    /* do nothing */
-                }
-                else if (alpha == amask) {
-                    *dstp = *srcp;
-                }
-                else {
-                    src1 = _mm_cvtsi32_si64(
-                        *srcp); /* src(ARGB) -> src1 (0000ARGB) */
-                    src1 =
-                        _mm_unpacklo_pi8(src1, mm_zero); /* 0A0R0G0B -> src1 */
-
-                    dst1 = _mm_cvtsi32_si64(
-                        *dstp); /* dst(ARGB) -> dst1 (0000ARGB) */
-                    dst1 =
-                        _mm_unpacklo_pi8(dst1, mm_zero); /* 0A0R0G0B -> dst1 */
-
-                    mm_alpha = _mm_cvtsi32_si64(
-                        alpha); /* alpha -> mm_alpha (0000000A) */
-                    mm_alpha = _mm_srli_si64(
-                        mm_alpha,
-                        ashift); /* mm_alpha >> ashift -> mm_alpha(0000000A) */
-                    mm_alpha = _mm_unpacklo_pi16(
-                        mm_alpha, mm_alpha); /* 00000A0A -> mm_alpha */
-                    mm_alpha2 = _mm_unpacklo_pi32(
-                        mm_alpha, mm_alpha); /* 0A0A0A0A -> mm_alpha2 */
-                    mm_alpha2 = _mm_xor_si64(
-                        mm_alpha2,
-                        *(__m64 *)&multmask2); /* 255 - mm_alpha -> mm_alpha */
-
-                    /* pre-multiplied alpha blend */
-                    dst1 = _mm_mullo_pi16(dst1, mm_alpha2);
-                    dst1 = _mm_srli_pi16(dst1, 8);
-                    dst1 = _mm_add_pi16(src1, dst1);
-                    dst1 = _mm_packs_pu16(dst1, mm_zero);
-
-                    *dstp = _mm_cvtsi64_si32(dst1); /* dst1 -> pixel */
-                }
-                ++srcp;
-                ++dstp;
-            },
-            n, width);
-        /* *INDENT-ON* */
-        srcp += srcskip;
-        dstp += dstskip;
-    }
-    _mm_empty();
-}
-#endif /*__MMX__*/
 
 static void
 blit_blend_premultiplied(SDL_BlitInfo *info)

--- a/src_c/simd_blitters.h
+++ b/src_c/simd_blitters.h
@@ -82,3 +82,5 @@ void
 blit_blend_rgba_min_avx2(SDL_BlitInfo *info);
 void
 blit_blend_rgb_min_avx2(SDL_BlitInfo *info);
+void
+blit_blend_premultiplied_avx2(SDL_BlitInfo *info);

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -909,3 +909,174 @@ blit_blend_rgb_min_avx2(SDL_BlitInfo *info)
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */
+
+#if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
+    !defined(SDL_DISABLE_IMMINTRIN_H)
+void
+blit_blend_premultiplied_avx2(SDL_BlitInfo *info)
+{
+    int n;
+    int width = info->width;
+    int height = info->height;
+
+    Uint32 *srcp = (Uint32 *)info->s_pixels;
+    int srcskip = info->s_skip >> 2;
+    int srcpxskip = info->s_pxskip >> 2;
+
+    Uint32 *dstp = (Uint32 *)info->d_pixels;
+    int dstskip = info->d_skip >> 2;
+    int dstpxskip = info->d_pxskip >> 2;
+
+    int pre_8_width = width % 8;
+    int post_8_width = (width - pre_8_width) / 8;
+
+    /* if either surface has a non-zero alpha mask use that as our mask */
+    Uint32 amask = info->src->Amask | info->dst->Amask;
+
+    __m256i *srcp256 = (__m256i *)info->s_pixels;
+    __m256i *dstp256 = (__m256i *)info->d_pixels;
+
+    __m128i mm_src, mm_dst, mm_zero, mm_alpha, mm_sub_dst, mm_ones;
+    __m256i mm256_src, mm256_dst, mm256_shuff_mask_A, mm256_shuff_mask_B,
+        mm256_src_shuff, mm256_dstA, mm256_dstB, mm256_ones, mm256_alpha,
+        mm256_shuff_alpha_mask_A, mm256_shuff_alpha_mask_B;
+
+    mm_zero = _mm_setzero_si128();
+    mm_ones = _mm_set_epi64x(0x0000000000000000, 0x0001000100010001);
+
+    mm256_shuff_mask_A =
+        _mm256_set_epi8(0x80, 23, 0x80, 22, 0x80, 21, 0x80, 20, 0x80, 19, 0x80,
+                        18, 0x80, 17, 0x80, 16, 0x80, 7, 0x80, 6, 0x80, 5,
+                        0x80, 4, 0x80, 3, 0x80, 2, 0x80, 1, 0x80, 0);
+
+    mm256_shuff_alpha_mask_A =
+        _mm256_set_epi8(0x80, 23, 0x80, 23, 0x80, 23, 0x80, 23, 0x80, 19, 0x80,
+                        19, 0x80, 19, 0x80, 19, 0x80, 7, 0x80, 7, 0x80, 7,
+                        0x80, 7, 0x80, 3, 0x80, 3, 0x80, 3, 0x80, 3);
+
+    mm256_shuff_mask_B =
+        _mm256_set_epi8(0x80, 31, 0x80, 30, 0x80, 29, 0x80, 28, 0x80, 27, 0x80,
+                        26, 0x80, 25, 0x80, 24, 0x80, 15, 0x80, 14, 0x80, 13,
+                        0x80, 12, 0x80, 11, 0x80, 10, 0x80, 9, 0x80, 8);
+
+    mm256_shuff_alpha_mask_B =
+        _mm256_set_epi8(0x80, 31, 0x80, 31, 0x80, 31, 0x80, 31, 0x80, 27, 0x80,
+                        27, 0x80, 27, 0x80, 27, 0x80, 15, 0x80, 15, 0x80, 15,
+                        0x80, 15, 0x80, 11, 0x80, 11, 0x80, 11, 0x80, 11);
+
+    mm256_ones = _mm256_set_epi8(
+        0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01,
+        0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01,
+        0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01);
+
+    while (height--) {
+        if (pre_8_width > 0) {
+            /* one pixel at a time - same as current sse2 version */
+            LOOP_UNROLLED4(
+                {
+                    Uint32 alpha = *srcp & amask;
+                    if (alpha == 0) {
+                        /* do nothing */
+                    }
+                    else if (alpha == amask) {
+                        *dstp = *srcp;
+                    }
+                    else {
+                        mm_src = _mm_cvtsi32_si128(*srcp);
+                        /*mm_src = 0x000000000000000000000000AARRGGBB*/
+                        mm_src = _mm_unpacklo_epi8(mm_src, mm_zero);
+                        /*mm_src = 0x000000000000000000AA00RR00GG00BB*/
+                        mm_dst = _mm_cvtsi32_si128(*dstp);
+                        /*mm_dst = 0x000000000000000000000000AARRGGBB*/
+                        mm_dst = _mm_unpacklo_epi8(mm_dst, mm_zero);
+                        /*mm_dst = 0x000000000000000000AA00RR00GG00BB*/
+
+                        mm_alpha = _mm_cvtsi32_si128(alpha);
+                        /* alpha -> mm_alpha (000000000000A000) */
+                        mm_alpha = _mm_srli_si128(mm_alpha, 3);
+                        /* mm_alpha >> ashift -> mm_alpha(000000000000000A) */
+                        mm_alpha = _mm_unpacklo_epi16(mm_alpha, mm_alpha);
+                        /* 0000000000000A0A -> mm_alpha */
+                        mm_alpha = _mm_unpacklo_epi32(mm_alpha, mm_alpha);
+                        /* 000000000A0A0A0A -> mm_alpha2 */
+
+                        /* pre-multiplied alpha blend */
+                        mm_sub_dst = _mm_add_epi16(mm_dst, mm_ones);
+                        mm_sub_dst = _mm_mullo_epi16(mm_sub_dst, mm_alpha);
+                        mm_sub_dst = _mm_srli_epi16(mm_sub_dst, 8);
+                        mm_dst = _mm_add_epi16(mm_src, mm_dst);
+                        mm_dst = _mm_sub_epi16(mm_dst, mm_sub_dst);
+                        mm_dst = _mm_packus_epi16(mm_dst, mm_zero);
+
+                        *dstp = _mm_cvtsi128_si32(mm_dst);
+                    }
+
+                    srcp += srcpxskip;
+                    dstp += dstpxskip;
+                },
+                n, pre_8_width);
+        }
+        srcp256 = (__m256i *)srcp;
+        dstp256 = (__m256i *)dstp;
+        if (post_8_width > 0) {
+            /*8 pixels at a time, need to use shuffle to get everything
+                lined up - see mul for an example*/
+            LOOP_UNROLLED4(
+                {
+                    mm256_src = _mm256_loadu_si256(srcp256);
+                    mm256_dst = _mm256_loadu_si256(dstp256);
+
+                    /* insert 8 pixel at a time blend here */
+
+                    /* do everything A set first */
+                    mm256_dstA =
+                        _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_A);
+                    mm256_src_shuff =
+                        _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_A);
+                    mm256_alpha = _mm256_shuffle_epi8(
+                        mm256_src, mm256_shuff_alpha_mask_A);
+                    mm256_src_shuff =
+                        _mm256_add_epi16(mm256_src_shuff, mm256_dstA);
+                    mm256_dstA = _mm256_add_epi16(mm256_dstA, mm256_ones);
+                    mm256_dstA = _mm256_mullo_epi16(mm256_alpha, mm256_dstA);
+                    mm256_dstA = _mm256_srli_epi16(mm256_dstA, 8);
+
+                    mm256_dstA = _mm256_sub_epi16(mm256_src_shuff, mm256_dstA);
+
+                    /* now do B set */
+                    mm256_dstB =
+                        _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_B);
+                    mm256_src_shuff =
+                        _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_B);
+                    mm256_alpha = _mm256_shuffle_epi8(
+                        mm256_src, mm256_shuff_alpha_mask_B);
+                    mm256_src_shuff =
+                        _mm256_add_epi16(mm256_src_shuff, mm256_dstB);
+                    mm256_dstB = _mm256_add_epi16(mm256_dstB, mm256_ones);
+                    mm256_dstB = _mm256_mullo_epi16(mm256_alpha, mm256_dstB);
+                    mm256_dstB = _mm256_srli_epi16(mm256_dstB, 8);
+
+                    mm256_dstB = _mm256_sub_epi16(mm256_src_shuff, mm256_dstB);
+
+                    /* now pack A & B together */
+                    mm256_dst = _mm256_packus_epi16(mm256_dstA, mm256_dstB);
+                    _mm256_storeu_si256(dstp256, mm256_dst);
+
+                    srcp256++;
+                    dstp256++;
+                },
+                n, post_8_width);
+        }
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
+    }
+}
+#else
+void
+blit_blend_premultiplied_avx2(SDL_BlitInfo *info)
+{
+    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
+    blit_blend_premultiplied_sse2(info);
+}
+#endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
+          !defined(SDL_DISABLE_IMMINTRIN_H) */

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -3663,34 +3663,26 @@ class SurfaceBlendTest(unittest.TestCase):
         bgra_surf_b = pygame.image.frombytes(byte_surf_b, (64, 64), "ARGB")
 
         argb_surf_a.fill((64, 0, 0, 128))
-        self.assertEqual(argb_surf_a.get_at((0, 0)),
-                         pygame.Color(64, 0, 0, 128))
+        self.assertEqual(argb_surf_a.get_at((0, 0)), pygame.Color(64, 0, 0, 128))
 
         # 128 green, 128 blue at 50% alpha, premultiplied
         argb_surf_b.fill((0, 64, 64, 128))
-        self.assertEqual(argb_surf_b.get_at((0, 0)),
-                         pygame.Color(0, 64, 64, 128))
+        self.assertEqual(argb_surf_b.get_at((0, 0)), pygame.Color(0, 64, 64, 128))
 
-        argb_surf_a.blit(argb_surf_b, (0, 0),
-                         special_flags=pygame.BLEND_PREMULTIPLIED)
+        argb_surf_a.blit(argb_surf_b, (0, 0), special_flags=pygame.BLEND_PREMULTIPLIED)
 
-        self.assertEqual(argb_surf_a.get_at((0, 0)),
-                         pygame.Color(32, 64, 64, 192))
+        self.assertEqual(argb_surf_a.get_at((0, 0)), pygame.Color(32, 64, 64, 192))
 
         bgra_surf_a.fill((64, 0, 0, 128))  # 128 red at 50% alpha
-        self.assertEqual(bgra_surf_a.get_at((0, 0)),
-                         pygame.Color(64, 0, 0, 128))
+        self.assertEqual(bgra_surf_a.get_at((0, 0)), pygame.Color(64, 0, 0, 128))
 
         # 128 green, 128 blue at 50% alpha, premultiplied
         bgra_surf_b.fill((0, 64, 64, 128))
-        self.assertEqual(bgra_surf_b.get_at((0, 0)),
-                         pygame.Color(0, 64, 64, 128))
+        self.assertEqual(bgra_surf_b.get_at((0, 0)), pygame.Color(0, 64, 64, 128))
 
-        bgra_surf_a.blit(bgra_surf_b, (0, 0),
-                         special_flags=pygame.BLEND_PREMULTIPLIED)
+        bgra_surf_a.blit(bgra_surf_b, (0, 0), special_flags=pygame.BLEND_PREMULTIPLIED)
 
-        self.assertEqual(bgra_surf_a.get_at((0, 0)),
-                         pygame.Color(32, 64, 64, 192))
+        self.assertEqual(bgra_surf_a.get_at((0, 0)), pygame.Color(32, 64, 64, 192))
 
     def test_blit_blend_big_rect(self):
         """test that an oversized rect works ok."""

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -3651,6 +3651,47 @@ class SurfaceBlendTest(unittest.TestCase):
             )
         )
 
+    def test_blit_blend_premultiplied_pixelformats(self):
+        # first create two BGRA pixel format surfaces using
+        # tobytes & frombytes
+        argb_surf_a = pygame.Surface((64, 64), flags=pygame.SRCALPHA)
+        byte_surf_a = pygame.image.tobytes(argb_surf_a, "ARGB")
+        bgra_surf_a = pygame.image.frombytes(byte_surf_a, (64, 64), "ARGB")
+
+        argb_surf_b = pygame.Surface((64, 64), flags=pygame.SRCALPHA)
+        byte_surf_b = pygame.image.tobytes(argb_surf_b, "ARGB")
+        bgra_surf_b = pygame.image.frombytes(byte_surf_b, (64, 64), "ARGB")
+
+        argb_surf_a.fill((64, 0, 0, 128))
+        self.assertEqual(argb_surf_a.get_at((0, 0)),
+                         pygame.Color(64, 0, 0, 128))
+
+        # 128 green, 128 blue at 50% alpha, premultiplied
+        argb_surf_b.fill((0, 64, 64, 128))
+        self.assertEqual(argb_surf_b.get_at((0, 0)),
+                         pygame.Color(0, 64, 64, 128))
+
+        argb_surf_a.blit(argb_surf_b, (0, 0),
+                         special_flags=pygame.BLEND_PREMULTIPLIED)
+
+        self.assertEqual(argb_surf_a.get_at((0, 0)),
+                         pygame.Color(32, 64, 64, 192))
+
+        bgra_surf_a.fill((64, 0, 0, 128))  # 128 red at 50% alpha
+        self.assertEqual(bgra_surf_a.get_at((0, 0)),
+                         pygame.Color(64, 0, 0, 128))
+
+        # 128 green, 128 blue at 50% alpha, premultiplied
+        bgra_surf_b.fill((0, 64, 64, 128))
+        self.assertEqual(bgra_surf_b.get_at((0, 0)),
+                         pygame.Color(0, 64, 64, 128))
+
+        bgra_surf_a.blit(bgra_surf_b, (0, 0),
+                         special_flags=pygame.BLEND_PREMULTIPLIED)
+
+        self.assertEqual(bgra_surf_a.get_at((0, 0)),
+                         pygame.Color(32, 64, 64, 192))
+
     def test_blit_blend_big_rect(self):
         """test that an oversized rect works ok."""
         color = (1, 2, 3, 255)


### PR DESCRIPTION
It is about 2 to 6 times faster on average than the old SSE2 version of `BLEND_PREMULTIPLIED` depending on the size of the blit with larger blits gaining more from the AVX2 code and very small blits having little difference.

AVX2 is the current 'top level' of our SIMD code in the pygame-ce codebase. It can do about twice the simultaneous operations as SSE2 which is out current 'base level' of SIMD. These levels are based on hardware adoption gathered via the Steam survey and the ability to transfer SIMD code between processor architectures (SSE2 is quite well supported for Arm ports, later stuff not so well).

In this PR I also get rid of the old MMX SIMD version of the `BLEND_PREMULTIPLIED` blitter - it simply wasn't being used on any real hardware anymore, MMX is the oldest SIMD technology and the slightly more modern SSE2 adoption is at 100% in hardware surveys these days, and has been for a long time.

For blitter/blends more operations usually translates to more pixels being processed at once, but this works a lot better if there are a lot of pixels together to work on, otherwise we have to drop down to slower techniques to finish off/entirely do a blit. This is why you see a growth in performance with larger blits that are more composed of big chunks of pixels we can feed into the SIMD blitter.

You can find the original versions of this PR [here](https://github.com/pygame/pygame/pull/3268) and [here](https://github.com/pygame/pygame/pull/3540).

The [Intel guide on intrinisics](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html) is very useful for reviewing and understanding all kinds of SIMD code.