### PR TITLE
Fix project logo URL in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://raw.githubusercontent.com/pygame-community/pygame-ce/main/docs/reST/_static/pygame_logo.svg
+.. image:: docs/reST/_static/pygame_logo.svg
   :alt: pygame
   :target: https://pyga.me/
 


### PR DESCRIPTION
Seems like the previous logo URL was referencing a cached SVG file on GitHub, which occured while fixing a previous broken logo URL upstream (according to git blame), and trying to rename the URL must have broken the link.

These changes should now properly target the logo SVG file from the repository.