### PR TITLE
Formatted `pixelarray_test.py` using `python setup.py format`

### DIFF
--- a/test/pixelarray_test.py
+++ b/test/pixelarray_test.py
@@ -698,25 +698,35 @@ class PixelArrayTypeTest(unittest.TestCase, TestMixin):
             # Test simple slicing
             self.assertEqual(len(ar[:, :]), 6)
             self.assertEqual(
-                len(ar[:,]),
+                len(
+                    ar[
+                        :,
+                    ]
+                ),
                 6,
             )
             self.assertEqual(len(ar[1, :]), 8)
             self.assertEqual(len(ar[:, 2]), 6)
             # Empty slices
             self.assertEqual(
-                ar[4:4,],
+                ar[
+                    4:4,
+                ],
                 None,
             )
             self.assertEqual(ar[4:4, ...], None)
             self.assertEqual(ar[4:4, 2:2], None)
             self.assertEqual(ar[4:4, 1:4], None)
             self.assertEqual(
-                ar[4:4:2,],
+                ar[
+                    4:4:2,
+                ],
                 None,
             )
             self.assertEqual(
-                ar[4:4:-2,],
+                ar[
+                    4:4:-2,
+                ],
                 None,
             )
             self.assertEqual(ar[4:4:1, ...], None)
@@ -847,7 +857,9 @@ class PixelArrayTypeTest(unittest.TestCase, TestMixin):
             self.assertEqual(ar[0, 0], 0)
             self.assertEqual(ar[1, 0], 0)
             self.assertEqual(ar[-1, -1], 0)
-            ar[...,] = (0, 0, 255)
+            ar[
+                ...,
+            ] = (0, 0, 255)
             self.assertEqual(ar[0, 0], sf.map_rgb((0, 0, 255)))
             self.assertEqual(ar[1, 0], sf.map_rgb((0, 0, 255)))
             self.assertEqual(ar[-1, -1], sf.map_rgb((0, 0, 255)))


### PR DESCRIPTION
Because it wasn't formatted for some reason? Not sure if this passes tests but apparently this could potentially be an issue? Either way it would get formatted whenever someone would run this command, so this would fix that.

Although not going lie, the formatting looks a bit atrocious.

This must wait to pass tests obviously.