### PR TITLE
Surface.fblits()

### DIFF
--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -70,6 +70,11 @@ class Surface:
         ],
         doreturn: Union[int, bool] = 1,
     ) -> Union[List[Rect], None]: ...
+    def fblits(
+            self,
+            blit_sequence: Sequence[Tuple[Surface, Union[Coordinate, RectValue]]],
+            blend_flags: int = 0, /
+    ) -> None: ...
     @overload
     def convert(self, surface: Surface) -> Surface: ...
     @overload

--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Sequence, Tuple, Union, overload
+from typing import Any, List, Optional, Sequence, Tuple, Union, overload, Iterable
 
 from pygame.bufferproxy import BufferProxy
 from pygame.color import Color
@@ -71,9 +71,12 @@ class Surface:
         doreturn: Union[int, bool] = 1,
     ) -> Union[List[Rect], None]: ...
     def fblits(
-            self,
-            blit_sequence: Sequence[Tuple[Surface, Union[Coordinate, RectValue]]],
-            special_flags: int = 0
+        self,
+        blit_sequence: Union[
+            Sequence[Tuple[Surface, Union[Coordinate, RectValue]]],
+            Iterable[Tuple[Surface, Union[Coordinate, RectValue]]],
+        ],
+        special_flags: int = 0,
     ) -> None: ...
     @overload
     def convert(self, surface: Surface) -> Surface: ...

--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -73,7 +73,7 @@ class Surface:
     def fblits(
             self,
             blit_sequence: Sequence[Tuple[Surface, Union[Coordinate, RectValue]]],
-            blend_flags: int = 0, /
+            special_flags: int = 0
     ) -> None: ...
     @overload
     def convert(self, surface: Surface) -> Surface: ...

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -154,6 +154,28 @@
 
       .. ## Surface.blits ##
 
+   .. method:: fblits
+
+      | :sl:`draw many images onto another, all with the full rect and same blend_flag`
+      | :sg:`fblits(blit_sequence=((source, dest), ...), blend_flags=0) -> None`
+
+      Draws many surfaces onto this Surface. It takes a sequence of tuples (source, dest) as input,
+      and a blend_flags parameter that applies to every surface being drawn. All surfaces are fully drawn.
+      It needs at minimum a sequence of (source, dest).
+
+      :param blit_sequence: a sequence of (Surface, dest)
+      :param blend_flags: the flag(s) representing the blend mode used for each surface
+
+      :returns: always returns ``None``
+      :rtype: None
+
+      .. note:: This function only accepts a sequence of (surf, dest) pairs and a single blend_flag.
+                This knowledge is used to achieve faster iteration over the sequence and
+                therefore better performance where blits() cannot. Further
+                optimizations are applied if the blit_sequence parameter is a list or a tuple
+                (using one of them is recommended).
+
+      .. ## Surface.fblits ##
 
    .. method:: convert
 

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -160,16 +160,15 @@
       | :sg:`fblits(blit_sequence=((source, dest), ...), special_flags=0) -> None`
 
       This method takes a sequence of tuples (source, dest) as input, where source is a Surface
-      object and dest is its destination position on this Surface. It draws each source surface
-      fully(meaning that unlike `blit()` you cannot pass an "area" parameter to represent
+      object and dest is its destination position on this Surface. It draws each source Surface
+      fully (meaning that unlike `blit()` you cannot pass an "area" parameter to represent
       a smaller portion of the source Surface to draw) on this Surface with the same blending
       mode specified by special_flags. The sequence must have at least one (source, dest) pair.
 
       :param blit_sequence: a sequence of (source, dest)
       :param special_flags: the flag(s) representing the blend mode used for each surface
 
-      :returns: always returns ``None``
-      :rtype: None
+      :returns: ``None``
 
       .. note:: This method only accepts a sequence of (source, dest) pairs and a single
                 special_flags value that's applied to all surfaces drawn. This allows faster

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -156,24 +156,26 @@
 
    .. method:: fblits
 
-      | :sl:`draw many images onto another, all with the full rect and same blend_flag`
-      | :sg:`fblits(blit_sequence=((source, dest), ...), blend_flags=0) -> None`
+      | :sl:`draw many surfaces onto the calling surface at their corresponding location and the same special_flags`
+      | :sg:`fblits(blit_sequence=((source, dest), ...), special_flags=0) -> None`
 
-      Draws many surfaces onto this Surface. It takes a sequence of tuples (source, dest) as input,
-      and a blend_flags parameter that applies to every surface being drawn. All surfaces are fully drawn.
-      It needs at minimum a sequence of (source, dest).
+      This method takes a sequence of tuples (source, dest) as input, where source is a Surface
+      object and dest is its destination position on this Surface. It draws each source surface
+      fully(meaning that unlike `blit()` you cannot pass an "area" parameter to represent
+      a smaller portion of the source Surface to draw) on this Surface with the same blending
+      mode specified by special_flags. The sequence must have at least one (source, dest) pair.
 
-      :param blit_sequence: a sequence of (Surface, dest)
-      :param blend_flags: the flag(s) representing the blend mode used for each surface
+      :param blit_sequence: a sequence of (source, dest)
+      :param special_flags: the flag(s) representing the blend mode used for each surface
 
       :returns: always returns ``None``
       :rtype: None
 
-      .. note:: This function only accepts a sequence of (surf, dest) pairs and a single blend_flag.
-                This knowledge is used to achieve faster iteration over the sequence and
-                therefore better performance where blits() cannot. Further
-                optimizations are applied if the blit_sequence parameter is a list or a tuple
-                (using one of them is recommended).
+      .. note:: This method only accepts a sequence of (source, dest) pairs and a single
+                special_flags value that's applied to all surfaces drawn. This allows faster
+                iteration over the sequence and better performance over `blits()`. Further
+                optimizations are applied if blit_sequence is a list or a tuple (using one
+                of them is recommended).
 
       .. ## Surface.fblits ##
 

--- a/src_c/doc/surface_doc.h
+++ b/src_c/doc/surface_doc.h
@@ -2,6 +2,7 @@
 #define DOC_PYGAMESURFACE "Surface((width, height), flags=0, depth=0, masks=None) -> Surface\nSurface((width, height), flags=0, Surface) -> Surface\npygame object for representing images"
 #define DOC_SURFACEBLIT "blit(source, dest, area=None, special_flags=0) -> Rect\ndraw one image onto another"
 #define DOC_SURFACEBLITS "blits(blit_sequence=((source, dest), ...), doreturn=1) -> [Rect, ...] or None\nblits(((source, dest, area), ...)) -> [Rect, ...]\nblits(((source, dest, area, special_flags), ...)) -> [Rect, ...]\ndraw many images onto another"
+#define DOC_SURFACEFBLITS "fblits(blit_sequence=((source, dest), ...), blend_flags=0) -> None\ndraw many images onto another, all with the full rect and same blend_flag"
 #define DOC_SURFACECONVERT "convert(Surface=None) -> Surface\nconvert(depth, flags=0) -> Surface\nconvert(masks, flags=0) -> Surface\nchange the pixel format of an image"
 #define DOC_SURFACECONVERTALPHA "convert_alpha(Surface) -> Surface\nconvert_alpha() -> Surface\nchange the pixel format of an image including per pixel alphas"
 #define DOC_SURFACECOPY "copy() -> Surface\ncreate a new copy of a Surface"
@@ -70,6 +71,10 @@ pygame.Surface.blits
  blits(((source, dest, area), ...)) -> [Rect, ...]
  blits(((source, dest, area, special_flags), ...)) -> [Rect, ...]
 draw many images onto another
+
+pygame.Surface.fblits
+ fblits(blit_sequence=((source, dest), ...), blend_flags=0) -> None
+draw many images onto another, all with the full rect and same blend_flag
 
 pygame.Surface.convert
  convert(Surface=None) -> Surface

--- a/src_c/doc/surface_doc.h
+++ b/src_c/doc/surface_doc.h
@@ -2,7 +2,7 @@
 #define DOC_PYGAMESURFACE "Surface((width, height), flags=0, depth=0, masks=None) -> Surface\nSurface((width, height), flags=0, Surface) -> Surface\npygame object for representing images"
 #define DOC_SURFACEBLIT "blit(source, dest, area=None, special_flags=0) -> Rect\ndraw one image onto another"
 #define DOC_SURFACEBLITS "blits(blit_sequence=((source, dest), ...), doreturn=1) -> [Rect, ...] or None\nblits(((source, dest, area), ...)) -> [Rect, ...]\nblits(((source, dest, area, special_flags), ...)) -> [Rect, ...]\ndraw many images onto another"
-#define DOC_SURFACEFBLITS "fblits(blit_sequence=((source, dest), ...), blend_flags=0) -> None\ndraw many images onto another, all with the full rect and same blend_flag"
+#define DOC_SURFACEFBLITS "fblits(blit_sequence=((source, dest), ...), special_flags=0) -> None\ndraw many surfaces onto the calling surface at their corresponding location and the same special_flags"
 #define DOC_SURFACECONVERT "convert(Surface=None) -> Surface\nconvert(depth, flags=0) -> Surface\nconvert(masks, flags=0) -> Surface\nchange the pixel format of an image"
 #define DOC_SURFACECONVERTALPHA "convert_alpha(Surface) -> Surface\nconvert_alpha() -> Surface\nchange the pixel format of an image including per pixel alphas"
 #define DOC_SURFACECOPY "copy() -> Surface\ncreate a new copy of a Surface"
@@ -73,8 +73,8 @@ pygame.Surface.blits
 draw many images onto another
 
 pygame.Surface.fblits
- fblits(blit_sequence=((source, dest), ...), blend_flags=0) -> None
-draw many images onto another, all with the full rect and same blend_flag
+ fblits(blit_sequence=((source, dest), ...), special_flags=0) -> None
+draw many surfaces onto the calling surface at their corresponding location and the same special_flags
 
 pygame.Surface.convert
  convert(Surface=None) -> Surface

--- a/test/blit_test.py
+++ b/test/blit_test.py
@@ -129,7 +129,6 @@ class BlitTest(unittest.TestCase):
             print(f"Surface.blits generator: {t1 - t0}")
 
     def test_fblits(self):
-
         NUM_SURFS = 255
         PRINT_TIMING = 0
         dst = pygame.Surface((NUM_SURFS * 10, 10), SRCALPHA, 32)

--- a/test/blit_test.py
+++ b/test/blit_test.py
@@ -128,6 +128,74 @@ class BlitTest(unittest.TestCase):
         if PRINT_TIMING:
             print(f"Surface.blits generator: {t1 - t0}")
 
+    def test_fblits(self):
+
+        NUM_SURFS = 255
+        PRINT_TIMING = 0
+        dst = pygame.Surface((NUM_SURFS * 10, 10), SRCALPHA, 32)
+        dst.fill((230, 230, 230))
+        blit_list = self.make_blit_list(NUM_SURFS)
+
+        def blits(blit_list):
+            for surface, dest in blit_list:
+                dst.blit(surface, dest)
+
+        from time import time
+
+        # tests for number of parameters
+        self.assertRaises(ValueError, dst.fblits)  # no params
+
+        # tests for the blit_sequence parameter
+        self.assertRaises(ValueError, dst.fblits, [-1])
+        self.assertRaises(ValueError, dst.fblits, (-1,))
+        self.assertRaises(ValueError, dst.fblits, "str")
+        self.assertRaises(ValueError, dst.fblits, 1)
+
+        # tests for the special_flags parameter
+        self.assertRaises(TypeError, dst.fblits, blit_list, -999)  # not impl. flag
+        self.assertRaises(TypeError, dst.fblits, blit_list, 12.245)  # float flag
+        self.assertRaises(TypeError, dst.fblits, blit_list, None)
+        self.assertRaises(TypeError, dst.fblits, blit_list, [])
+        self.assertRaises(TypeError, dst.fblits, blit_list, ())
+        self.assertRaises(TypeError, dst.fblits, blit_list, "str")
+        self.assertRaises(TypeError, dst.fblits, blit_list, "str")
+
+        # tests for return value
+        self.assertEqual(dst.fblits(blit_list, 0), None)
+        self.assertEqual(dst.fblits(blit_list, 1), dst.blits(blit_list, doreturn=0))
+
+        t0 = time()
+        results = blits(blit_list)
+        t1 = time()
+        if PRINT_TIMING:
+            print(f"python blits: {t1 - t0}")
+
+        dst.fill((230, 230, 230))
+        t0 = time()
+        results = dst.fblits(blit_list, 0)
+        t1 = time()
+        if PRINT_TIMING:
+            print(f"Surface.fblits :{t1 - t0}")
+
+        # check if we blit all the different colors in the correct spots.
+        for i in range(NUM_SURFS):
+            color = (i * 1, i * 1, i * 1)
+            self.assertEqual(dst.get_at((i * 10, 0)), color)
+            self.assertEqual(dst.get_at(((i * 10) + 5, 5)), color)
+
+        t0 = time()
+        results = dst.fblits(blit_list, 0)
+        t1 = time()
+        if PRINT_TIMING:
+            print(f"Surface.fblits doreturn=0: {t1 - t0}")
+        self.assertEqual(results, None)
+
+        t0 = time()
+        results = dst.fblits(((surf, dest) for surf, dest in blit_list), 0)
+        t1 = time()
+        if PRINT_TIMING:
+            print(f"Surface.fblits generator: {t1 - t0}")
+
     def test_blits_not_sequence(self):
         dst = pygame.Surface((100, 10), SRCALPHA, 32)
         self.assertRaises(ValueError, dst.blits, None)

--- a/test/blit_test.py
+++ b/test/blit_test.py
@@ -171,7 +171,7 @@ class BlitTest(unittest.TestCase):
 
         dst.fill((230, 230, 230))
         t0 = time()
-        results = dst.fblits(blit_list, 0)
+        dst.fblits(blit_list, 0)
         t1 = time()
         if PRINT_TIMING:
             print(f"Surface.fblits :{t1 - t0}")
@@ -183,17 +183,37 @@ class BlitTest(unittest.TestCase):
             self.assertEqual(dst.get_at(((i * 10) + 5, 5)), color)
 
         t0 = time()
-        results = dst.fblits(blit_list, 0)
+        result = dst.fblits(blit_list)
         t1 = time()
         if PRINT_TIMING:
             print(f"Surface.fblits: {t1 - t0}")
-        self.assertEqual(results, None)
+        self.assertEqual(result, None)
 
         t0 = time()
-        results = dst.fblits(((surf, dest) for surf, dest in blit_list), 0)
+        dst.fblits(((surf, dest) for surf, dest in blit_list))
         t1 = time()
         if PRINT_TIMING:
             print(f"Surface.fblits generator: {t1 - t0}")
+
+    def test_fblits_not_sequence(self):
+        dst = pygame.Surface((100, 10), SRCALPHA, 32)
+        self.assertRaises(ValueError, dst.fblits, None)
+
+    def test_fblits_wrong_length(self):
+        dst = pygame.Surface((100, 10), SRCALPHA, 32)
+        self.assertRaises(
+            ValueError, dst.fblits, [pygame.Surface((10, 10), SRCALPHA, 32)]
+        )
+
+    def test_fblits_bad_surf_args(self):
+        dst = pygame.Surface((100, 10), SRCALPHA, 32)
+        self.assertRaises(TypeError, dst.fblits, [(None, None)])
+
+    def test_fblits_bad_dest(self):
+        dst = pygame.Surface((100, 10), SRCALPHA, 32)
+        self.assertRaises(
+            TypeError, dst.fblits, [(pygame.Surface((10, 10), SRCALPHA, 32), None)]
+        )
 
     def test_blits_not_sequence(self):
         dst = pygame.Surface((100, 10), SRCALPHA, 32)

--- a/test/blit_test.py
+++ b/test/blit_test.py
@@ -186,7 +186,7 @@ class BlitTest(unittest.TestCase):
         results = dst.fblits(blit_list, 0)
         t1 = time()
         if PRINT_TIMING:
-            print(f"Surface.fblits doreturn=0: {t1 - t0}")
+            print(f"Surface.fblits: {t1 - t0}")
         self.assertEqual(results, None)
 
         t0 = time()


### PR DESCRIPTION
Adds the `Surface.fblits(blit_sequence, blit_flag)` function. A faster version of `Surface.blits()` that leverages:
- A faster calling convention (FASTCALL)
- Faster sequence looping
- A single blend flag instead of N flags to process individually
- Always draws the entire surface, so no surface slicing through rects
- Doesn't return a list of rects

The function call is also simpler, as with `blits` if you want to blit with a BLEND_ADD flag and blit the entire images you'd write something like this:
```Python
surf.blits([(obj.img, obj.pos, None, pygame.BLEND_ADD) for obj in to_draw])
```
Whereas with fblits you could do
```Python
surf.fblits([(obj.img, obj.pos) for obj in to_draw], pygame.BLEND_ADD)  # btw you can even pass a Rect as pos as in blits
```
Basically fblits takes in a single blend flag that's then applied to all images in the sequence and draws all images entirely.