### PR TITLE
pygame.draw.circles() function

### DIFF
--- a/buildconfig/stubs/pygame/draw.pyi
+++ b/buildconfig/stubs/pygame/draw.pyi
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 
 from pygame.rect import Rect
 from pygame.surface import Surface
@@ -33,6 +33,10 @@ def circle(
     draw_bottom_left: bool = False,
     draw_bottom_right: bool = False,
 ) -> Rect: ...
+def circles(
+        surface: Surface,
+        draw_sequence: Sequence[Tuple[ColorValue, Coordinate, int, Optional[int]]], /
+) -> None: ...
 def ellipse(
     surface: Surface, color: ColorValue, rect: RectValue, width: int = 0
 ) -> Rect: ...

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -207,6 +207,41 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
    .. ## pygame.draw.circle ##
 
+.. function:: circles
+
+   | :sl:`draws circles on a surface`
+   | :sg:`circles(surface, draw_sequence) -> None`
+
+   Draws a sequence of circles on the given surface.
+
+   :param surface: the surface to draw on
+   :param draw_sequence: a sequence composed of (color, center, radius, width) where:
+
+      - color: color to draw with, the alpha value is optional if using a tuple ``(RGB[A])``,
+
+      - center: center point of the circle as a sequence of 2 ints/floats, e.g. ``(x, y)``
+
+      - radius: radius of the circle, measured from the ``center`` parameter, nothing will
+              be drawn if the ``radius`` is less than 1
+
+      - width(optional): indicates the thickness of the circle (default=0)
+                         | if ``width == 0``, (default) fill the circle
+                         | if ``width > 0``, used for line thickness
+                         | if ``width < 0``, nothing will be drawn
+            .. note::
+               When using ``width`` values ``> 1``, the edge lines will only grow
+               inward.
+
+   :returns: always returns `None`
+   :rtype: None
+
+   .. note:: Takes positional only arguments in the order: surface, draw_sequence
+
+   :raises TypeError: if ``center`` is not a sequence of two numbers
+   :raises TypeError: if ``radius`` is not a number
+
+   .. ## pygame.draw.circles ##
+
 .. function:: ellipse
 
    | :sl:`draw an ellipse`

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -3,6 +3,7 @@
 #define DOC_PYGAMEDRAWRECT "rect(surface, color, rect) -> Rect\nrect(surface, color, rect, width=0, border_radius=0, border_top_left_radius=-1, border_top_right_radius=-1, border_bottom_left_radius=-1, border_bottom_right_radius=-1) -> Rect\ndraw a rectangle"
 #define DOC_PYGAMEDRAWPOLYGON "polygon(surface, color, points) -> Rect\npolygon(surface, color, points, width=0) -> Rect\ndraw a polygon"
 #define DOC_PYGAMEDRAWCIRCLE "circle(surface, color, center, radius) -> Rect\ncircle(surface, color, center, radius, width=0, draw_top_right=None, draw_top_left=None, draw_bottom_left=None, draw_bottom_right=None) -> Rect\ndraw a circle"
+#define DOC_PYGAMEDRAWCIRCLES "circles(surface, draw_sequence) -> None\ndraws circles on a surface"
 #define DOC_PYGAMEDRAWELLIPSE "ellipse(surface, color, rect) -> Rect\nellipse(surface, color, rect, width=0) -> Rect\ndraw an ellipse"
 #define DOC_PYGAMEDRAWARC "arc(surface, color, rect, start_angle, stop_angle) -> Rect\narc(surface, color, rect, start_angle, stop_angle, width=1) -> Rect\ndraw an elliptical arc"
 #define DOC_PYGAMEDRAWLINE "line(surface, color, start_pos, end_pos) -> Rect\nline(surface, color, start_pos, end_pos, width=1) -> Rect\ndraw a straight line"
@@ -32,6 +33,10 @@ pygame.draw.circle
  circle(surface, color, center, radius) -> Rect
  circle(surface, color, center, radius, width=0, draw_top_right=None, draw_top_left=None, draw_bottom_left=None, draw_bottom_right=None) -> Rect
 draw a circle
+
+pygame.draw.circles
+ circles(surface, draw_sequence) -> None
+draws circles on a surface
 
 pygame.draw.ellipse
  ellipse(surface, color, rect) -> Rect


### PR DESCRIPTION
This PR introduces a new draw function called `circles`, which allows for drawing multiple circles with various colors, center points, radii, and thicknesses on a given surface. This function fills the gap that existed before in Pygame, where there was no single function available to draw multiple circles on a surface, and people had to use for loops to draw each circle individually, while also loosing performance in the process.