### PR TITLE
Add concurrecy check to CI runs.

### DIFF
--- a/.github/workflows/build-debian-multiarch.yml
+++ b/.github/workflows/build-debian-multiarch.yml
@@ -34,6 +34,10 @@ on:
       # re-include current file to not be excluded
       - '!.github/workflows/build-debian-multiarch.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-multiarch:
     name: Debian (Bullseye - 11) [${{ matrix.arch }}]

--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -27,6 +27,10 @@ on:
       # re-include current file to not be excluded
       - '!.github/workflows/build-emsdk.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -30,6 +30,10 @@ on:
       # re-include current file to not be excluded
       - '!.github/workflows/build-macos.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deps:
     name: ${{ matrix.macarch }} deps

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -30,6 +30,10 @@ on:
       # re-include current file to not be excluded
       - '!.github/workflows/build-manylinux.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.image }} [${{ matrix.arch }}]

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -37,6 +37,10 @@ on:
       # re-include current file to not be excluded
       - '!.github/workflows/build-ubuntu-sdist.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}  

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -30,6 +30,10 @@ on:
       # re-include current file to not be excluded
       - '!.github/workflows/build-windows.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.name }}
@@ -38,13 +42,6 @@ jobs:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       matrix:
         include:
-          - {
-            name: "x86_64 (CPython 3.6 3.10 and above)",
-            winarch: AMD64,
-            msvc-dev-arch: x86_amd64,
-            # pattern matches 6 or any 2 digit number
-            pyversions: "cp3{6,[1-9][0-9]}-*"
-          }
           - {
             name: "CPython 3.11 (64 bit)",
             winarch: AMD64,

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -12,6 +12,10 @@ on:
     paths:
       - 'src_c/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # TODO: Any more static checkers can be added here
 jobs:
   run-cppcheck:

--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -20,6 +20,10 @@ on:
       - '**.py'
       - '**.rst'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   format-lint-code-check:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Should cancel old in progress jobs when new one is started in same workflow.

Idea borrowed from Pillow [here](https://github.com/python-pillow/Pillow/blob/main/.github/workflows/test-windows.yml).
GitHub docs [here](https://docs.github.com/en/actions/using-jobs/using-concurrency). 