### PR TITLE
wasm ci : bump sdk version, and python 3.11.2

### DIFF
--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # pin SDK version to the latest, update manually
-      SDK_VERSION: 3.1.27.0
+      SDK_VERSION: 3.1.31.2
       SDK_ARCHIVE: python3.11-wasm-sdk-Ubuntu-22.04.tar.lz4
       SDKROOT: /opt/python-wasm-sdk
 

--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # pin SDK version to the latest, update manually
-      SDK_VERSION: 3.1.31.2
+      SDK_VERSION: 3.1.32.0
       SDK_ARCHIVE: python3.11-wasm-sdk-Ubuntu-22.04.tar.lz4
       SDKROOT: /opt/python-wasm-sdk
 


### PR DESCRIPTION
as only newer version of SDK are suited to build for dynamic wheels (dynamic will be required for pyodide)