### PR TITLE
Implement `pitch` argument for `pygame.image.frombuffer`, `pygame.image.fromstring`, and `pygame.image.frombytes`

### DIFF
--- a/buildconfig/stubs/pygame/image.pyi
+++ b/buildconfig/stubs/pygame/image.pyi
@@ -26,7 +26,7 @@ def fromstring(
     size: Union[Sequence[int], Tuple[int, int]],
     format: _from_string_format,
     flipped: bool = False,
-    stride: int = -1,
+    pitch: int = -1,
 ) -> Surface: ...
 
 # the use of tobytes/frombytes is preferred over tostring/fromstring
@@ -38,13 +38,13 @@ def frombytes(
     size: Union[Sequence[int], Tuple[int, int]],
     format: _from_string_format,
     flipped: bool = False,
-    stride: int = -1,
+    pitch: int = -1,
 ) -> Surface: ...
 def frombuffer(
     bytes: _BufferStyle,
     size: Union[Sequence[int], Tuple[int, int]],
     format: _from_buffer_format,
-    stride: int = -1,
+    pitch: int = -1,
 ) -> Surface: ...
 def load_basic(filename: FileArg) -> Surface: ...
 def load_extended(filename: FileArg, namehint: str = "") -> Surface: ...

--- a/buildconfig/stubs/pygame/image.pyi
+++ b/buildconfig/stubs/pygame/image.pyi
@@ -17,14 +17,18 @@ def save(surface: Surface, filename: FileArg, namehint: str = "") -> None: ...
 def get_sdl_image_version(linked: bool = True) -> Optional[Tuple[int, int, int]]: ...
 def get_extended() -> bool: ...
 def tostring(
-    surface: Surface, format: _to_string_format, flipped: bool = False
+    surface: Surface,
+    format: _to_string_format,
+    flipped: bool = False,
 ) -> bytes: ...
 def fromstring(
     bytes: bytes,
     size: Union[Sequence[int], Tuple[int, int]],
     format: _from_string_format,
     flipped: bool = False,
+    stride: int = -1,
 ) -> Surface: ...
+
 # the use of tobytes/frombytes is preferred over tostring/fromstring
 def tobytes(
     surface: Surface, format: _to_string_format, flipped: bool = False
@@ -34,11 +38,13 @@ def frombytes(
     size: Union[Sequence[int], Tuple[int, int]],
     format: _from_string_format,
     flipped: bool = False,
+    stride: int = -1,
 ) -> Surface: ...
 def frombuffer(
     bytes: _BufferStyle,
     size: Union[Sequence[int], Tuple[int, int]],
     format: _from_buffer_format,
+    stride: int = -1,
 ) -> Surface: ...
 def load_basic(filename: FileArg) -> Surface: ...
 def load_extended(filename: FileArg, namehint: str = "") -> Surface: ...

--- a/docs/reST/ref/image.rst
+++ b/docs/reST/ref/image.rst
@@ -250,10 +250,18 @@ following formats.
    The bytes and format passed must compute to the exact size of image
    specified. Otherwise a ``ValueError`` will be raised.
 
+   The 'pitch' argument can be used specify the pitch/stride per horizontal line
+   of the image bytes in bytes. It must be equal to or greater than how many bytes
+   the pixel data of each horizontal line in the image bytes occupies without any
+   extra padding. By default, it is ``-1``, which means that the pitch/stride is 
+   the same size as how many bytes the pure pixel data of each horizontal line takes.
+
    See the :func:`pygame.image.frombuffer()` method for a potentially faster
    way to transfer images into pygame.
 
    .. note:: it is preferred to use :func:`frombytes` as of pygame 2.1.3
+
+   .. versionadded:: 2.1.4 Added a 'pitch' argument and support for keyword arguments.
 
    .. ## pygame.image.fromstring ##
 
@@ -270,6 +278,12 @@ following formats.
    The bytes and format passed must compute to the exact size of image
    specified. Otherwise a ``ValueError`` will be raised.
 
+   The 'pitch' argument can be used specify the pitch/stride per horizontal line
+   of the image bytes in bytes. It must be equal to or greater than how many bytes
+   the pixel data of each horizontal line in the image bytes occupies without any
+   extra padding. By default, it is ``-1``, which means that the pitch/stride is 
+   the same size as how many bytes the pure pixel data of each horizontal line takes.
+
    See the :func:`pygame.image.frombuffer()` method for a potentially faster
    way to transfer images into pygame.
 
@@ -278,7 +292,8 @@ following formats.
              This function was introduced so it matches nicely with other 
              libraries (PIL, numpy, etc), and with people's expectations.
 
-   .. versionadded:: 2.1.3 
+   .. versionadded:: 2.1.3
+   .. versionadded:: 2.1.4 Added a 'pitch' argument and support for keyword arguments.
 
    .. ## pygame.image.frombytes ##
 
@@ -311,8 +326,16 @@ following formats.
       * ``ARGB``, 32-bit image with alpha channel first
 
       * ``BGRA``, 32-bit image with alpha channel, red and blue channels swapped
-  
+
+   The 'pitch' argument can be used specify the pitch/stride per horizontal line
+   of the image buffer in bytes. It must be equal to or greater than how many bytes
+   the pixel data of each horizontal line in the image buffer occupies without any
+   extra padding. By default, it is ``-1``, which means that the pitch/stride is 
+   the same size as how many bytes the pure pixel data of each horizontal line takes.
+
    .. versionadded:: 2.1.3 BGRA format
+   .. versionadded:: 2.1.4 Added a 'pitch' argument and support for keyword arguments.
+
    .. ## pygame.image.frombuffer ##
 
 .. function:: load_basic

--- a/docs/reST/ref/image.rst
+++ b/docs/reST/ref/image.rst
@@ -240,7 +240,7 @@ following formats.
 .. function:: fromstring
 
    | :sl:`create new Surface from a byte buffer`
-   | :sg:`fromstring(bytes, size, format, flipped=False) -> Surface`
+   | :sg:`fromstring(bytes, size, format, flipped=False, stride=-1) -> Surface`
 
    This function takes arguments similar to :func:`pygame.image.tostring()`.
    The size argument is a pair of numbers representing the width and height.
@@ -260,7 +260,7 @@ following formats.
 .. function:: frombytes
 
    | :sl:`create new Surface from a byte buffer`
-   | :sg:`frombytes(bytes, size, format, flipped=False) -> Surface`
+   | :sg:`frombytes(bytes, size, format, flipped=False, stride=-1) -> Surface`
 
    This function takes arguments similar to :func:`pygame.image.tobytes()`.
    The size argument is a pair of numbers representing the width and height.
@@ -285,7 +285,7 @@ following formats.
 .. function:: frombuffer
 
    | :sl:`create a new Surface that shares data inside a bytes buffer`
-   | :sg:`frombuffer(buffer, size, format) -> Surface`
+   | :sg:`frombuffer(buffer, size, format, stride=-1) -> Surface`
 
    Create a new Surface that shares pixel data directly from a buffer. This
    buffer can be bytes, a bytearray, a memoryview, a

--- a/docs/reST/ref/image.rst
+++ b/docs/reST/ref/image.rst
@@ -240,7 +240,7 @@ following formats.
 .. function:: fromstring
 
    | :sl:`create new Surface from a byte buffer`
-   | :sg:`fromstring(bytes, size, format, flipped=False, stride=-1) -> Surface`
+   | :sg:`fromstring(bytes, size, format, flipped=False, pitch=-1) -> Surface`
 
    This function takes arguments similar to :func:`pygame.image.tostring()`.
    The size argument is a pair of numbers representing the width and height.
@@ -260,7 +260,7 @@ following formats.
 .. function:: frombytes
 
    | :sl:`create new Surface from a byte buffer`
-   | :sg:`frombytes(bytes, size, format, flipped=False, stride=-1) -> Surface`
+   | :sg:`frombytes(bytes, size, format, flipped=False, pitch=-1) -> Surface`
 
    This function takes arguments similar to :func:`pygame.image.tobytes()`.
    The size argument is a pair of numbers representing the width and height.
@@ -285,7 +285,7 @@ following formats.
 .. function:: frombuffer
 
    | :sl:`create a new Surface that shares data inside a bytes buffer`
-   | :sg:`frombuffer(buffer, size, format, stride=-1) -> Surface`
+   | :sg:`frombuffer(buffer, size, format, pitch=-1) -> Surface`
 
    Create a new Surface that shares pixel data directly from a buffer. This
    buffer can be bytes, a bytearray, a memoryview, a

--- a/src_c/doc/image_doc.h
+++ b/src_c/doc/image_doc.h
@@ -6,9 +6,9 @@
 #define DOC_PYGAMEIMAGEGETEXTENDED "get_extended() -> bool\ntest if extended image formats can be loaded"
 #define DOC_PYGAMEIMAGETOSTRING "tostring(Surface, format, flipped=False) -> bytes\ntransfer image to byte buffer"
 #define DOC_PYGAMEIMAGETOBYTES "tobytes(Surface, format, flipped=False) -> bytes\ntransfer image to byte buffer"
-#define DOC_PYGAMEIMAGEFROMSTRING "fromstring(bytes, size, format, flipped=False, stride=-1) -> Surface\ncreate new Surface from a byte buffer"
-#define DOC_PYGAMEIMAGEFROMBYTES "frombytes(bytes, size, format, flipped=False, stride=-1) -> Surface\ncreate new Surface from a byte buffer"
-#define DOC_PYGAMEIMAGEFROMBUFFER "frombuffer(buffer, size, format, stride=-1) -> Surface\ncreate a new Surface that shares data inside a bytes buffer"
+#define DOC_PYGAMEIMAGEFROMSTRING "fromstring(bytes, size, format, flipped=False, pitch=-1) -> Surface\ncreate new Surface from a byte buffer"
+#define DOC_PYGAMEIMAGEFROMBYTES "frombytes(bytes, size, format, flipped=False, pitch=-1) -> Surface\ncreate new Surface from a byte buffer"
+#define DOC_PYGAMEIMAGEFROMBUFFER "frombuffer(buffer, size, format, pitch=-1) -> Surface\ncreate a new Surface that shares data inside a bytes buffer"
 #define DOC_PYGAMEIMAGELOADBASIC "load_basic(file) -> Surface\nload new BMP image from a file (or file-like object)"
 #define DOC_PYGAMEIMAGELOADEXTENDED "load_extended(filename) -> Surface\nload_extended(fileobj, namehint="") -> Surface\nload an image from a file (or file-like object)"
 #define DOC_PYGAMEIMAGESAVEEXTENDED "save_extended(Surface, filename) -> None\nsave_extended(Surface, fileobj, namehint="") -> None\nsave a png/jpg image to file (or file-like object)"
@@ -49,15 +49,15 @@ pygame.image.tobytes
 transfer image to byte buffer
 
 pygame.image.fromstring
- fromstring(bytes, size, format, flipped=False, stride=-1) -> Surface
+ fromstring(bytes, size, format, flipped=False, pitch=-1) -> Surface
 create new Surface from a byte buffer
 
 pygame.image.frombytes
- frombytes(bytes, size, format, flipped=False, stride=-1) -> Surface
+ frombytes(bytes, size, format, flipped=False, pitch=-1) -> Surface
 create new Surface from a byte buffer
 
 pygame.image.frombuffer
- frombuffer(buffer, size, format, stride=-1) -> Surface
+ frombuffer(buffer, size, format, pitch=-1) -> Surface
 create a new Surface that shares data inside a bytes buffer
 
 pygame.image.load_basic

--- a/src_c/doc/image_doc.h
+++ b/src_c/doc/image_doc.h
@@ -6,9 +6,9 @@
 #define DOC_PYGAMEIMAGEGETEXTENDED "get_extended() -> bool\ntest if extended image formats can be loaded"
 #define DOC_PYGAMEIMAGETOSTRING "tostring(Surface, format, flipped=False) -> bytes\ntransfer image to byte buffer"
 #define DOC_PYGAMEIMAGETOBYTES "tobytes(Surface, format, flipped=False) -> bytes\ntransfer image to byte buffer"
-#define DOC_PYGAMEIMAGEFROMSTRING "fromstring(bytes, size, format, flipped=False) -> Surface\ncreate new Surface from a byte buffer"
-#define DOC_PYGAMEIMAGEFROMBYTES "frombytes(bytes, size, format, flipped=False) -> Surface\ncreate new Surface from a byte buffer"
-#define DOC_PYGAMEIMAGEFROMBUFFER "frombuffer(buffer, size, format) -> Surface\ncreate a new Surface that shares data inside a bytes buffer"
+#define DOC_PYGAMEIMAGEFROMSTRING "fromstring(bytes, size, format, flipped=False, stride=-1) -> Surface\ncreate new Surface from a byte buffer"
+#define DOC_PYGAMEIMAGEFROMBYTES "frombytes(bytes, size, format, flipped=False, stride=-1) -> Surface\ncreate new Surface from a byte buffer"
+#define DOC_PYGAMEIMAGEFROMBUFFER "frombuffer(buffer, size, format, stride=-1) -> Surface\ncreate a new Surface that shares data inside a bytes buffer"
 #define DOC_PYGAMEIMAGELOADBASIC "load_basic(file) -> Surface\nload new BMP image from a file (or file-like object)"
 #define DOC_PYGAMEIMAGELOADEXTENDED "load_extended(filename) -> Surface\nload_extended(fileobj, namehint="") -> Surface\nload an image from a file (or file-like object)"
 #define DOC_PYGAMEIMAGESAVEEXTENDED "save_extended(Surface, filename) -> None\nsave_extended(Surface, fileobj, namehint="") -> None\nsave a png/jpg image to file (or file-like object)"
@@ -49,15 +49,15 @@ pygame.image.tobytes
 transfer image to byte buffer
 
 pygame.image.fromstring
- fromstring(bytes, size, format, flipped=False) -> Surface
+ fromstring(bytes, size, format, flipped=False, stride=-1) -> Surface
 create new Surface from a byte buffer
 
 pygame.image.frombytes
- frombytes(bytes, size, format, flipped=False) -> Surface
+ frombytes(bytes, size, format, flipped=False, stride=-1) -> Surface
 create new Surface from a byte buffer
 
 pygame.image.frombuffer
- frombuffer(buffer, size, format) -> Surface
+ frombuffer(buffer, size, format, stride=-1) -> Surface
 create a new Surface that shares data inside a bytes buffer
 
 pygame.image.load_basic

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1021,7 +1021,7 @@ image_tobytes(PyObject *self, PyObject *arg)
 }
 
 PyObject *
-image_frombytes(PyObject *self, PyObject *arg)
+image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
 {
     PyObject *bytes;
     char *format, *data;
@@ -1036,8 +1036,11 @@ image_frombytes(PyObject *self, PyObject *arg)
     __analysis_assume(format = "inited");
 #endif
 
-    if (!PyArg_ParseTuple(arg, "O!(ii)s|ii", &PyBytes_Type, &bytes, &w, &h,
-                          &format, &flipped, &stride))
+    const char *kwids[] = {"bytes",   "size",   "format",
+                           "flipped", "stride", NULL};
+    if (!PyArg_ParseTupleAndKeywords(arg, kwds, "O!(ii)s|ii", kwids,
+                                     &PyBytes_Type, &bytes, &w, &h, &format,
+                                     &flipped, &stride))
         return NULL;
 
     if (w < 1 || h < 1)
@@ -1240,7 +1243,7 @@ pgObject_AsCharBuffer(PyObject *obj, const char **buffer,
 }
 
 PyObject *
-image_frombuffer(PyObject *self, PyObject *arg)
+image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
 {
     PyObject *buffer;
     char *format, *data;
@@ -1255,7 +1258,9 @@ image_frombuffer(PyObject *self, PyObject *arg)
     __analysis_assume(format = "inited");
 #endif
 
-    if (!PyArg_ParseTuple(arg, "O(ii)s|ii", &buffer, &w, &h, &format, &stride))
+    const char *kwids[] = {"buffer", "size", "format", "stride", NULL};
+    if (!PyArg_ParseTupleAndKeywords(arg, kwds, "O(ii)s|i", kwids, &buffer, &w,
+                                     &h, &format, &stride))
         return NULL;
 
     if (w < 1 || h < 1)
@@ -1690,9 +1695,12 @@ static PyMethodDef _image_methods[] = {
 
     {"tostring", image_tobytes, METH_VARARGS, DOC_PYGAMEIMAGETOSTRING},
     {"tobytes", image_tobytes, METH_VARARGS, DOC_PYGAMEIMAGETOBYTES},
-    {"fromstring", image_frombytes, METH_VARARGS, DOC_PYGAMEIMAGEFROMSTRING},
-    {"frombytes", image_frombytes, METH_VARARGS, DOC_PYGAMEIMAGEFROMBYTES},
-    {"frombuffer", image_frombuffer, METH_VARARGS, DOC_PYGAMEIMAGEFROMBUFFER},
+    {"fromstring", image_frombytes, METH_VARARGS | METH_KEYWORDS,
+     DOC_PYGAMEIMAGEFROMSTRING},
+    {"frombytes", image_frombytes, METH_VARARGS | METH_KEYWORDS,
+     DOC_PYGAMEIMAGEFROMBYTES},
+    {"frombuffer", image_frombuffer, METH_VARARGS | METH_KEYWORDS,
+     DOC_PYGAMEIMAGEFROMBUFFER},
     {NULL, NULL, 0, NULL}};
 
 MODINIT_DEFINE(image)

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1056,7 +1056,7 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
         else if (pitch < w) {
             return RAISE(PyExc_ValueError,
                          "Pitch must be greater than or equal to the width "
-                         "by the format");
+                         "as per the format");
         }
 
         if (len != (Py_ssize_t)pitch * h)
@@ -1080,7 +1080,7 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
         else if (pitch < w * 3) {
             return RAISE(PyExc_ValueError,
                          "Pitch must be greater than or equal to the width * "
-                         "3 by the format");
+                         "3 as per the format");
         }
 
         if (len != (Py_ssize_t)pitch * h)
@@ -1120,7 +1120,7 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
         else if (pitch < w * 4) {
             return RAISE(PyExc_ValueError,
                          "Pitch must be greater than or equal to the width * "
-                         "4 by the format");
+                         "4 as per the format");
         }
 
         int alphamult = !strcmp(format, "RGBA");
@@ -1154,7 +1154,7 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
         else if (pitch < w * 4) {
             return RAISE(PyExc_ValueError,
                          "Pitch must be greater than or equal to the width * "
-                         "4 by the format");
+                         "4 as per the format");
         }
 
         if (len != (Py_ssize_t)pitch * h)
@@ -1185,7 +1185,7 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
         else if (pitch < w * 4) {
             return RAISE(PyExc_ValueError,
                          "Pitch must be greater than or equal to the width * "
-                         "4 by the format");
+                         "4 as per the format");
         }
 
         if (len != (Py_ssize_t)pitch * h)
@@ -1278,7 +1278,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
         else if (pitch < w) {
             return RAISE(PyExc_ValueError,
                          "Pitch must be greater than or equal to the width "
-                         "by the format");
+                         "as per the format");
         }
 
         if (len != (Py_ssize_t)pitch * h)
@@ -1295,7 +1295,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
         else if (pitch < w * 3) {
             return RAISE(PyExc_ValueError,
                          "Pitch must be greater than or equal to the width * "
-                         "3 by the format");
+                         "3 as per the format");
         }
 
         if (len != (Py_ssize_t)pitch * h)
@@ -1317,7 +1317,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
         else if (pitch < w * 3) {
             return RAISE(PyExc_ValueError,
                          "Pitch must be greater than or equal to the width * "
-                         "3 by the format");
+                         "3 as per the format");
         }
 
         if (len != (Py_ssize_t)pitch * h)
@@ -1339,7 +1339,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
         else if (pitch < w * 4) {
             return RAISE(PyExc_ValueError,
                          "Pitch must be greater than or equal to the width * "
-                         "4 by the format");
+                         "4 as per the format");
         }
 
         if (len != (Py_ssize_t)pitch * h)
@@ -1363,7 +1363,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
         else if (pitch < w * 4) {
             return RAISE(PyExc_ValueError,
                          "Pitch must be greater than or equal to the width * "
-                         "4 by the format");
+                         "4 as per the format");
         }
 
         int alphamult = !strcmp(format, "RGBA");
@@ -1389,7 +1389,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
         else if (pitch < w * 4) {
             return RAISE(PyExc_ValueError,
                          "Pitch must be greater than or equal to the width * "
-                         "4 by the format");
+                         "4 as per the format");
         }
 
         if (len != (Py_ssize_t)pitch * h)

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1026,7 +1026,7 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
     PyObject *bytes;
     char *format, *data;
     SDL_Surface *surf = NULL;
-    int w, h, flipped = 0, stride = -1;
+    int w, h, flipped = 0, pitch = -1;
     Py_ssize_t len;
     int loopw, looph;
 
@@ -1036,11 +1036,11 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
     __analysis_assume(format = "inited");
 #endif
 
-    static char *kwids[] = {"bytes",   "size",   "format",
-                            "flipped", "stride", NULL};
+    static char *kwids[] = {"bytes",   "size",  "format",
+                            "flipped", "pitch", NULL};
     if (!PyArg_ParseTupleAndKeywords(arg, kwds, "O!(ii)s|ii", kwids,
                                      &PyBytes_Type, &bytes, &w, &h, &format,
-                                     &flipped, &stride))
+                                     &flipped, &pitch))
         return NULL;
 
     if (w < 1 || h < 1)
@@ -1050,16 +1050,16 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
     PyBytes_AsStringAndSize(bytes, &data, &len);
 
     if (!strcmp(format, "P")) {
-        if (stride == -1) {
-            stride = w;
+        if (pitch == -1) {
+            pitch = w;
         }
-        else if (stride < w) {
+        else if (pitch < w) {
             return RAISE(PyExc_ValueError,
-                         "Stride must be greater than or equal to the width "
+                         "Pitch must be greater than or equal to the width "
                          "by the format");
         }
 
-        if (len != (Py_ssize_t)stride * h)
+        if (len != (Py_ssize_t)pitch * h)
             return RAISE(
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
@@ -1070,20 +1070,20 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
         SDL_LockSurface(surf);
         for (looph = 0; looph < h; ++looph)
             memcpy(((char *)surf->pixels) + looph * surf->pitch,
-                   DATAROW(data, looph, stride, h, flipped), w);
+                   DATAROW(data, looph, pitch, h, flipped), w);
         SDL_UnlockSurface(surf);
     }
     else if (!strcmp(format, "RGB")) {
-        if (stride == -1) {
-            stride = w * 3;
+        if (pitch == -1) {
+            pitch = w * 3;
         }
-        else if (stride < w * 3) {
+        else if (pitch < w * 3) {
             return RAISE(PyExc_ValueError,
-                         "Stride must be greater than or equal to the width * "
+                         "Pitch must be greater than or equal to the width * "
                          "3 by the format");
         }
 
-        if (len != (Py_ssize_t)stride * h)
+        if (len != (Py_ssize_t)pitch * h)
             return RAISE(
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
@@ -1109,22 +1109,22 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
                 data += 3;
             }
 
-            data += stride - w * 3;
+            data += pitch - w * 3;
         }
         SDL_UnlockSurface(surf);
     }
     else if (!strcmp(format, "RGBA") || !strcmp(format, "RGBX")) {
-        if (stride == -1) {
-            stride = w * 4;
+        if (pitch == -1) {
+            pitch = w * 4;
         }
-        else if (stride < w * 4) {
+        else if (pitch < w * 4) {
             return RAISE(PyExc_ValueError,
-                         "Stride must be greater than or equal to the width * "
+                         "Pitch must be greater than or equal to the width * "
                          "4 by the format");
         }
 
         int alphamult = !strcmp(format, "RGBA");
-        if (len != (Py_ssize_t)stride * h)
+        if (len != (Py_ssize_t)pitch * h)
             return RAISE(
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
@@ -1143,21 +1143,21 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
             Uint32 *pix = (Uint32 *)DATAROW(surf->pixels, looph, surf->pitch,
                                             h, flipped);
             memcpy(pix, data, w * sizeof(Uint32));
-            data += stride;
+            data += pitch;
         }
         SDL_UnlockSurface(surf);
     }
     else if (!strcmp(format, "BGRA")) {
-        if (stride == -1) {
-            stride = w * 4;
+        if (pitch == -1) {
+            pitch = w * 4;
         }
-        else if (stride < w * 4) {
+        else if (pitch < w * 4) {
             return RAISE(PyExc_ValueError,
-                         "Stride must be greater than or equal to the width * "
+                         "Pitch must be greater than or equal to the width * "
                          "4 by the format");
         }
 
-        if (len != (Py_ssize_t)stride * h)
+        if (len != (Py_ssize_t)pitch * h)
             return RAISE(
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
@@ -1174,21 +1174,21 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
             Uint32 *pix = (Uint32 *)DATAROW(surf->pixels, looph, surf->pitch,
                                             h, flipped);
             memcpy(pix, data, w * sizeof(Uint32));
-            data += stride;
+            data += pitch;
         }
         SDL_UnlockSurface(surf);
     }
     else if (!strcmp(format, "ARGB")) {
-        if (stride == -1) {
-            stride = w * 4;
+        if (pitch == -1) {
+            pitch = w * 4;
         }
-        else if (stride < w * 4) {
+        else if (pitch < w * 4) {
             return RAISE(PyExc_ValueError,
-                         "Stride must be greater than or equal to the width * "
+                         "Pitch must be greater than or equal to the width * "
                          "4 by the format");
         }
 
-        if (len != (Py_ssize_t)stride * h)
+        if (len != (Py_ssize_t)pitch * h)
             return RAISE(
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
@@ -1205,7 +1205,7 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
             Uint32 *pix = (Uint32 *)DATAROW(surf->pixels, looph, surf->pitch,
                                             h, flipped);
             memcpy(pix, data, w * sizeof(Uint32));
-            data += stride;
+            data += pitch;
         }
         SDL_UnlockSurface(surf);
     }
@@ -1248,7 +1248,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
     PyObject *buffer;
     char *format, *data;
     SDL_Surface *surf = NULL;
-    int w, h, stride = -1;
+    int w, h, pitch = -1;
     Py_ssize_t len;
     pgSurfaceObject *surfobj;
 
@@ -1258,9 +1258,9 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
     __analysis_assume(format = "inited");
 #endif
 
-    static char *kwids[] = {"buffer", "size", "format", "stride", NULL};
+    static char *kwids[] = {"buffer", "size", "format", "pitch", NULL};
     if (!PyArg_ParseTupleAndKeywords(arg, kwds, "O(ii)s|i", kwids, &buffer, &w,
-                                     &h, &format, &stride))
+                                     &h, &format, &pitch))
         return NULL;
 
     if (w < 1 || h < 1)
@@ -1272,106 +1272,106 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
         return NULL;
 
     if (!strcmp(format, "P")) {
-        if (stride == -1) {
-            stride = w;
+        if (pitch == -1) {
+            pitch = w;
         }
-        else if (stride < w) {
+        else if (pitch < w) {
             return RAISE(PyExc_ValueError,
-                         "Stride must be greater than or equal to the width "
+                         "Pitch must be greater than or equal to the width "
                          "by the format");
         }
 
-        if (len != (Py_ssize_t)stride * h)
+        if (len != (Py_ssize_t)pitch * h)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
 
-        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 8, stride, 0, 0, 0, 0);
+        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 8, pitch, 0, 0, 0, 0);
     }
     else if (!strcmp(format, "RGB")) {
-        if (stride == -1) {
-            stride = w * 3;
+        if (pitch == -1) {
+            pitch = w * 3;
         }
-        else if (stride < w * 3) {
+        else if (pitch < w * 3) {
             return RAISE(PyExc_ValueError,
-                         "Stride must be greater than or equal to the width * "
+                         "Pitch must be greater than or equal to the width * "
                          "3 by the format");
         }
 
-        if (len != (Py_ssize_t)stride * h)
+        if (len != (Py_ssize_t)pitch * h)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 24, stride, 0xFF,
-                                        0xFF << 8, 0xFF << 16, 0);
+        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 24, pitch, 0xFF, 0xFF << 8,
+                                        0xFF << 16, 0);
 #else
-        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 24, stride, 0xFF << 16,
+        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 24, pitch, 0xFF << 16,
                                         0xFF << 8, 0xFF, 0);
 #endif
     }
     else if (!strcmp(format, "BGR")) {
-        if (stride == -1) {
-            stride = w * 3;
+        if (pitch == -1) {
+            pitch = w * 3;
         }
-        else if (stride < w * 3) {
+        else if (pitch < w * 3) {
             return RAISE(PyExc_ValueError,
-                         "Stride must be greater than or equal to the width * "
+                         "Pitch must be greater than or equal to the width * "
                          "3 by the format");
         }
 
-        if (len != (Py_ssize_t)stride * h)
+        if (len != (Py_ssize_t)pitch * h)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 24, stride, 0xFF << 16,
+        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 24, pitch, 0xFF << 16,
                                         0xFF << 8, 0xFF, 0);
 #else
-        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 24, stride, 0xFF,
-                                        0xFF << 8, 0xFF << 16, 0);
+        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 24, pitch, 0xFF, 0xFF << 8,
+                                        0xFF << 16, 0);
 #endif
     }
     else if (!strcmp(format, "BGRA")) {
-        if (stride == -1) {
-            stride = w * 4;
+        if (pitch == -1) {
+            pitch = w * 4;
         }
-        else if (stride < w * 4) {
+        else if (pitch < w * 4) {
             return RAISE(PyExc_ValueError,
-                         "Stride must be greater than or equal to the width * "
+                         "Pitch must be greater than or equal to the width * "
                          "4 by the format");
         }
 
-        if (len != (Py_ssize_t)stride * h)
+        if (len != (Py_ssize_t)pitch * h)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
 
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 32, stride, 0xFF << 16,
+        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 32, pitch, 0xFF << 16,
                                         0xFF << 8, 0xFF, 0xFF << 24);
 
 #else
-        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 32, stride, 0xFF << 8,
+        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 32, pitch, 0xFF << 8,
                                         0xFF << 16, 0xFF << 24, 0xFF);
 #endif
     }
     else if (!strcmp(format, "RGBA") || !strcmp(format, "RGBX")) {
-        if (stride == -1) {
-            stride = w * 4;
+        if (pitch == -1) {
+            pitch = w * 4;
         }
-        else if (stride < w * 4) {
+        else if (pitch < w * 4) {
             return RAISE(PyExc_ValueError,
-                         "Stride must be greater than or equal to the width * "
+                         "Pitch must be greater than or equal to the width * "
                          "4 by the format");
         }
 
         int alphamult = !strcmp(format, "RGBA");
-        if (len != (Py_ssize_t)stride * h)
+        if (len != (Py_ssize_t)pitch * h)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
-        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 32, stride,
+        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 32, pitch,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
                                         0xFF, 0xFF << 8, 0xFF << 16,
                                         (alphamult ? 0xFF << 24 : 0));
@@ -1383,21 +1383,21 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
             surf->flags |= SDL_SRCALPHA;
     }
     else if (!strcmp(format, "ARGB")) {
-        if (stride == -1) {
-            stride = w * 4;
+        if (pitch == -1) {
+            pitch = w * 4;
         }
-        else if (stride < w * 4) {
+        else if (pitch < w * 4) {
             return RAISE(PyExc_ValueError,
-                         "Stride must be greater than or equal to the width * "
+                         "Pitch must be greater than or equal to the width * "
                          "4 by the format");
         }
 
-        if (len != (Py_ssize_t)stride * h)
+        if (len != (Py_ssize_t)pitch * h)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
         surf =
-            SDL_CreateRGBSurfaceFrom(data, w, h, 32, stride,
+            SDL_CreateRGBSurfaceFrom(data, w, h, 32, pitch,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
                                      0xFF << 8, 0xFF << 16, 0xFF << 24, 0xFF);
 #else

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1036,8 +1036,8 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
     __analysis_assume(format = "inited");
 #endif
 
-    const char *kwids[] = {"bytes",   "size",   "format",
-                           "flipped", "stride", NULL};
+    static char *kwids[] = {"bytes",   "size",   "format",
+                            "flipped", "stride", NULL};
     if (!PyArg_ParseTupleAndKeywords(arg, kwds, "O!(ii)s|ii", kwids,
                                      &PyBytes_Type, &bytes, &w, &h, &format,
                                      &flipped, &stride))
@@ -1258,7 +1258,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
     __analysis_assume(format = "inited");
 #endif
 
-    const char *kwids[] = {"buffer", "size", "format", "stride", NULL};
+    static char *kwids[] = {"buffer", "size", "format", "stride", NULL};
     if (!PyArg_ParseTupleAndKeywords(arg, kwds, "O(ii)s|i", kwids, &buffer, &w,
                                      &h, &format, &stride))
         return NULL;
@@ -1695,11 +1695,11 @@ static PyMethodDef _image_methods[] = {
 
     {"tostring", image_tobytes, METH_VARARGS, DOC_PYGAMEIMAGETOSTRING},
     {"tobytes", image_tobytes, METH_VARARGS, DOC_PYGAMEIMAGETOBYTES},
-    {"fromstring", image_frombytes, METH_VARARGS | METH_KEYWORDS,
+    {"fromstring", (PyCFunction)image_frombytes, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEIMAGEFROMSTRING},
-    {"frombytes", image_frombytes, METH_VARARGS | METH_KEYWORDS,
+    {"frombytes", (PyCFunction)image_frombytes, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEIMAGEFROMBYTES},
-    {"frombuffer", image_frombuffer, METH_VARARGS | METH_KEYWORDS,
+    {"frombuffer", (PyCFunction)image_frombuffer, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEIMAGEFROMBUFFER},
     {NULL, NULL, 0, NULL}};
 

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1106,7 +1106,7 @@ image_frombytes(PyObject *self, PyObject *arg)
                 data += 3;
             }
 
-            data += stride - w;
+            data += stride - w * 3;
         }
         SDL_UnlockSurface(surf);
     }
@@ -1140,7 +1140,6 @@ image_frombytes(PyObject *self, PyObject *arg)
             Uint32 *pix = (Uint32 *)DATAROW(surf->pixels, looph, surf->pitch,
                                             h, flipped);
             memcpy(pix, data, w * sizeof(Uint32));
-
             data += stride;
         }
         SDL_UnlockSurface(surf);

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1103,6 +1103,569 @@ class ImageModuleTest(unittest.TestCase):
         self.assertEqual(argb_surf.get_at((2, 2)), pygame.Color(0, 0, 0, 79))
         self.assertEqual(argb_surf.get_at((3, 3)), pygame.Color(50, 200, 20, 255))
 
+    def test_frombuffer_pitched_8bit(self):
+        """test reading pixel data from a bytes buffer with a pitch"""
+        pygame.display.init()
+        eight_bit_palette_buffer = bytearray(
+            [
+                0,
+                0,
+                0,
+                0,
+                0,  # Padding
+                0,  # Padding
+                1,
+                1,
+                1,
+                1,
+                0,  # Padding
+                0,  # Padding
+                2,
+                2,
+                2,
+                2,
+                0,  # Padding
+                0,  # Padding
+                3,
+                3,
+                3,
+                3,
+                0,  # Padding
+                0,  # Padding
+            ]
+        )
+
+        eight_bit_surf = pygame.image.frombuffer(
+            eight_bit_palette_buffer, (4, 4), "P", pitch=6
+        )
+        eight_bit_surf.set_palette(
+            [(255, 10, 20), (255, 255, 255), (0, 0, 0), (50, 200, 20)]
+        )
+        self.assertEqual(eight_bit_surf.get_at((0, 0)), pygame.Color(255, 10, 20))
+        self.assertEqual(eight_bit_surf.get_at((1, 1)), pygame.Color(255, 255, 255))
+        self.assertEqual(eight_bit_surf.get_at((2, 2)), pygame.Color(0, 0, 0))
+        self.assertEqual(eight_bit_surf.get_at((3, 3)), pygame.Color(50, 200, 20))
+
+    def test_frombuffer_pitched_RGB(self):
+        rgb_buffer = bytearray(
+            [
+                255,
+                10,
+                20,
+                255,
+                10,
+                20,
+                255,
+                10,
+                20,
+                255,
+                10,
+                20,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                50,
+                200,
+                20,
+                50,
+                200,
+                20,
+                50,
+                200,
+                20,
+                50,
+                200,
+                20,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+            ]
+        )
+
+        rgb_surf = pygame.image.frombuffer(rgb_buffer, (4, 4), "RGB", pitch=16)
+        self.assertEqual(rgb_surf.get_at((0, 0)), pygame.Color(255, 10, 20))
+        self.assertEqual(rgb_surf.get_at((1, 1)), pygame.Color(255, 255, 255))
+        self.assertEqual(rgb_surf.get_at((2, 2)), pygame.Color(0, 0, 0))
+        self.assertEqual(rgb_surf.get_at((3, 3)), pygame.Color(50, 200, 20))
+
+    def test_frombuffer_pitched_BGR(self):
+        bgr_buffer = bytearray(
+            [
+                20,
+                10,
+                255,
+                20,
+                10,
+                255,
+                20,
+                10,
+                255,
+                20,
+                10,
+                255,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                20,
+                200,
+                50,
+                20,
+                200,
+                50,
+                20,
+                200,
+                50,
+                20,
+                200,
+                50,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+            ]
+        )
+
+        bgr_surf = pygame.image.frombuffer(bgr_buffer, (4, 4), "BGR", pitch=16)
+        self.assertEqual(bgr_surf.get_at((0, 0)), pygame.Color(255, 10, 20))
+        self.assertEqual(bgr_surf.get_at((1, 1)), pygame.Color(255, 255, 255))
+        self.assertEqual(bgr_surf.get_at((2, 2)), pygame.Color(0, 0, 0))
+        self.assertEqual(bgr_surf.get_at((3, 3)), pygame.Color(50, 200, 20))
+
+    def test_frombuffer_pitched_BGRA(self):
+        bgra_buffer = bytearray(
+            [
+                255,
+                10,
+                20,
+                200,
+                255,
+                10,
+                20,
+                200,
+                255,
+                10,
+                20,
+                200,
+                255,
+                10,
+                20,
+                200,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                255,
+                255,
+                255,
+                127,
+                255,
+                255,
+                255,
+                127,
+                255,
+                255,
+                255,
+                127,
+                255,
+                255,
+                255,
+                127,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,
+                0,
+                0,
+                79,
+                0,
+                0,
+                0,
+                79,
+                0,
+                0,
+                0,
+                79,
+                0,
+                0,
+                0,
+                79,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+            ]
+        )
+
+        bgra_surf = pygame.image.frombuffer(bgra_buffer, (4, 4), "BGRA", pitch=20)
+        self.assertEqual(bgra_surf.get_at((0, 0)), pygame.Color(20, 10, 255, 200))
+        self.assertEqual(bgra_surf.get_at((1, 1)), pygame.Color(255, 255, 255, 127))
+        self.assertEqual(bgra_surf.get_at((2, 2)), pygame.Color(0, 0, 0, 79))
+        self.assertEqual(bgra_surf.get_at((3, 3)), pygame.Color(20, 200, 50, 255))
+
+    def test_frombuffer_pitched_RGBX(self):
+        rgbx_buffer = bytearray(
+            [
+                255,
+                10,
+                20,
+                255,
+                255,
+                10,
+                20,
+                255,
+                255,
+                10,
+                20,
+                255,
+                255,
+                10,
+                20,
+                255,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                255,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,
+                0,
+                0,
+                255,
+                0,
+                0,
+                0,
+                255,
+                0,
+                0,
+                0,
+                255,
+                0,
+                0,
+                0,
+                255,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+            ]
+        )
+
+        rgbx_surf = pygame.image.frombuffer(rgbx_buffer, (4, 4), "RGBX", pitch=20)
+        self.assertEqual(rgbx_surf.get_at((0, 0)), pygame.Color(255, 10, 20, 255))
+        self.assertEqual(rgbx_surf.get_at((1, 1)), pygame.Color(255, 255, 255, 255))
+        self.assertEqual(rgbx_surf.get_at((2, 2)), pygame.Color(0, 0, 0, 255))
+        self.assertEqual(rgbx_surf.get_at((3, 3)), pygame.Color(50, 200, 20, 255))
+
+    def test_frombuffer_pitched_RGBA(self):
+        rgba_buffer = bytearray(
+            [
+                255,
+                10,
+                20,
+                200,
+                255,
+                10,
+                20,
+                200,
+                255,
+                10,
+                20,
+                200,
+                255,
+                10,
+                20,
+                200,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                255,
+                255,
+                255,
+                127,
+                255,
+                255,
+                255,
+                127,
+                255,
+                255,
+                255,
+                127,
+                255,
+                255,
+                255,
+                127,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,
+                0,
+                0,
+                79,
+                0,
+                0,
+                0,
+                79,
+                0,
+                0,
+                0,
+                79,
+                0,
+                0,
+                0,
+                79,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+            ]
+        )
+
+        rgba_surf = pygame.image.frombuffer(rgba_buffer, (4, 4), "RGBA", pitch=20)
+        self.assertEqual(rgba_surf.get_at((0, 0)), pygame.Color(255, 10, 20, 200))
+        self.assertEqual(rgba_surf.get_at((1, 1)), pygame.Color(255, 255, 255, 127))
+        self.assertEqual(rgba_surf.get_at((2, 2)), pygame.Color(0, 0, 0, 79))
+        self.assertEqual(rgba_surf.get_at((3, 3)), pygame.Color(50, 200, 20, 255))
+
+    def test_frombuffer_pitched_ARGB(self):
+        argb_buffer = bytearray(
+            [
+                200,
+                255,
+                10,
+                20,
+                200,
+                255,
+                10,
+                20,
+                200,
+                255,
+                10,
+                20,
+                200,
+                255,
+                10,
+                20,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                127,
+                255,
+                255,
+                255,
+                127,
+                255,
+                255,
+                255,
+                127,
+                255,
+                255,
+                255,
+                127,
+                255,
+                255,
+                255,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                79,
+                0,
+                0,
+                0,
+                79,
+                0,
+                0,
+                0,
+                79,
+                0,
+                0,
+                0,
+                79,
+                0,
+                0,
+                0,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                255,
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+                0,  # Padding
+            ]
+        )
+
+        argb_surf = pygame.image.frombuffer(argb_buffer, (4, 4), "ARGB", pitch=20)
+        self.assertEqual(argb_surf.get_at((0, 0)), pygame.Color(255, 10, 20, 200))
+        self.assertEqual(argb_surf.get_at((1, 1)), pygame.Color(255, 255, 255, 127))
+        self.assertEqual(argb_surf.get_at((2, 2)), pygame.Color(0, 0, 0, 79))
+        self.assertEqual(argb_surf.get_at((3, 3)), pygame.Color(50, 200, 20, 255))
+
     def test_get_extended(self):
         # Create a png file and try to load it. If it cannot, get_extended() should return False
         raw_image = []


### PR DESCRIPTION
Supposed to close pygame/pygame#3630 if I had the access. This PR implements a ~~`stride`~~ `pitch` argument for the functions `pygame.image.frombuffer`, `pygame.image.fromstring`, and `pygame.image.frombytes`. The argument is placed at the very back, so that it wouldn't ruin the behavior of existing code.

# Examples

```py
>>> pygame.image.fromstring(b"\xFF\xFF..\xFF\xFF..", (2, 2), "P", False, 4)
<Surface(2x2x8 SW)>
>>> pygame.image.frombytes(b"\xFF\xFF..\xFF\xFF..", (2, 2), "P", False, 4)
<Surface(2x2x8 SW)>
>>> pygame.image.frombuffer(b"\xFF\xFF..\xFF\xFF..", (2, 2), "P", 4)
<Surface(2x2x8 SW)>
```

```py
>>> pygame.image.fromstring(b"\xFF\xFF\xFF...\xFF\xFF\xFF...", (1, 2), "RGB", False, 6)
<Surface(1x2x24 SW)>
>>> pygame.image.frombytes(b"\xFF\xFF\xFF...\xFF\xFF\xFF...", (1, 2), "RGB", False, 6)
<Surface(1x2x24 SW)>
>>> pygame.image.frombuffer(b"\xFF\xFF\xFF...\xFF\xFF\xFF...", (1, 2), "RGB", 6)
<Surface(1x2x24 SW)>
```

```py
>>> pygame.image.fromstring(b"\xFF\xFF\xFF\xFF...\xFF\xFF\xFF\xFF...", (1, 2), "RGBA", False, 7)
<Surface(1x2x32 SW)>
>>> pygame.image.frombytes(b"\xFF\xFF\xFF\xFF...\xFF\xFF\xFF\xFF...", (1, 2), "RGBA", False, 7)
<Surface(1x2x32 SW)>
>>> pygame.image.frombuffer(b"\xFF\xFF\xFF\xFF...\xFF\xFF\xFF\xFF...", (1, 2), "RGBA", 7)
<Surface(1x2x32 SW)>
```