### PR TITLE
Add 'stubcheck' into setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -983,6 +983,38 @@ class DocsCommand(Command):
         if subprocess.call(command_line) != 0:
             raise SystemExit("Failed to build documentation")
 
+@add_command('stubcheck')
+class StubcheckCommand(Command):
+    """ For checking the stubs with `python setup.py stubcheck`.
+    """
+    user_options = []
+    def initialize_options(self):
+        pass
+        
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        '''
+        runs mypy to build the docs.
+        '''
+        import subprocess
+        import warnings
+
+        print("Using python:", sys.executable)
+
+        if shutil.which('mypy') is None:
+            warnings.warn("Please install 'mypy' in your environment. (hint: 'python3 -m pip install mypy')")
+            sys.exit(1)
+
+        os.chdir('buildconfig/stubs')
+        command_line = [
+            sys.executable,'-m','mypy.stubtest',"pygame","--allowlist","mypy_allow_list.txt"
+        ]
+        result = subprocess.call(command_line)
+        os.chdir('../../')
+        if result != 0:
+            raise SystemExit("Stubcheck failed.")
 
 # Prune empty file lists.
 data_files = [(path, files) for path, files in data_files if files]


### PR DESCRIPTION
Example:
```
PS X:\github小项目\pygame-ce> py .\setup.py stubcheck
running stubcheck
Using python: C:\Users\yunline\AppData\Local\Programs\Python\Python310\python.exe
Success: no issues found in 210 modules
PS X:\github小项目\pygame-ce> 
```