### PR TITLE
Bump cibw, more pypy builds on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run:
           name: Build the Linux wheels.
           command: |
-            pip3 install --user cibuildwheel==2.10.2
+            pip3 install --user cibuildwheel==2.12.0
             PATH="$HOME/.local/bin:$PATH" cibuildwheel --output-dir wheelhouse
 
       - store_artifacts:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -159,7 +159,7 @@ jobs:
           key: macdep-${{ hashFiles('buildconfig/manylinux-build/**') }}-${{ hashFiles('buildconfig/macdependencies/*.sh') }}-${{ matrix.macarch }}
 
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@v2.10.2
+        uses: pypa/cibuildwheel@v2.12.0
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -100,7 +100,7 @@ jobs:
     - uses: actions/checkout@v3.3.0
 
     - name: Build and test wheels
-      uses: pypa/cibuildwheel@v2.10.2
+      uses: pypa/cibuildwheel@v2.12.0
 
     # We upload the generated files under github actions assets
     - name: Upload dist

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -115,10 +115,22 @@ jobs:
             pyversions: "cp36-win32"
           }
           - {
+            name: "Pypy 3.7",
+            winarch: AMD64,
+            msvc-dev-arch: x86_amd64,
+            pyversions: "pp37-*"
+          }
+          - {
             name: "Pypy 3.8",
             winarch: AMD64,
             msvc-dev-arch: x86_amd64,
             pyversions: "pp38-*"
+          }
+          - {
+            name: "Pypy 3.9",
+            winarch: AMD64,
+            msvc-dev-arch: x86_amd64,
+            pyversions: "pp39-*"
           }
 
 
@@ -157,7 +169,7 @@ jobs:
           set MSSdk=1
           python -m pip install setuptools wheel requests numpy Sphinx
           python setup.py docs
-          python -m pip --disable-pip-version-check install cibuildwheel
+          python -m pip --disable-pip-version-check install cibuildwheel==2.12.0
           python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Simple PR, bumps cibuildwheel to hopefully speeden up the mac builds a bit. Also adds pypy 3.7 and pypy 3.9 builds on windows to be consistent with other platforms