### PR TITLE
Use `SDL_GetTicks64` instead of `SDL_GetTicks`

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1610,10 +1610,10 @@ _pg_event_wait(SDL_Event *event, int timeout)
     /* Custom re-implementation of SDL_WaitEventTimeout, doing this has
      * many advantages. This is copied from SDL source code, with a few
      * minor modifications */
-    Uint32 finish = 0;
+    Uint64 finish = 0;
 
     if (timeout > 0)
-        finish = SDL_GetTicks() + timeout;
+        finish = SDL_GetTicks64() + timeout;
 
     while (1) {
         _pg_event_pump(1); /* Use our custom pump here */
@@ -1624,7 +1624,7 @@ _pg_event_wait(SDL_Event *event, int timeout)
                 return 1;
 
             default:
-                if (timeout >= 0 && SDL_GetTicks() >= finish) {
+                if (timeout >= 0 && SDL_GetTicks64() >= finish) {
                     /* no events */
                     return 0;
                 }

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1613,7 +1613,7 @@ _pg_event_wait(SDL_Event *event, int timeout)
     Uint64 finish = 0;
 
     if (timeout > 0)
-        finish = SDL_GetTicks64() + timeout;
+        finish = PG_GetTicks() + timeout;
 
     while (1) {
         _pg_event_pump(1); /* Use our custom pump here */
@@ -1624,7 +1624,7 @@ _pg_event_wait(SDL_Event *event, int timeout)
                 return 1;
 
             default:
-                if (timeout >= 0 && SDL_GetTicks64() >= finish) {
+                if (timeout >= 0 && PG_GetTicks() >= finish) {
                     /* no events */
                     return 0;
                 }

--- a/src_c/include/pgcompat.h
+++ b/src_c/include/pgcompat.h
@@ -25,6 +25,12 @@ typedef uint8_t Uint8;
 
 #if defined(SDL_VERSION_ATLEAST)
 
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+#define PG_GetTicks SDL_GetTicks64
+#else
+#define PG_GetTicks SDL_GetTicks
+#endif
+
 #ifndef SDL_WINDOW_VULKAN
 #define SDL_WINDOW_VULKAN 0
 #endif

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -47,7 +47,7 @@ mixmusic_callback(void *udata, Uint8 *stream, int len)
 {
     if (!Mix_PausedMusic()) {
         music_pos += len;
-        music_pos_time = SDL_GetTicks64();
+        music_pos_time = PG_GetTicks();
     }
 }
 
@@ -112,7 +112,7 @@ music_play(PyObject *self, PyObject *args, PyObject *keywds)
     Mix_SetPostMix(mixmusic_callback, NULL);
     Mix_QuerySpec(&music_frequency, &music_format, &music_channels);
     music_pos = 0;
-    music_pos_time = SDL_GetTicks64();
+    music_pos_time = PG_GetTicks();
 
     volume = Mix_VolumeMusic(-1);
     val = Mix_FadeInMusicPos(current_music, loops, fade_ms, startpos);
@@ -196,7 +196,7 @@ music_unpause(PyObject *self, PyObject *_null)
 
     Mix_ResumeMusic();
     /* need to set pos_time for the adjusted time spent paused*/
-    music_pos_time = SDL_GetTicks64();
+    music_pos_time = PG_GetTicks();
     Py_RETURN_NONE;
 }
 
@@ -264,7 +264,7 @@ music_set_pos(PyObject *self, PyObject *arg)
 static PyObject *
 music_get_pos(PyObject *self, PyObject *_null)
 {
-    long ticks;
+    Uint64 ticks;
 
     MIXER_INIT_CHECK();
 
@@ -275,9 +275,9 @@ music_get_pos(PyObject *self, PyObject *_null)
                    (music_channels * music_frequency *
                     ((music_format & 0xff) >> 3)));
     if (!Mix_PausedMusic())
-        ticks += SDL_GetTicks64() - music_pos_time;
+        ticks += PG_GetTicks() - music_pos_time;
 
-    return PyLong_FromLong((long)ticks);
+    return PyLong_FromUnsignedLongLong(ticks);
 }
 
 static PyObject *

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -37,7 +37,7 @@ static Mix_Music *queue_music = NULL;
 static int queue_music_loops = 0;
 static int endmusic_event = SDL_NOEVENT;
 static Uint64 music_pos = 0;
-static long music_pos_time = -1;
+static Uint64 music_pos_time = -1;
 static int music_frequency = 0;
 static Uint16 music_format = 0;
 static int music_channels = 0;
@@ -47,7 +47,7 @@ mixmusic_callback(void *udata, Uint8 *stream, int len)
 {
     if (!Mix_PausedMusic()) {
         music_pos += len;
-        music_pos_time = SDL_GetTicks();
+        music_pos_time = SDL_GetTicks64();
     }
 }
 
@@ -112,7 +112,7 @@ music_play(PyObject *self, PyObject *args, PyObject *keywds)
     Mix_SetPostMix(mixmusic_callback, NULL);
     Mix_QuerySpec(&music_frequency, &music_format, &music_channels);
     music_pos = 0;
-    music_pos_time = SDL_GetTicks();
+    music_pos_time = SDL_GetTicks64();
 
     volume = Mix_VolumeMusic(-1);
     val = Mix_FadeInMusicPos(current_music, loops, fade_ms, startpos);
@@ -196,7 +196,7 @@ music_unpause(PyObject *self, PyObject *_null)
 
     Mix_ResumeMusic();
     /* need to set pos_time for the adjusted time spent paused*/
-    music_pos_time = SDL_GetTicks();
+    music_pos_time = SDL_GetTicks64();
     Py_RETURN_NONE;
 }
 
@@ -275,7 +275,7 @@ music_get_pos(PyObject *self, PyObject *_null)
                    (music_channels * music_frequency *
                     ((music_format & 0xff) >> 3)));
     if (!Mix_PausedMusic())
-        ticks += SDL_GetTicks() - music_pos_time;
+        ticks += SDL_GetTicks64() - music_pos_time;
 
     return PyLong_FromLong((long)ticks);
 }

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -198,10 +198,11 @@ timer_callback(Uint32 interval, void *param)
     return interval;
 }
 
-static int
-accurate_delay(int ticks)
+static Uint64
+accurate_delay(Sint64 ticks)
 {
-    int funcstart, delay;
+    Uint64 funcstart, delay;
+
     if (ticks <= 0)
         return 0;
 
@@ -212,7 +213,7 @@ accurate_delay(int ticks)
         }
     }
 
-    funcstart = SDL_GetTicks();
+    funcstart = SDL_GetTicks64();
     if (ticks >= WORST_CLOCK_ACCURACY) {
         delay = (ticks - 2) - (ticks % WORST_CLOCK_ACCURACY);
         if (delay >= WORST_CLOCK_ACCURACY) {
@@ -222,10 +223,10 @@ accurate_delay(int ticks)
         }
     }
     do {
-        delay = ticks - (SDL_GetTicks() - funcstart);
+        delay = ticks - (SDL_GetTicks64() - funcstart);
     } while (delay > 0);
 
-    return SDL_GetTicks() - funcstart;
+    return SDL_GetTicks64() - funcstart;
 }
 
 static PyObject *
@@ -233,30 +234,30 @@ time_get_ticks(PyObject *self, PyObject *_null)
 {
     if (!SDL_WasInit(SDL_INIT_TIMER))
         return PyLong_FromLong(0);
-    return PyLong_FromLong(SDL_GetTicks());
+    return PyLong_FromUnsignedLongLong(SDL_GetTicks64());
 }
 
 static PyObject *
 time_delay(PyObject *self, PyObject *arg)
 {
-    int ticks;
+    Sint64 ticks;
     if (!PyLong_Check(arg))
         return RAISE(PyExc_TypeError, "delay requires one integer argument");
 
-    ticks = PyLong_AsLong(arg);
+    ticks = PyLong_AsLongLong(arg);
     if (ticks < 0)
         ticks = 0;
 
     ticks = accurate_delay(ticks);
     if (ticks == -1)
         return NULL;
-    return PyLong_FromLong(ticks);
+    return PyLong_FromLongLong(ticks);
 }
 
 static PyObject *
 time_wait(PyObject *self, PyObject *arg)
 {
-    int ticks, start;
+    Sint64 ticks, start;
     if (!PyLong_Check(arg))
         return RAISE(PyExc_TypeError, "wait requires one integer argument");
 
@@ -266,16 +267,16 @@ time_wait(PyObject *self, PyObject *arg)
         }
     }
 
-    ticks = PyLong_AsLong(arg);
+    ticks = PyLong_AsLongLong(arg);
     if (ticks < 0)
         ticks = 0;
 
-    start = SDL_GetTicks();
+    start = SDL_GetTicks64();
     Py_BEGIN_ALLOW_THREADS;
     SDL_Delay(ticks);
     Py_END_ALLOW_THREADS;
 
-    return PyLong_FromLong(SDL_GetTicks() - start);
+    return PyLong_FromUnsignedLongLong(SDL_GetTicks64() - start);
 }
 
 static PyObject *
@@ -347,10 +348,10 @@ time_set_timer(PyObject *self, PyObject *args, PyObject *kwargs)
 
 /*clock object interface*/
 typedef struct {
-    PyObject_HEAD int last_tick;
+    PyObject_HEAD Uint64 last_tick;
     int fps_count, fps_tick;
     float fps;
-    int timepassed, rawpassed;
+    Uint64 timepassed, rawpassed;
     PyObject *rendered;
 } PyClockObject;
 
@@ -360,14 +361,14 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
 {
     PyClockObject *_clock = (PyClockObject *)self;
     float framerate = 0.0f;
-    int nowtime;
+    Uint64 nowtime;
 
     if (!PyArg_ParseTuple(arg, "|f", &framerate))
         return NULL;
 
     if (framerate) {
-        int delay, endtime = (int)((1.0f / framerate) * 1000.0f);
-        _clock->rawpassed = SDL_GetTicks() - _clock->last_tick;
+        Sint64 delay, endtime = (Sint64)((1.0f / framerate) * 1000.0f);
+        _clock->rawpassed = SDL_GetTicks64() - _clock->last_tick;
         delay = endtime - _clock->rawpassed;
 
         /*just doublecheck that timer is initialized*/
@@ -393,7 +394,7 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
             return NULL;
     }
 
-    nowtime = SDL_GetTicks();
+    nowtime = SDL_GetTicks64();
     _clock->timepassed = nowtime - _clock->last_tick;
     _clock->fps_count += 1;
     _clock->last_tick = nowtime;
@@ -411,7 +412,7 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
         _clock->fps_tick = nowtime;
         Py_XDECREF(_clock->rendered);
     }
-    return PyLong_FromLong(_clock->timepassed);
+    return PyLong_FromUnsignedLongLong(_clock->timepassed);
 }
 
 static PyObject *
@@ -437,14 +438,14 @@ static PyObject *
 clock_get_time(PyObject *self, PyObject *_null)
 {
     PyClockObject *_clock = (PyClockObject *)self;
-    return PyLong_FromLong(_clock->timepassed);
+    return PyLong_FromUnsignedLongLong(_clock->timepassed);
 }
 
 static PyObject *
 clock_get_rawtime(PyObject *self, PyObject *_null)
 {
     PyClockObject *_clock = (PyClockObject *)self;
-    return PyLong_FromLong(_clock->rawpassed);
+    return PyLong_FromUnsignedLongLong(_clock->rawpassed);
 }
 
 /* clock object internals */
@@ -502,7 +503,7 @@ clock_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     self->fps_tick = 0;
     self->timepassed = 0;
     self->rawpassed = 0;
-    self->last_tick = SDL_GetTicks();
+    self->last_tick = SDL_GetTicks64();
     self->fps = 0.0f;
     self->fps_count = 0;
     self->rendered = NULL;

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -213,20 +213,20 @@ accurate_delay(Sint64 ticks)
         }
     }
 
-    funcstart = SDL_GetTicks64();
+    funcstart = PG_GetTicks();
     if (ticks >= WORST_CLOCK_ACCURACY) {
         delay = (ticks - 2) - (ticks % WORST_CLOCK_ACCURACY);
         if (delay >= WORST_CLOCK_ACCURACY) {
             Py_BEGIN_ALLOW_THREADS;
-            SDL_Delay(delay);
+            SDL_Delay((Uint32)delay);
             Py_END_ALLOW_THREADS;
         }
     }
     do {
-        delay = ticks - (SDL_GetTicks64() - funcstart);
+        delay = ticks - (PG_GetTicks() - funcstart);
     } while (delay > 0);
 
-    return SDL_GetTicks64() - funcstart;
+    return PG_GetTicks() - funcstart;
 }
 
 static PyObject *
@@ -234,7 +234,7 @@ time_get_ticks(PyObject *self, PyObject *_null)
 {
     if (!SDL_WasInit(SDL_INIT_TIMER))
         return PyLong_FromLong(0);
-    return PyLong_FromUnsignedLongLong(SDL_GetTicks64());
+    return PyLong_FromUnsignedLongLong(PG_GetTicks());
 }
 
 static PyObject *
@@ -271,12 +271,12 @@ time_wait(PyObject *self, PyObject *arg)
     if (ticks < 0)
         ticks = 0;
 
-    start = SDL_GetTicks64();
+    start = PG_GetTicks();
     Py_BEGIN_ALLOW_THREADS;
-    SDL_Delay(ticks);
+    SDL_Delay((Uint32)ticks);
     Py_END_ALLOW_THREADS;
 
-    return PyLong_FromUnsignedLongLong(SDL_GetTicks64() - start);
+    return PyLong_FromUnsignedLongLong(PG_GetTicks() - start);
 }
 
 static PyObject *
@@ -348,8 +348,7 @@ time_set_timer(PyObject *self, PyObject *args, PyObject *kwargs)
 
 /*clock object interface*/
 typedef struct {
-    PyObject_HEAD Uint64 last_tick;
-    int fps_count, fps_tick;
+    PyObject_HEAD Uint64 last_tick, fps_count, fps_tick;
     float fps;
     Uint64 timepassed, rawpassed;
     PyObject *rendered;
@@ -368,7 +367,7 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
 
     if (framerate) {
         Sint64 delay, endtime = (Sint64)((1.0f / framerate) * 1000.0f);
-        _clock->rawpassed = SDL_GetTicks64() - _clock->last_tick;
+        _clock->rawpassed = PG_GetTicks() - _clock->last_tick;
         delay = endtime - _clock->rawpassed;
 
         /*just doublecheck that timer is initialized*/
@@ -394,7 +393,7 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
             return NULL;
     }
 
-    nowtime = SDL_GetTicks64();
+    nowtime = PG_GetTicks();
     _clock->timepassed = nowtime - _clock->last_tick;
     _clock->fps_count += 1;
     _clock->last_tick = nowtime;
@@ -503,7 +502,7 @@ clock_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     self->fps_tick = 0;
     self->timepassed = 0;
     self->rawpassed = 0;
-    self->last_tick = SDL_GetTicks64();
+    self->last_tick = PG_GetTicks();
     self->fps = 0.0f;
     self->fps_count = 0;
     self->rendered = NULL;


### PR DESCRIPTION
Supposed to close pygame/pygame#3658. This replaces the every of `SDL_GetTicks` with `SDL_GetTicks64`. `SDL_GetTicks` would overflow once every 49.71 days, as it returns an `Uint32`. Of course, most programs wouldn't run that long, but it's still nice to fix such case for the few running it that long. Using `SDL_GetTicks64` returns an `Uint64`, which extends the overflowing cycle to 584,542,046 years. If anyone's planning to make a graphical time-capsule using pygame to the end of Earth, hit me up to replace it with `SDL_GetTicks128`.