### PR TITLE
Add "ABGR" format to pygame.image.fromstring

### DIFF
--- a/buildconfig/stubs/pygame/image.pyi
+++ b/buildconfig/stubs/pygame/image.pyi
@@ -9,7 +9,7 @@ _BufferStyle = Union[BufferProxy, bytes, bytearray, memoryview]
 _to_string_format = Literal[
     "P", "RGB", "RGBX", "RGBA", "ARGB", "BGRA", "RGBA_PREMULT", "ARGB_PREMULT"
 ]
-_from_buffer_format = Literal["P", "RGB", "BGR", "BGRA", "RGBX", "RGBA", "ARGB"]
+_from_buffer_format = Literal["P", "RGB", "BGR", "BGRA", "RGBX", "RGBA", "ARGB", "ABGR"]
 _from_string_format = Literal["P", "RGB", "RGBX", "RGBA", "ARGB", "BGRA"]
 
 def load(filename: FileArg, namehint: str = "") -> Surface: ...

--- a/docs/reST/ref/image.rst
+++ b/docs/reST/ref/image.rst
@@ -190,6 +190,8 @@ following formats.
 
       * ``ARGB_PREMULT``, 32-bit image with colors scaled by alpha channel, alpha channel first
 
+      * ``ABGR``, 32-bit image with alpha channel, all channels reversed
+
    .. note:: it is preferred to use :func:`tobytes` as of pygame 2.1.3
 
    .. versionadded:: 2.1.3 BGRA format
@@ -226,6 +228,8 @@ following formats.
       * ``RGBA_PREMULT``, 32-bit image with colors scaled by alpha channel
 
       * ``ARGB_PREMULT``, 32-bit image with colors scaled by alpha channel, alpha channel first
+
+      * ``ABGR``, 32-bit image with alpha channel, all channels reversed
    
    .. note:: this function is an alias for :func:`tostring`. The use of this
              function is recommended over :func:`tostring` as of pygame 2.1.3.
@@ -311,6 +315,8 @@ following formats.
       * ``ARGB``, 32-bit image with alpha channel first
 
       * ``BGRA``, 32-bit image with alpha channel, red and blue channels swapped
+
+      * ``ABGR``, 32-bit image with alpha channel, all channels reversed
   
    .. versionadded:: 2.1.3 BGRA format
    .. ## pygame.image.frombuffer ##

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1159,6 +1159,28 @@ image_frombytes(PyObject *self, PyObject *arg)
         }
         SDL_UnlockSurface(surf);
     }
+    else if (!strcmp(format, "ABGR")) {
+        if (len != (Py_ssize_t)w * h * 4)
+            return RAISE(
+                PyExc_ValueError,
+                "Bytes length does not equal format and resolution size");
+        surf = SDL_CreateRGBSurface(SDL_SRCALPHA, w, h, 32,
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+                                    0xFF << 24, 0xFF << 16, 0xFF << 8, 0xFF);
+#else
+                                    0xFF << 16, 0xFF << 24, 0xFF, 0xFF << 8);
+#endif
+        if (!surf)
+            return RAISE(pgExc_SDLError, SDL_GetError());
+        SDL_LockSurface(surf);
+        for (looph = 0; looph < h; ++looph) {
+            Uint32 *pix = (Uint32 *)DATAROW(surf->pixels, looph, surf->pitch,
+                                            h, flipped);
+            memcpy(pix, data, w * sizeof(Uint32));
+            data += w * sizeof(Uint32);
+        }
+        SDL_UnlockSurface(surf);
+    }
     else
         return RAISE(PyExc_ValueError, "Unrecognized type of format");
 
@@ -1296,6 +1318,20 @@ image_frombuffer(PyObject *self, PyObject *arg)
                                      0xFF << 8, 0xFF << 16, 0xFF << 24, 0xFF);
 #else
                                      0xFF << 16, 0xFF << 8, 0xFF, 0xFF << 24);
+#endif
+        surf->flags |= SDL_SRCALPHA;
+    }
+    else if (!strcmp(format, "ABGR")) {
+        if (len != (Py_ssize_t)w * h * 4)
+            return RAISE(
+                PyExc_ValueError,
+                "Buffer length does not equal format and resolution size");
+        surf =
+            SDL_CreateRGBSurfaceFrom(data, w, h, 32, w * 4,
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+                                     0xFF << 24, 0xFF << 16, 0xFF << 8, 0xFF);
+#else
+                                     0xFF << 16, 0xFF << 24, 0xFF, 0xFF << 8);
 #endif
         surf->flags |= SDL_SRCALPHA;
     }

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1173,11 +1173,22 @@ class ImageModuleTest(unittest.TestCase):
             ]
         )
 
-        argb_surf = pygame.image.frombuffer(abgr_buffer, (4, 4), "ABGR")
-        self.assertEqual(argb_surf.get_at((0, 0)), pygame.Color(20, 10, 255, 200))
-        self.assertEqual(argb_surf.get_at((1, 1)), pygame.Color(255, 255, 255, 127))
-        self.assertEqual(argb_surf.get_at((2, 2)), pygame.Color(0, 0, 0, 79))
-        self.assertEqual(argb_surf.get_at((3, 3)), pygame.Color(20, 200, 50, 255))
+        try:
+            """
+            We need to test if the machine's hardware supports ABGR surfaces.
+            During the pull request review phase, the unittests on the
+            machine: Debian Multiarch / Debian (Bullseye - 11) [s390x]
+            were failing thus resulting in this try except else.
+            """
+            abgr_surf = pygame.image.frombuffer(abgr_buffer, (4, 4), "ABGR")
+        except pygame.error:
+            pass
+        else:
+            abgr_surf = pygame.image.frombuffer(abgr_buffer, (4, 4), "ABGR")
+            self.assertEqual(abgr_surf.get_at((0, 0)), pygame.Color(20, 10, 255, 200))
+            self.assertEqual(abgr_surf.get_at((1, 1)), pygame.Color(255, 255, 255, 127))
+            self.assertEqual(abgr_surf.get_at((2, 2)), pygame.Color(0, 0, 0, 79))
+            self.assertEqual(abgr_surf.get_at((3, 3)), pygame.Color(20, 200, 50, 255))
 
     def test_get_extended(self):
         # Create a png file and try to load it. If it cannot, get_extended() should return False

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1103,6 +1103,82 @@ class ImageModuleTest(unittest.TestCase):
         self.assertEqual(argb_surf.get_at((2, 2)), pygame.Color(0, 0, 0, 79))
         self.assertEqual(argb_surf.get_at((3, 3)), pygame.Color(50, 200, 20, 255))
 
+    def test_frombuffer_ABGR(self):
+        abgr_buffer = bytearray(
+            [
+                200,
+                255,
+                10,
+                20,
+                200,
+                255,
+                10,
+                20,
+                200,
+                255,
+                10,
+                20,
+                200,
+                255,
+                10,
+                20,
+                127,
+                255,
+                255,
+                255,
+                127,
+                255,
+                255,
+                255,
+                127,
+                255,
+                255,
+                255,
+                127,
+                255,
+                255,
+                255,
+                79,
+                0,
+                0,
+                0,
+                79,
+                0,
+                0,
+                0,
+                79,
+                0,
+                0,
+                0,
+                79,
+                0,
+                0,
+                0,
+                255,
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+                255,
+                50,
+                200,
+                20,
+            ]
+        )
+
+        argb_surf = pygame.image.frombuffer(abgr_buffer, (4, 4), "ABGR")
+        self.assertEqual(argb_surf.get_at((0, 0)), pygame.Color(20, 10, 255, 200))
+        self.assertEqual(argb_surf.get_at((1, 1)), pygame.Color(255, 255, 255, 127))
+        self.assertEqual(argb_surf.get_at((2, 2)), pygame.Color(0, 0, 0, 79))
+        self.assertEqual(argb_surf.get_at((3, 3)), pygame.Color(20, 200, 50, 255))
+
     def test_get_extended(self):
         # Create a png file and try to load it. If it cannot, get_extended() should return False
         raw_image = []


### PR DESCRIPTION
Ported from: https://github.com/pygame/pygame/pull/3674
Fixes: https://github.com/pygame/pygame/issues/3629


Looking at the SDL_PIXELFORMAT page (https://wiki.libsdl.org/SDL2/SDL_PixelFormatEnum), they have
```
SDL_PIXELFORMAT_RGBA32
SDL_PIXELFORMAT_ARGB32
SDL_PIXELFORMAT_BGRA32
SDL_PIXELFORMAT_ABGR32
```
Similarly, in pygame.image.fromstring, we support
```
RGBA
ARGB
BGRA
```
But with no `ABGR`

Somebody might need that support someday, and it seems like an obvious addition to what we support already.