### PR TITLE
Remove broken ubuntu 20.04 version

### DIFF
--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-18.04, ubuntu-22.04]
 
     steps:
     - uses: actions/checkout@v3.0.2
@@ -57,10 +57,6 @@ jobs:
       # and has typestubs
       run: |
         sudo apt-get update --fix-missing
-        sudo apt-get purge grub\*
-        sudo apt-get install grub-efi
-        sudo apt-get autoremove
-        sudo update-grub
         sudo apt-get upgrade
         sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev python3-setuptools python3-dev
         pip3 install sphinx numpy>=1.21.0

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -58,7 +58,6 @@ jobs:
       run: |
         sudo apt-get update --fix-missing
         sudo apt-get install grub-efi
-        sudo apt-get update-grub
         sudo apt-get upgrade
         sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev python3-setuptools python3-dev
         pip3 install sphinx numpy>=1.21.0

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -57,7 +57,10 @@ jobs:
       # and has typestubs
       run: |
         sudo apt-get update --fix-missing
+        sudo apt-get purge grub\*
         sudo apt-get install grub-efi
+        sudo apt-get autoremove
+        sudo update-grub
         sudo apt-get upgrade
         sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev python3-setuptools python3-dev
         pip3 install sphinx numpy>=1.21.0

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -57,6 +57,8 @@ jobs:
       # and has typestubs
       run: |
         sudo apt-get update --fix-missing
+        sudo apt-get install grub-efi
+        sudo apt-get update-grub
         sudo apt-get upgrade
         sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev python3-setuptools python3-dev
         pip3 install sphinx numpy>=1.21.0

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -28,7 +28,6 @@ jobs:
         run: |
           sudo apt-get update --fix-missing
           sudo apt-get install grub-efi
-          sudo apt-get update-grub
           sudo apt-get upgrade
           sudo apt install cppcheck
 

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update --fix-missing
-          sudo apt-get install grub-efi
           sudo apt-get upgrade
           sudo apt install cppcheck
 

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -19,7 +19,7 @@ concurrency:
 # TODO: Any more static checkers can be added here
 jobs:
   run-cppcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3.0.2

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update --fix-missing
+          sudo apt-get install grub-efi
+          sudo apt-get update-grub
           sudo apt-get upgrade
           sudo apt install cppcheck
 


### PR DESCRIPTION
Ubuntu 20.04 on GitHub currently fails while doing a basic system update & upgrade.

This is nothing to do with the pygame-ce project, so I say we remove that CI for now and consider re-adding it later.