### PR TITLE
Add brew install pkg-config to mac builds

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.macdep-cache.outputs.cache-hit != 'true'
         run: |
           export MAC_ARCH="${{ matrix.macarch }}"
-          brew install coreutils
+          brew install coreutils pkg-config
           cd buildconfig/macdependencies
           bash ./build_mac_deps.sh
 
@@ -129,6 +129,7 @@ jobs:
       # Setup MacOS dependencies
       CIBW_BEFORE_ALL: |
         export MAC_ARCH="${{ matrix.macarch }}"
+        brew install pkg-config
         cd buildconfig/macdependencies
         bash ./install_mac_deps.sh
 


### PR DESCRIPTION
Somehow `pkg-config` is missing in the mac runners now, which has led to new fails.
A workaround is implemented in this PR: we install `pkg-config` with brew.