### PR TITLE
Fix `gen_stubs.py` and regenerate `__init__.pyi`

### DIFF
--- a/buildconfig/stubs/gen_stubs.py
+++ b/buildconfig/stubs/gen_stubs.py
@@ -49,6 +49,7 @@ PG_AUTOIMPORT_SUBMODS = [
     "surface",
     "surflock",
     "sysfont",
+    "_debug"
 ]
 
 # pygame classes that are autoimported into main namespace are kept in this dict
@@ -61,6 +62,12 @@ PG_AUTOIMPORT_CLASSES = {
     "cursors": ["Cursor"],
     "bufferproxy": ["BufferProxy"],
     "mask": ["Mask"],
+    "_debug": ["print_debug_info"],
+    "event": ["Event"],
+    "font": ["Font"],
+    "mixer": ["Channel"],
+    "time": ["Clock"],
+    "joystick": ["Joystick"]
 }
 
 # pygame modules from which __init__.py does the equivalent of

--- a/buildconfig/stubs/pygame/__init__.pyi
+++ b/buildconfig/stubs/pygame/__init__.pyi
@@ -41,7 +41,7 @@ from pygame import (
     surface as surface,
     surflock as surflock,
     sysfont as sysfont,
-    _debug as _debug
+    _debug as _debug,
 )
 
 from .rect import Rect as Rect


### PR DESCRIPTION
Someone edited the auto-generated `__init__.pyi` by hand, causing the failure of `gen_stubs.py`.