### PR TITLE
Rect `collidelist()`/`collidelistall()` speedup

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -316,6 +316,12 @@ supported Python version. #endif */
 
 #endif /* PY_VERSION_HEX >= 0x03070000 */
 
+/* Update this function if new sequences are added to the fast sequence
+ * type. */
+#ifndef pgSequenceFast_Check
+#define pgSequenceFast_Check(o) (PyList_Check(o) || PyTuple_Check(o))
+#endif /* ~pgSequenceFast_Check */
+
 /*
  * event module internals
  */

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -808,11 +808,11 @@ pg_rect_collidelistall(pgRectObject *self, PyObject *arg)
             }
         }
     }
-    /* If the sequence is not a fast sequence, we have to use the slower
-     * PySequence_GetItem() function to get the items. */
+    /* Slower path for general sequences. */
     else {
         for (loop = 0; loop < PySequence_Length(arg); loop++) {
-            PyObject *obj = PySequence_GetItem(arg, loop);
+            PyObject *obj = PySequence_ITEM(arg, loop);
+
             if (!obj || !(argrect = pgRect_FromObject(obj, &temp))) {
                 Py_XDECREF(obj);
                 Py_DECREF(ret);
@@ -821,22 +821,21 @@ pg_rect_collidelistall(pgRectObject *self, PyObject *arg)
                     "Argument must be a sequence of rectstyle objects.");
             }
 
+            Py_DECREF(obj);
+
             if (_pg_do_rects_intersect(srect, argrect)) {
                 PyObject *num = PyLong_FromLong(loop);
                 if (!num) {
                     Py_DECREF(ret);
-                    Py_DECREF(obj);
                     return NULL;
                 }
                 if (PyList_Append(ret, num)) {
                     Py_DECREF(ret);
                     Py_DECREF(num);
-                    Py_DECREF(obj);
                     return NULL; /* Exception already set. */
                 }
                 Py_DECREF(num);
             }
-            Py_DECREF(obj);
         }
     }
 

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -720,8 +720,7 @@ PG_WRAP_FASTCALL_FUNC(pg_rect_colliderect, pgRectObject)
 static PyObject *
 pg_rect_collidelist(pgRectObject *self, PyObject *arg)
 {
-    SDL_Rect *argrect, temp;
-    const SDL_Rect *const srect = &self->r;
+    SDL_Rect *argrect, *srect = &self->r, temp;
     Py_ssize_t loop;
 
     if (!PySequence_Check(arg)) {
@@ -769,8 +768,7 @@ pg_rect_collidelist(pgRectObject *self, PyObject *arg)
 static PyObject *
 pg_rect_collidelistall(pgRectObject *self, PyObject *arg)
 {
-    SDL_Rect *argrect, temp;
-    const SDL_Rect *const srect = &self->r;
+    SDL_Rect *argrect, *srect = &self->r, temp;
     Py_ssize_t loop;
     PyObject *ret = NULL;
 

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -748,17 +748,19 @@ pg_rect_collidelist(pgRectObject *self, PyObject *arg)
     else {
         for (loop = 0; loop < PySequence_Length(arg); loop++) {
             PyObject *obj = PySequence_GetItem(arg, loop);
+
             if (!obj || !(argrect = pgRect_FromObject(obj, &temp))) {
                 Py_XDECREF(obj);
                 return RAISE(
                     PyExc_TypeError,
                     "Argument must be a sequence of rectstyle objects.");
             }
+
+            Py_DECREF(obj);
+
             if (_pg_do_rects_intersect(srect, argrect)) {
-                Py_DECREF(obj);
                 return PyLong_FromLong(loop);
             }
-            Py_DECREF(obj);
         }
     }
 

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -721,7 +721,7 @@ static PyObject *
 pg_rect_collidelist(pgRectObject *self, PyObject *arg)
 {
     SDL_Rect *argrect, *srect = &self->r, temp;
-    Py_ssize_t loop;
+    int loop;
 
     if (!PySequence_Check(arg)) {
         return RAISE(PyExc_TypeError,
@@ -769,7 +769,7 @@ static PyObject *
 pg_rect_collidelistall(pgRectObject *self, PyObject *arg)
 {
     SDL_Rect *argrect, *srect = &self->r, temp;
-    Py_ssize_t loop;
+    int loop;
     PyObject *ret = NULL;
 
     if (!PySequence_Check(arg)) {

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -718,97 +718,128 @@ pg_rect_colliderect(pgRectObject *self, PyObject *const *args,
 PG_WRAP_FASTCALL_FUNC(pg_rect_colliderect, pgRectObject)
 
 static PyObject *
-pg_rect_collidelist(pgRectObject *self, PyObject *args)
+pg_rect_collidelist(pgRectObject *self, PyObject *arg)
 {
     SDL_Rect *argrect, temp;
-    Py_ssize_t size;
-    int loop;
-    PyObject *list, *obj;
-    PyObject *ret = NULL;
+    const SDL_Rect *const srect = &self->r;
+    Py_ssize_t loop;
 
-    if (!PyArg_ParseTuple(args, "O", &list)) {
-        return NULL;
-    }
-
-    if (!PySequence_Check(list)) {
+    if (!PySequence_Check(arg)) {
         return RAISE(PyExc_TypeError,
                      "Argument must be a sequence of rectstyle objects.");
     }
 
-    size = PySequence_Length(list); /*warning, size could be -1 on error?*/
-    for (loop = 0; loop < size; ++loop) {
-        obj = PySequence_GetItem(list, loop);
-        if (!obj || !(argrect = pgRect_FromObject(obj, &temp))) {
-            PyErr_SetString(
-                PyExc_TypeError,
-                "Argument must be a sequence of rectstyle objects.");
-            Py_XDECREF(obj);
-            break;
+    /* If the sequence is a fast sequence, we can use the faster
+     * PySequence_Fast_ITEMS() function to get the items. */
+    if (pgSequenceFast_Check(arg)) {
+        PyObject **items = PySequence_Fast_ITEMS(arg);
+        for (loop = 0; loop < PySequence_Fast_GET_SIZE(arg); loop++) {
+            if (!(argrect = pgRect_FromObject(items[loop], &temp))) {
+                return RAISE(
+                    PyExc_TypeError,
+                    "Argument must be a sequence of rectstyle objects.");
+            }
+            if (_pg_do_rects_intersect(srect, argrect)) {
+                return PyLong_FromLong(loop);
+            }
         }
-        if (_pg_do_rects_intersect(&self->r, argrect)) {
-            ret = PyLong_FromLong(loop);
-            Py_DECREF(obj);
-            break;
-        }
-        Py_DECREF(obj);
     }
-    if (loop == size) {
-        ret = PyLong_FromLong(-1);
+    /* If the sequence is not a fast sequence, we have to use the slower
+     * PySequence_GetItem() function to get the items. */
+    else {
+        for (loop = 0; loop < PySequence_Length(arg); loop++) {
+            PyObject *obj = PySequence_GetItem(arg, loop);
+            if (!obj || !(argrect = pgRect_FromObject(obj, &temp))) {
+                Py_XDECREF(obj);
+                return RAISE(
+                    PyExc_TypeError,
+                    "Argument must be a sequence of rectstyle objects.");
+            }
+            if (_pg_do_rects_intersect(srect, argrect)) {
+                Py_DECREF(obj);
+                return PyLong_FromLong(loop);
+            }
+            Py_DECREF(obj);
+        }
     }
 
-    return ret;
+    return PyLong_FromLong(-1);
 }
 
 static PyObject *
-pg_rect_collidelistall(pgRectObject *self, PyObject *args)
+pg_rect_collidelistall(pgRectObject *self, PyObject *arg)
 {
     SDL_Rect *argrect, temp;
-    Py_ssize_t size;
-    int loop;
-    PyObject *list, *obj;
+    const SDL_Rect *const srect = &self->r;
+    Py_ssize_t loop;
     PyObject *ret = NULL;
 
-    if (!PyArg_ParseTuple(args, "O", &list)) {
-        return NULL;
-    }
-
-    if (!PySequence_Check(list)) {
+    if (!PySequence_Check(arg)) {
         return RAISE(PyExc_TypeError,
                      "Argument must be a sequence of rectstyle objects.");
     }
 
-    ret = PyList_New(0);
-    if (!ret) {
+    if (!(ret = PyList_New(0))) {
         return NULL;
     }
 
-    size = PySequence_Length(list); /*warning, size could be -1?*/
-    for (loop = 0; loop < size; ++loop) {
-        obj = PySequence_GetItem(list, loop);
-
-        if (!obj || !(argrect = pgRect_FromObject(obj, &temp))) {
-            Py_XDECREF(obj);
-            Py_DECREF(ret);
-            return RAISE(PyExc_TypeError,
-                         "Argument must be a sequence of rectstyle objects.");
-        }
-
-        if (_pg_do_rects_intersect(&self->r, argrect)) {
-            PyObject *num = PyLong_FromLong(loop);
-            if (!num) {
+    /* If the sequence is a fast sequence, we can use the faster
+     * PySequence_Fast_ITEMS() function to get the items. */
+    if (pgSequenceFast_Check(arg)) {
+        PyObject **items = PySequence_Fast_ITEMS(arg);
+        for (loop = 0; loop < PySequence_Fast_GET_SIZE(arg); loop++) {
+            if (!(argrect = pgRect_FromObject(items[loop], &temp))) {
                 Py_DECREF(ret);
-                Py_DECREF(obj);
-                return NULL;
+                return RAISE(
+                    PyExc_TypeError,
+                    "Argument must be a sequence of rectstyle objects.");
             }
-            if (0 != PyList_Append(ret, num)) {
-                Py_DECREF(ret);
+
+            if (_pg_do_rects_intersect(srect, argrect)) {
+                PyObject *num = PyLong_FromLong(loop);
+                if (!num) {
+                    Py_DECREF(ret);
+                    return NULL;
+                }
+                if (PyList_Append(ret, num)) {
+                    Py_DECREF(ret);
+                    Py_DECREF(num);
+                    return NULL; /* Exception already set. */
+                }
                 Py_DECREF(num);
-                Py_DECREF(obj);
-                return NULL; /* Exception already set. */
             }
-            Py_DECREF(num);
         }
-        Py_DECREF(obj);
+    }
+    /* If the sequence is not a fast sequence, we have to use the slower
+     * PySequence_GetItem() function to get the items. */
+    else {
+        for (loop = 0; loop < PySequence_Length(arg); loop++) {
+            PyObject *obj = PySequence_GetItem(arg, loop);
+            if (!obj || !(argrect = pgRect_FromObject(obj, &temp))) {
+                Py_XDECREF(obj);
+                Py_DECREF(ret);
+                return RAISE(
+                    PyExc_TypeError,
+                    "Argument must be a sequence of rectstyle objects.");
+            }
+
+            if (_pg_do_rects_intersect(srect, argrect)) {
+                PyObject *num = PyLong_FromLong(loop);
+                if (!num) {
+                    Py_DECREF(ret);
+                    Py_DECREF(obj);
+                    return NULL;
+                }
+                if (PyList_Append(ret, num)) {
+                    Py_DECREF(ret);
+                    Py_DECREF(num);
+                    Py_DECREF(obj);
+                    return NULL; /* Exception already set. */
+                }
+                Py_DECREF(num);
+            }
+            Py_DECREF(obj);
+        }
     }
 
     return ret;
@@ -1401,9 +1432,9 @@ static struct PyMethodDef pg_rect_methods[] = {
      PG_FASTCALL, DOC_RECTCOLLIDEPOINT},
     {"colliderect", (PyCFunction)PG_FASTCALL_NAME(pg_rect_colliderect),
      PG_FASTCALL, DOC_RECTCOLLIDERECT},
-    {"collidelist", (PyCFunction)pg_rect_collidelist, METH_VARARGS,
+    {"collidelist", (PyCFunction)pg_rect_collidelist, METH_O,
      DOC_RECTCOLLIDELIST},
-    {"collidelistall", (PyCFunction)pg_rect_collidelistall, METH_VARARGS,
+    {"collidelistall", (PyCFunction)pg_rect_collidelistall, METH_O,
      DOC_RECTCOLLIDELISTALL},
     {"collideobjectsall", (PyCFunction)pg_rect_collideobjectsall,
      METH_VARARGS | METH_KEYWORDS, DOC_RECTCOLLIDEOBJECTSALL},

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -1964,10 +1964,12 @@ class RectTypeTest(unittest.TestCase):
         r = Rect(1, 1, 10, 10)
         l = [Rect(50, 50, 1, 1), Rect(5, 5, 10, 10), Rect(15, 15, 1, 1)]
 
-        self.assertEqual(r.collidelist(l), 1)
+        self.assertEqual(r.collidelist(l), 1)  # list
+        self.assertEqual(r.collidelist(tuple(l)), 1)  # tuple
 
         f = [Rect(50, 50, 1, 1), (100, 100, 4, 4)]
-        self.assertEqual(r.collidelist(f), -1)
+        self.assertEqual(r.collidelist(f), -1)  # list
+        self.assertEqual(r.collidelist(tuple(f)), -1)  # tuple
 
     def test_collidelistall(self):
         # __doc__ (as of 2008-08-02) for pygame.rect.Rect.collidelistall:
@@ -1987,10 +1989,12 @@ class RectTypeTest(unittest.TestCase):
             Rect(15, 15, 1, 1),
             Rect(2, 2, 1, 1),
         ]
-        self.assertEqual(r.collidelistall(l), [0, 1, 3])
+        self.assertEqual(r.collidelistall(l), [0, 1, 3])  # list
+        self.assertEqual(r.collidelistall(tuple(l)), [0, 1, 3])  # tuple
 
         f = [Rect(50, 50, 1, 1), Rect(20, 20, 5, 5)]
-        self.assertFalse(r.collidelistall(f))
+        self.assertFalse(r.collidelistall(f))  # list
+        self.assertFalse(r.collidelistall(tuple(f)))  # tuple
 
     def test_collidelistall_returns_empty_list(self):
         r = Rect(1, 1, 10, 10)
@@ -2001,7 +2005,8 @@ class RectTypeTest(unittest.TestCase):
             Rect(15, 15, 1, 1),
             Rect(-20, 2, 1, 1),
         ]
-        self.assertEqual(r.collidelistall(l), [])
+        self.assertEqual(r.collidelistall(l), [])  # list
+        self.assertEqual(r.collidelistall(tuple(l)), [])  # tuple
 
     def test_collidelistall_list_of_tuples(self):
         r = Rect(1, 1, 10, 10)
@@ -2012,10 +2017,12 @@ class RectTypeTest(unittest.TestCase):
             (15, 15, 1, 1),
             (2, 2, 1, 1),
         ]
-        self.assertEqual(r.collidelistall(l), [0, 1, 3])
+        self.assertEqual(r.collidelistall(l), [0, 1, 3])  # list
+        self.assertEqual(r.collidelistall(tuple(l)), [0, 1, 3])  # tuple
 
         f = [(50, 50, 1, 1), (20, 20, 5, 5)]
-        self.assertFalse(r.collidelistall(f))
+        self.assertFalse(r.collidelistall(f))  # list
+        self.assertFalse(r.collidelistall(tuple(f)))  # tuple
 
     def test_collidelistall_list_of_two_tuples(self):
         r = Rect(1, 1, 10, 10)
@@ -2026,10 +2033,12 @@ class RectTypeTest(unittest.TestCase):
             ((15, 15), (1, 1)),
             ((2, 2), (1, 1)),
         ]
-        self.assertEqual(r.collidelistall(l), [0, 1, 3])
+        self.assertEqual(r.collidelistall(l), [0, 1, 3])  # list
+        self.assertEqual(r.collidelistall(tuple(l)), [0, 1, 3])  # tuple
 
         f = [((50, 50), (1, 1)), ((20, 20), (5, 5))]
-        self.assertFalse(r.collidelistall(f))
+        self.assertFalse(r.collidelistall(f))  # list
+        self.assertFalse(r.collidelistall(tuple(f)))  # tuple
 
     def test_collidelistall_list_of_lists(self):
         r = Rect(1, 1, 10, 10)
@@ -2040,10 +2049,12 @@ class RectTypeTest(unittest.TestCase):
             [15, 15, 1, 1],
             [2, 2, 1, 1],
         ]
-        self.assertEqual(r.collidelistall(l), [0, 1, 3])
+        self.assertEqual(r.collidelistall(l), [0, 1, 3])  # list
+        self.assertEqual(r.collidelistall(tuple(l)), [0, 1, 3])  # tuple
 
         f = [[50, 50, 1, 1], [20, 20, 5, 5]]
-        self.assertFalse(r.collidelistall(f))
+        self.assertFalse(r.collidelistall(f))  # list
+        self.assertFalse(r.collidelistall(tuple(f)))  # tuple
 
     class _ObjectWithRectAttribute:
         def __init__(self, r):
@@ -2079,13 +2090,15 @@ class RectTypeTest(unittest.TestCase):
             self._ObjectWithRectAttribute(Rect(15, 15, 1, 1)),
             self._ObjectWithRectAttribute(Rect(2, 2, 1, 1)),
         ]
-        self.assertEqual(r.collidelistall(l), [0, 1, 3])
+        self.assertEqual(r.collidelistall(l), [0, 1, 3])  # list
+        self.assertEqual(r.collidelistall(tuple(l)), [0, 1, 3])  # tuple
 
         f = [
             self._ObjectWithRectAttribute(Rect(50, 50, 1, 1)),
             self._ObjectWithRectAttribute(Rect(20, 20, 5, 5)),
         ]
-        self.assertFalse(r.collidelistall(f))
+        self.assertFalse(r.collidelistall(f))  # list
+        self.assertFalse(r.collidelistall(tuple(f)))  # tuple
 
     def test_collidelistall_list_of_object_with_callable_rect_attribute(self):
         r = Rect(1, 1, 10, 10)
@@ -2096,13 +2109,15 @@ class RectTypeTest(unittest.TestCase):
             self._ObjectWithCallableRectAttribute(Rect(15, 15, 1, 1)),
             self._ObjectWithCallableRectAttribute(Rect(2, 2, 1, 1)),
         ]
-        self.assertEqual(r.collidelistall(l), [0, 1, 3])
+        self.assertEqual(r.collidelistall(l), [0, 1, 3])  # list
+        self.assertEqual(r.collidelistall(tuple(l)), [0, 1, 3])  # tuple
 
         f = [
             self._ObjectWithCallableRectAttribute(Rect(50, 50, 1, 1)),
             self._ObjectWithCallableRectAttribute(Rect(20, 20, 5, 5)),
         ]
-        self.assertFalse(r.collidelistall(f))
+        self.assertFalse(r.collidelistall(f))  # list
+        self.assertFalse(r.collidelistall(tuple(f)))  # tuple
 
     def test_collidelistall_list_of_object_with_callable_rect_returning_object_with_rect_attribute(
         self,
@@ -2123,13 +2138,15 @@ class RectTypeTest(unittest.TestCase):
                 self._ObjectWithRectAttribute(Rect(2, 2, 1, 1))
             ),
         ]
-        self.assertEqual(r.collidelistall(l), [0, 1, 3])
+        self.assertEqual(r.collidelistall(l), [0, 1, 3])  # list
+        self.assertEqual(r.collidelistall(tuple(l)), [0, 1, 3])  # tuple
 
         f = [
             self._ObjectWithCallableRectAttribute(Rect(50, 50, 1, 1)),
             self._ObjectWithCallableRectAttribute(Rect(20, 20, 5, 5)),
         ]
-        self.assertFalse(r.collidelistall(f))
+        self.assertFalse(r.collidelistall(f))  # list
+        self.assertFalse(r.collidelistall(tuple(f)))  # tuple
 
     def test_collidelistall_list_of_object_with_rect_property(self):
         r = Rect(1, 1, 10, 10)
@@ -2140,13 +2157,15 @@ class RectTypeTest(unittest.TestCase):
             self._ObjectWithRectProperty(Rect(15, 15, 1, 1)),
             self._ObjectWithRectProperty(Rect(2, 2, 1, 1)),
         ]
-        self.assertEqual(r.collidelistall(l), [0, 1, 3])
+        self.assertEqual(r.collidelistall(l), [0, 1, 3])  # list
+        self.assertEqual(r.collidelistall(tuple(l)), [0, 1, 3])  # tuple
 
         f = [
             self._ObjectWithRectProperty(Rect(50, 50, 1, 1)),
             self._ObjectWithRectProperty(Rect(20, 20, 5, 5)),
         ]
-        self.assertFalse(r.collidelistall(f))
+        self.assertFalse(r.collidelistall(f))  # list
+        self.assertFalse(r.collidelistall(tuple(f)))  # tuple
 
     def test_collideobjects_call_variants(self):
         # arrange


### PR DESCRIPTION
Changed:
- The functions now use `METH_O` instead of `METH_VARARGS` with a `PyArg_ParseTuple(args, "O", &list)`. This makes them 100% compatible as before.
- There are two paths for different types of sequences: a fast path for sequences that allow faster iteration and a normal path for general sequences.

Added:
- A new macro called `pgSequenceFast_Check` that checks if a sequence object is compatible with PySequence_Fast. Currently, the macro is defined as `pgSequenceFast_Check(o) (PyList_Check(o) || PyTuple_Check(o))`. This will make it easier to add another check if Python introduces another fast sequence type in the future.
- More tests for both functions

Perf. tests:
TLDR:
collidelist: 66% faster on my pc.
collidelistall: 53% faster on my pc.
Of course the longer the sequence, the better the benefits.
```
OLD
===| collidelist |===
1): 216.64ms
2): 217.03ms
3): 216.89ms
4): 215.63ms
5): 215.41ms
Mean: 216.32ms
===| collidelistall |===
1): 252.01ms
2): 248.19ms
3): 256.87ms
4): 255.00ms
5): 256.72ms
Mean: 253.76ms

NEW
===| collidelist |===
1): 130.00ms
2): 129.85ms
3): 129.98ms
4): 131.40ms
5): 130.17ms
Mean: 130.28ms
===| collidelistall |===
1): 163.49ms
2): 166.11ms
3): 165.83ms
4): 165.82ms
5): 166.47ms
Mean: 165.54ms
```
I used this program:
```Python
from pygame import Rect

from statistics import fmean
from timeit import repeat


rects = [
    Rect(0, 0, 100, 100),
    Rect(50, 50, 100, 100),
    Rect(100, 100, 100, 100),
    Rect(150, 150, 100, 100),
    Rect(200, 200, 100, 100),
    Rect(250, 250, 100, 100),
    Rect(300, 300, 100, 100),
    Rect(350, 350, 100, 100),
    Rect(400, 400, 100, 100),
    Rect(450, 450, 100, 100),
    Rect(500, 500, 100, 100),
    Rect(550, 550, 100, 100),
    Rect(600, 600, 100, 100),
    Rect(650, 650, 100, 100),
    Rect(700, 700, 100, 100),
]

r = Rect(799, 799, 33, 33)
rep = 10
N = 5
tot = 0

print("===| collidelist |===")
for i in range(N):
    data = repeat("r.collidelist(rects)", globals=globals(), repeat=rep)
    tot += fmean(data)
    print(f"{i+1}): {fmean(data)*1000:.2f}ms")
print(f"Mean: {tot/N*1000:.2f}ms")

print("===| collidelistall |===")
tot = 0
for i in range(N):
    data = repeat("r.collidelistall(rects)", globals=globals(), repeat=rep)
    tot += fmean(data)
    print(f"{i+1}): {fmean(data)*1000:.2f}ms")
print(f"Mean: {tot/N*1000:.2f}ms")
```