### PR TITLE
Fix freetype dylib with install_name_tool

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -161,6 +161,11 @@ jobs:
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.12.0
 
+      - name: Fix freetype dylib
+        run: |
+          cd buildconfig
+          python3 fix_freetype_dylib.py
+
       - uses: actions/upload-artifact@v3
         with:
           name: pygame-wheels

--- a/buildconfig/fix_freetype_dylib.py
+++ b/buildconfig/fix_freetype_dylib.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+import zipfile
+
+os.chdir("../wheelhouse")
+
+for file in os.listdir("."):
+    if not file.endswith(".whl"):
+        continue
+
+    os.mkdir("extract")
+
+    with zipfile.ZipFile(file) as f:
+        f.extractall('./extract')
+
+    os.chdir("extract")
+
+    # What is this doing?
+    # So.
+    # dlopen() on MacOS 10 and 11 appears to fail when a dynamic library tries
+    # to load itself as one of its dependencies. You can see dynamic library
+    # links with otool -L xxx.dylib, and you can change things with
+    # install_name_tool. But why is the freetype dylib trying to load itself?
+    # This is likely a bug in cibuildwheel/auditwheel/delocate?
+    #
+    # Anyways, this hacky solution creates a "libpaidtype" dylib, convinces it
+    # is actually "libpaidtype", and then makes libfreetype link to it, 
+    # avoiding the bug in dlopen.
+
+    os.system("cp pygame/.dylibs/libfreetype.6.dylib pygame/.dylibs/libpaidtype.6.dylib")
+    os.system("install_name_tool -id /DLC/pygame/.dylibs/libpaidtype.6.dylib pygame/.dylibs/libpaidtype.6.dylib")
+    os.system("install_name_tool -change @loader_path/libfreetype.6.dylib @loader_path/libpaidtype.6.dylib pygame/.dylibs/libfreetype.6.dylib")
+
+    file_namever = "-".join(file.split("-")[:2])
+    print(file_namever)
+
+    os.system(f"zip -r {file} pygame {file_namever}.data {file_namever}.dist-info")
+
+    os.system(f"cp {file} ../{file}")
+
+    os.chdir("..")
+
+    shutil.rmtree("extract", ignore_errors=True)


### PR DESCRIPTION
Fixes the issue originally reported in https://github.com/pygame/pygame/issues/3596

```py
Python 3.10.9 (v3.10.9:1dd9be6584, Dec  6 2022, 14:37:36) [Clang 13.0.0 (clang-1300.0.29.30)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pygame
pygame-ce 2.1.4.dev1 (SDL 2.0.22, Python 3.10.9)
>>> pygame.font
<module 'pygame.font' from '/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pygame/font.cpython-310-darwin.so'>
>>> pygame.font.init()
>>> 
```

Freetype works as well.
Tested on my old macOS 10.13 laptop.

Wrote an explanation of how this works in the fix dylib python script.