### PR TITLE
Fix mac freetype dylib circular import issue, make sure CI generated wheels are self-contained

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -131,11 +131,16 @@ jobs:
         export MAC_ARCH="${{ matrix.macarch }}"
         brew install pkg-config
         cd buildconfig/macdependencies
+        cp -r ${{ github.workspace }}/pygame_mac_deps_${{ matrix.macarch }} ${{ github.workspace }}/pygame_mac_deps
         bash ./install_mac_deps.sh
 
       CIBW_BEFORE_BUILD: |
         pip install requests numpy Sphinx
         python setup.py docs
+        cp -r ${{ github.workspace }}/pygame_mac_deps_${{ matrix.macarch }} ${{ github.workspace }}/pygame_mac_deps
+
+      # To remove any speculations about the wheel not being self-contained
+      CIBW_BEFORE_TEST: rm -rf ${{ github.workspace }}/pygame_mac_deps
 
       CIBW_TEST_COMMAND: python -m pygame.tests -v --exclude opengl,timing --time_out 300
 

--- a/buildconfig/manylinux-build/docker_base/freetype/build-freetype.sh
+++ b/buildconfig/manylinux-build/docker_base/freetype/build-freetype.sh
@@ -47,6 +47,16 @@ make install
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # Install to mac deps cache dir as well
     make install DESTDIR=${MACDEP_CACHE_PREFIX_PATH}
+
+    # We do a little hack...
+    # When freetype finds harfbuzz with pkg-config, we tell freetype a little
+    # lie that harfbuzz doesn't depend on freetype (even though it does).
+    # This ensures no direct circular dylib link happen.
+    # This is a bit of a brittle hack: This command removes the entire line that
+    # contains "freetype". This is fine for now when the harfbuzz we are
+    # building has no other dependencies
+    sed -i '' '/freetype/d' /usr/local/lib/pkgconfig/harfbuzz.pc
+    sed -i '' 's/ \/usr\/local\/lib\/libfreetype.la//g' /usr/local/lib/libharfbuzz.la
 fi
 
 cd ..
@@ -56,6 +66,9 @@ cd $FREETYPE
 
 # fully clean previous install
 make clean
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    make uninstall
+fi
 
 ./configure $ARCHS_CONFIG_FLAG --with-harfbuzz=yes
 make


### PR DESCRIPTION
The freetype self-link was happening in the dependency build step itself, the fix was to remove the old freetype that harfbuzz needs, and re-install freetype (with harfbuzz link) while lying to freetype that harfbuzz doesn't need freetype. But after the new freetype is built linked to harfbuzz, this harfbuzz can also dynamically load the new freetype dylib in theory.

Also in this PR I introduce a little change, the installed dependencies are essentially deleted while a wheel is being tested: this is to ensure the self-contained-ness of the wheel.

An alternative solution to what #1917 fixes