### PR TITLE
Add image & rect properties to Sprite

### DIFF
--- a/buildconfig/stubs/pygame/sprite.pyi
+++ b/buildconfig/stubs/pygame/sprite.pyi
@@ -28,6 +28,14 @@ _Group = AbstractGroup[_SpriteSupportsGroup]
 # protocol helps with structural subtyping for typevars in sprite group generics
 class _SupportsSprite(Protocol):
     @property
+    def image(self) -> Optional[Surface]: ...
+    @image.setter
+    def image(self, value: Optional[Surface]) -> None: ...
+    @property
+    def rect(self) -> Optional[Rect]: ...
+    @rect.setter
+    def rect(self, value: Optional[Rect]) -> None: ...
+    @property
     def layer(self) -> int: ...
     @layer.setter
     def layer(self, value: int) -> None: ...
@@ -53,6 +61,14 @@ class _SupportsDirtySprite(_SupportsSprite, Protocol):
 
 # concrete sprite implementation class
 class Sprite(_SupportsSprite):
+    @property
+    def image(self) -> Optional[Surface]: ...
+    @image.setter
+    def image(self, value: Optional[Surface]) -> None: ...
+    @property
+    def rect(self) -> Optional[Rect]: ...
+    @rect.setter
+    def rect(self, value: Optional[Rect]) -> None: ...
     @property
     def layer(self) -> int: ...
     @layer.setter
@@ -84,11 +100,13 @@ _TGroup = TypeVar("_TGroup", bound=AbstractGroup)
 # sprite functions don't need all sprite attributes to be present in the
 # arguments passed, they only use a few which are marked in the below protocols
 class _HasRect(Protocol):
-    rect: Rect
+    @property
+    def rect(self) -> Optional[Rect]: ...
 
 # image in addition to rect
 class _HasImageAndRect(_HasRect, Protocol):
-    image: Surface
+    @property
+    def image(self) -> Optional[Surface]: ...
 
 # mask in addition to rect
 class _HasMaskAndRect(_HasRect, Protocol):

--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -86,6 +86,7 @@ Sprites are not thread safe, so lock them yourself if using threads.
 # specialized cases.
 
 from warnings import warn
+from typing import Optional
 
 import pygame
 
@@ -111,8 +112,26 @@ class Sprite:
 
     def __init__(self, *groups):
         self.__g = {}  # The groups the sprite is in
+        self.__image: Optional[pygame.surface.Surface] = None
+        self.__rect: Optional[pygame.rect.Rect] = None
         if groups:
             self.add(*groups)
+
+    @property
+    def image(self):
+        return self.__image
+
+    @image.setter
+    def image(self, value: Optional[pygame.surface.Surface]):
+        self.__image = value
+
+    @property
+    def rect(self):
+        return self.__rect
+
+    @rect.setter
+    def rect(self, value: Optional[pygame.rect.Rect]):
+        self.__rect = value
 
     def add(self, *groups):
         """add the sprite to groups


### PR DESCRIPTION
Hopefully, I didn't miss anything. Related to #1941 

I can't see any good reason not to have these as properties. Sprite has never been an actual abstract base class, and python has always allowed you to just add a `.image` and `.rect` onto instances of `Sprite` without having to make a derived class.

By adding these as properties we gain hooks we can use on assignments for other refactoring later to boost performance. 

I expect 90% of all sprite group using sprites derive from Sprite.