### PR TITLE
Get numpy on all CI faster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
       - CIBW_SKIP: '*-musllinux_*'
       - CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014_base_aarch64
       - CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: manylinux2014_base_aarch64
+      - CIBW_BEFORE_TEST: pip install numpy --prefer-binary
       - CIBW_TEST_COMMAND: python -m pygame.tests -v --exclude opengl,music,timing --time_out 300
       - CIBW_BUILD_VERBOSITY: 2
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -152,11 +152,12 @@ jobs:
         bash ./install_mac_deps.sh
 
       CIBW_BEFORE_BUILD: |
-        pip install numpy
         cp -r ${{ github.workspace }}/pygame_mac_deps_${{ matrix.macarch }} ${{ github.workspace }}/pygame_mac_deps
 
       # To remove any speculations about the wheel not being self-contained
-      CIBW_BEFORE_TEST: rm -rf ${{ github.workspace }}/pygame_mac_deps
+      CIBW_BEFORE_TEST: |
+        rm -rf ${{ github.workspace }}/pygame_mac_deps
+        pip install numpy --prefer-binary
 
       CIBW_TEST_COMMAND: python -m pygame.tests -v --exclude opengl,timing --time_out 300
 

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -62,13 +62,7 @@ jobs:
 
       CIBW_TEST_COMMAND: python -m pygame.tests -v --exclude opengl,music,timing --time_out 300
 
-      # To 'solve' this issue:
-      #   >>> process 338: D-Bus library appears to be incorrectly set up; failed to read
-      #   machine uuid: Failed to open "/var/lib/dbus/machine-id": No such file or directory
-      CIBW_BEFORE_TEST: |
-        if [ ! -f /var/lib/dbus/machine-id ]; then
-            dbus-uuidgen > /var/lib/dbus/machine-id
-        fi
+      CIBW_BEFORE_TEST: pip install numpy --prefer-binary
 
       # Increase pip debugging output
       CIBW_BUILD_VERBOSITY: 2

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -132,7 +132,7 @@ jobs:
       CIBW_BUILD: ${{ matrix.pyversions }}
       CIBW_ARCHS: ${{ matrix.winarch }}
 
-      CIBW_BEFORE_BUILD: pip install numpy
+      CIBW_BEFORE_TEST: pip install numpy --prefer-binary
 
       CIBW_TEST_COMMAND: python -m pygame.tests -v --exclude opengl,timing --time_out 300
 


### PR DESCRIPTION
This PR does a couple of CI related improvements

- Makes sure we prefer a binary install of numpy for testing our wheels. On more obscure builds (like some pypy ones) latest numpy version is built from source and this takes a lot of CI time. Now, older versions of numpy can be picked if they offer binaries