### PR TITLE
Fix rect drawing issues around surface edges

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1458,7 +1458,6 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     int end_x = x2;
     int end_y = y2;
     int xinc = 0;
-    int clip = 0;
     /* Decide which direction to grow (width/thickness). */
     if (abs(x1 - x2) <= abs(y1 - y2)) {
         /* The line's thickness will be in the x direction. The top/bottom

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -914,7 +914,7 @@ rect(PyObject *self, PyObject *args, PyObject *kwargs)
         if (!SDL_IntersectRect(&sdlrect, &cliprect, &clipped)) {
             return pgRect_New4(rect->x, rect->y, 0, 0);
         }
-        if (width > 0 && (width * 2) < clipped.w && (width * 2) < clipped.h) {
+        if (width > 0 && width < clipped.w && width < clipped.h) {
             draw_rect(surf, sdlrect.x, sdlrect.y, sdlrect.x + sdlrect.w - 1,
                       sdlrect.y + sdlrect.h - 1, width, color);
         }

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1061,7 +1061,8 @@ add_line_to_drawn_list(int x1, int y1, int x2, int *pts)
 }
 
 static int
-clip_line(SDL_Surface *surf, int *x1, int *y1, int *x2, int *y2, int width, int xinc)
+clip_line(SDL_Surface *surf, int *x1, int *y1, int *x2, int *y2, int width,
+          int xinc)
 {
     int p1 = *x1 - *x2;
     int p2 = -p1;
@@ -1077,8 +1078,8 @@ clip_line(SDL_Surface *surf, int *x1, int *y1, int *x2, int *y2, int width, int 
     double pmin = 1;
     double r1, r2;
     if (xinc) {
-       q1 += width;
-       q2 -= width;
+        q1 += width;
+        q2 -= width;
     }
     else {
         q3 += width;
@@ -1122,14 +1123,14 @@ clip_line(SDL_Surface *surf, int *x1, int *y1, int *x2, int *y2, int width, int 
     if (nmax > pmin)
         return 0;
     if (width == 0) {
-    *x1 =
-        old_x1 + (int)(p2 * nmax < 0 ? (p2 * nmax - 0.5) : (p2 * nmax + 0.5));
-    *y1 =
-        old_y1 + (int)(p4 * nmax < 0 ? (p4 * nmax - 0.5) : (p4 * nmax + 0.5));
-    *x2 =
-        old_x1 + (int)(p2 * pmin < 0 ? (p2 * pmin - 0.5) : (p2 * pmin + 0.5));
-    *y2 =
-        old_y1 + (int)(p4 * pmin < 0 ? (p4 * pmin - 0.5) : (p4 * pmin + 0.5));
+        *x1 = old_x1 +
+              (int)(p2 * nmax < 0 ? (p2 * nmax - 0.5) : (p2 * nmax + 0.5));
+        *y1 = old_y1 +
+              (int)(p4 * nmax < 0 ? (p4 * nmax - 0.5) : (p4 * nmax + 0.5));
+        *x2 = old_x1 +
+              (int)(p2 * pmin < 0 ? (p2 * pmin - 0.5) : (p2 * pmin + 0.5));
+        *y2 = old_y1 +
+              (int)(p4 * pmin < 0 ? (p4 * pmin - 0.5) : (p4 * pmin + 0.5));
     }
     return 1;
 }
@@ -1499,7 +1500,8 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     dy = abs(y2 - y1);
     sy = y1 < y2 ? 1 : -1;
     err = (dx > dy ? dx : -dy) / 2;
-    clip = clip_line(surf, &x1, &y1, &x2, &y2, width, xinc) || clip_line(surf, &x1+width, &y1, &x2, &y2, -width, xinc);
+    clip = clip_line(surf, &x1, &y1, &x2, &y2, width, xinc) ||
+           clip_line(surf, &x1 + width, &y1, &x2, &y2, -width, xinc);
     clip_line(surf, &x1, &y1, &x2, &y2, 0, 0);
     if (clip) {
         if (width == 1)

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1501,8 +1501,8 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     sy = y1 < y2 ? 1 : -1;
     err = (dx > dy ? dx : -dy) / 2;
     clip = clip_line(surf, &x1, &y1, &x2, &y2, width, xinc) ||
-           clip_line(surf, &x1 + width, &y1, &x2, &y2, -width, xinc);
-    clip_line(surf, &x1, &y1, &x2, &y2, 0, 0);
+           clip_line(surf, &x1 + width, &y1, &x2, &y2, -width, xinc) ||
+           clip_line(surf, &x1, &y1, &x2, &y2, 0, 0);
     if (clip) {
         if (width == 1)
             draw_line(surf, x1, y1, x2, y2, color, drawn_area);


### PR DESCRIPTION
This resolves #1968 and a similar issue encountered where the drawn rect would be stretched to the edge of the screen when in close proximity. 