### PR TITLE
`font.SysFont` - Warn user if no font was found

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -18,7 +18,7 @@
 # Pete Shinners
 # pete@shinners.org
 """sysfont, used in the font module to find system fonts"""
-
+import logging
 import os
 import sys
 import warnings
@@ -451,6 +451,23 @@ def SysFont(name, size, bold=False, italic=False, constructor=None):
                     gotitalic = italic
             if fontname:
                 break
+
+        else:
+            if len(name) > 1:
+                name = list(name)
+                for i in range(len(name)):
+                    if isinstance(name[i], bytes):
+                        name[i] = name[i].decode()
+                logging.warning(
+                    f"None of the specified system fonts ({', '.join(name)}) "
+                    f"could be found. Using the default font instead."
+                )
+            else:
+                single_name = name[0].decode() if type(name[0]) is bytes else name[0]
+                logging.warning(
+                    f"The system font '{single_name}' couldn't be "
+                    f"found. Using the default font instead."
+                )
 
     set_bold = set_italic = False
     if bold and not gotbold:

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -22,7 +22,6 @@
 import warnings
 import os
 import sys
-import warnings
 from os.path import basename, dirname, exists, join, splitext
 
 from pygame.font import Font

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -459,16 +459,19 @@ def SysFont(name, size, bold=False, italic=False, constructor=None):
                 for idx, single_name in enumerate(name):
                     if isinstance(single_name, bytes):
                         name[idx] = single_name.decode()
+
+                names = "', '".join(name)
                 warnings.warn(
-                    f"None of the specified system fonts ({', '.join(name)}) "
-                    "could be found. Using the default font instead."
+                    f"None of the specified system fonts "
+                    f"('{names}') could be found. "
+                    f"Using the default font instead."
                 )
             else:
                 single_name = (
                     name[0].decode() if isinstance(name[0], bytes) else name[0]
                 )
                 warnings.warn(
-                    f"The system font {single_name} couldn't be "
+                    f"The system font '{single_name}' couldn't be "
                     "found. Using the default font instead."
                 )
 

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -18,7 +18,8 @@
 # Pete Shinners
 # pete@shinners.org
 """sysfont, used in the font module to find system fonts"""
-import logging
+
+import warnings
 import os
 import sys
 import warnings
@@ -459,19 +460,17 @@ def SysFont(name, size, bold=False, italic=False, constructor=None):
                 for idx, single_name in enumerate(name):
                     if isinstance(single_name, bytes):
                         name[idx] = single_name.decode()
-                logging.warning(
-                    f"None of the specified system fonts (%s) "
-                    f"could be found. Using the default font instead.",
-                    ", ".join(name),
+                warnings.warn(
+                    f"None of the specified system fonts ({', '.join(name)}) "
+                    "could be found. Using the default font instead."
                 )
             else:
                 single_name = (
                     name[0].decode() if isinstance(name[0], bytes) else name[0]
                 )
-                logging.warning(
-                    f"The system font '%s' couldn't be "
-                    f"found. Using the default font instead.",
-                    single_name,
+                warnings.warn(
+                    f"The system font {single_name} couldn't be "
+                    "found. Using the default font instead."
                 )
 
     set_bold = set_italic = False

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -455,18 +455,23 @@ def SysFont(name, size, bold=False, italic=False, constructor=None):
         else:
             if len(name) > 1:
                 name = list(name)
-                for i in range(len(name)):
-                    if isinstance(name[i], bytes):
-                        name[i] = name[i].decode()
+
+                for idx, single_name in enumerate(name):
+                    if isinstance(single_name, bytes):
+                        name[idx] = single_name.decode()
                 logging.warning(
-                    f"None of the specified system fonts ({', '.join(name)}) "
-                    f"could be found. Using the default font instead."
+                    f"None of the specified system fonts (%s) "
+                    f"could be found. Using the default font instead.",
+                    ", ".join(name),
                 )
             else:
-                single_name = name[0].decode() if type(name[0]) is bytes else name[0]
+                single_name = (
+                    name[0].decode() if isinstance(name[0], bytes) else name[0]
+                )
                 logging.warning(
-                    f"The system font '{single_name}' couldn't be "
-                    f"found. Using the default font instead."
+                    f"The system font '%s' couldn't be "
+                    f"found. Using the default font instead.",
+                    single_name,
                 )
 
     set_bold = set_italic = False

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -421,10 +421,13 @@ def SysFont(name, size, bold=False, italic=False, constructor=None):
     if name:
         if isinstance(name, (str, bytes)):
             name = name.split(b"," if isinstance(name, bytes) else ",")
-        for single_name in name:
+        else:
+            name = list(name)
+        for idx, single_name in enumerate(name):
             if isinstance(single_name, bytes):
-                single_name = single_name.decode()
+                name[idx] = single_name.decode()
 
+        for single_name in name:
             single_name = _simplename(single_name)
             styles = Sysfonts.get(single_name)
             if not styles:
@@ -454,12 +457,6 @@ def SysFont(name, size, bold=False, italic=False, constructor=None):
 
         else:
             if len(name) > 1:
-                name = list(name)
-
-                for idx, single_name in enumerate(name):
-                    if isinstance(single_name, bytes):
-                        name[idx] = single_name.decode()
-
                 names = "', '".join(name)
                 warnings.warn(
                     f"None of the specified system fonts "
@@ -467,11 +464,8 @@ def SysFont(name, size, bold=False, italic=False, constructor=None):
                     f"Using the default font instead."
                 )
             else:
-                single_name = (
-                    name[0].decode() if isinstance(name[0], bytes) else name[0]
-                )
                 warnings.warn(
-                    f"The system font '{single_name}' couldn't be "
+                    f"The system font '{name[0]}' couldn't be "
                     "found. Using the default font instead."
                 )
 

--- a/test/sysfont_test.py
+++ b/test/sysfont_test.py
@@ -63,6 +63,7 @@ class SysfontModuleTest(unittest.TestCase):
                 (bytes("non-existent font", "utf-8"), "non-existent font2"), 40
             )
 
+
 ###############################################################################
 
 if __name__ == "__main__":

--- a/test/sysfont_test.py
+++ b/test/sysfont_test.py
@@ -44,6 +44,24 @@ class SysfontModuleTest(unittest.TestCase):
 
         self.assertTrue(len(pygame.sysfont.get_fonts()) > 10)
 
+    def test_sysfont_warnings(self):
+        import pygame.font
+
+        pygame.font.init()
+
+        with self.assertWarns(UserWarning):
+            pygame.font.SysFont("non-existent font", 40)
+
+        with self.assertWarns(UserWarning):
+            pygame.font.SysFont(bytes("non-existent font", "utf-8"), 40)
+
+        with self.assertWarns(UserWarning):
+            pygame.font.SysFont(("non-existent font", "non-existent font2"), 40)
+
+        with self.assertWarns(UserWarning):
+            pygame.font.SysFont(
+                (bytes("non-existent font", "utf-8"), "non-existent font2"), 40
+            )
 
 ###############################################################################
 


### PR DESCRIPTION
See issue #1970 

When a non-existent font is passed to `pygame.font.SysFont`, Pygame uses a default font instead and doesn't raise an error. I've added a warning (not an error) that is shown when the user does this.
`The system font 'non-existent font' couldn't be found. Using the default font instead.`
`None of the specified system fonts (non-existent font, non-existent font2) could be found. Using the default font instead.`

Let me know if you would prefer a different error message, or if there's anything else you'd like me to change :)

Here's some test code:

```py
import pygame

pygame.font.init()

# Shows the following warning:
# The system font 'non-existent font' couldn't be found. Using the default font instead.
pygame.font.SysFont("non-existent font",40)
pygame.font.SysFont(bytes("non-existent font",'utf-8'),40)

# Shows the following warning:
# None of the specified system fonts (non-existent font, non-existent font2) could be found. Using the default font instead.
pygame.font.SysFont(("non-existent font","non-existent font2"),40)
pygame.font.SysFont((bytes("non-existent font",'utf-8'),"non-existent font2"),40)

# No warning is shown for any of the following:
pygame.font.SysFont("arial",40)
pygame.font.SysFont(("arial","comic sans"),40)
pygame.font.SysFont(("non-existent font", "arial"),40)
pygame.font.SysFont(bytes("arial",'utf-8'),40)
pygame.font.SysFont((bytes("non-existent font",'utf-8'), 'arial'),40)
pygame.font.SysFont(None,40)
```