### PR TITLE
add *venv* to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 # Other
 envdev*
 .virtualenv*
+*venv*
 buildconfig/manylinux-build/wheelhouse/
 anenv
 dist


### PR DESCRIPTION
I use the `venv` pattern for my virtual environments, and I often name them a bit differently to distinguish between python versions. So, I would like to add this wildcard match to the gitignore so that it matches anything like `venv`, `3.10venv`, `venv3.10`, etc