### PR TITLE
Change font.c to compare with SDL_ttf instead of SDL itself

### DIFF
--- a/src_c/font.c
+++ b/src_c/font.c
@@ -779,7 +779,7 @@ font_set_direction(PyObject *self, PyObject *arg, PyObject *kwarg)
             break;
         }
 
-/*  There is a bug in SDL2 up to 2.26.3 (the current release version as of
+/*  There is a bug in SDL_ttf up to 2.22.0 (the current release version as of
    writing this) This bug flips the top-to-bottom and bottom-to-top rendering.
    So, this is a compat patch for that behavior
  */

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -784,7 +784,7 @@ font_set_direction(PyObject *self, PyObject *arg, PyObject *kwarg)
    So, this is a compat patch for that behavior
  */
 #if SDL_VERSIONNUM(SDL_TTF_MAJOR_VERSION, SDL_TTF_MINOR_VERSION, \
-                   SDL_TTF_PATCHLEVEL) < SDL_TTF_VERSIONNUM(2, 22, 0)
+                   SDL_TTF_PATCHLEVEL) < SDL_VERSIONNUM(2, 22, 0)
         case 2: {
             dir = TTF_DIRECTION_BTT;
             break;

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -784,7 +784,7 @@ font_set_direction(PyObject *self, PyObject *arg, PyObject *kwarg)
    So, this is a compat patch for that behavior
  */
 #if SDL_VERSIONNUM(SDL_TTF_MAJOR_VERSION, SDL_TTF_MINOR_VERSION, \
-                   SDL_TTF_PATCHLEVEL) <= SDL_VERSIONNUM(2, 26, 3)
+                   SDL_TTF_PATCHLEVEL) < SDL_TTF_VERSIONNUM(2, 22, 0)
         case 2: {
             dir = TTF_DIRECTION_BTT;
             break;

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -779,7 +779,7 @@ font_set_direction(PyObject *self, PyObject *arg, PyObject *kwarg)
             break;
         }
 
-/*  There is a bug in SDL_ttf up to 2.22.0 (the current release version as of
+/*  There is a bug in SDL_ttf up to 2.22.0 (the next release version as of
    writing this) This bug flips the top-to-bottom and bottom-to-top rendering.
    So, this is a compat patch for that behavior
  */


### PR DESCRIPTION
Fixes: #1987
Compares SDL_ttf version to 2.22.0, as requested by @Starbuck5.