### PR TITLE
doc fixes for `Font.set_direction`

### DIFF
--- a/docs/reST/ref/font.rst
+++ b/docs/reST/ref/font.rst
@@ -517,7 +517,7 @@ solves no longer exists, it will likely be removed in the future.
    .. method:: set_direction
 
       | :sl:`set the script direction for text shaping`
-      | :sg:`set_direction(direction=int) -> None`
+      | :sg:`set_direction(direction) -> None`
 
       Sets the font direction for harfbuzz text rendering, taking in an integer
       between 0 and 3 (inclusive) as input. There are convenient constants defined
@@ -530,6 +530,9 @@ solves no longer exists, it will likely be removed in the future.
 
       This method requires pygame built with SDL_ttf 2.20.0 or above. Otherwise the
       method will raise a pygame.error.
+
+      .. note:: multiline renders with :meth:`render` do not play nicely with top-to-bottom
+         or bottom-to-top rendering.
 
       .. versionadded:: 2.1.4
       

--- a/src_c/doc/font_doc.h
+++ b/src_c/doc/font_doc.h
@@ -30,7 +30,7 @@
 #define DOC_FONTGETASCENT "get_ascent() -> int\nget the ascent of the font"
 #define DOC_FONTGETDESCENT "get_descent() -> int\nget the descent of the font"
 #define DOC_FONTSETSCRIPT "set_script(str) -> None\nset the script code for text shaping"
-#define DOC_FONTSETDIRECTION "set_direction(direction=int) -> None\nset the script direction for text shaping"
+#define DOC_FONTSETDIRECTION "set_direction(direction) -> None\nset the script direction for text shaping"
 
 
 /* Docs in a comment... slightly easier to read. */
@@ -164,7 +164,7 @@ pygame.font.Font.set_script
 set the script code for text shaping
 
 pygame.font.Font.set_direction
- set_direction(direction=int) -> None
+ set_direction(direction) -> None
 set the script direction for text shaping
 
 */


### PR DESCRIPTION
Fixed a mistake in the function signature and added a note about top-to-bottom rendering and bottom-to-top rendering not working well with multiline rendering