### PR TITLE
Fix color swizzling as per request in #1989

### DIFF
--- a/docs/reST/ref/color.rst
+++ b/docs/reST/ref/color.rst
@@ -24,9 +24,9 @@
 
    Color objects support swizzling for their ``RGBA`` attributes, which allows
    the creation of new color objects with the corresponding swizzled attributes
-   as its ``RGBA`` attributes. For example, ``color.bgr`` provides a shortcut to
-   doing ``Color(color.b, color.g, color.r)``. Swizzling with 2 or more than 4
-   attributes will return a tuple consisting of the corresponding elements
+   as its ``RGBA`` attributes. For example, ``color.bgra`` provides a shortcut to
+   doing ``Color(color.b, color.g, color.r, color.a)``. Swizzling with other than
+   4 attributes will return a tuple consisting of the corresponding elements
    instead of a color object.
 
    Color objects support equality comparison with other color objects and 3 or

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -2079,8 +2079,8 @@ _color_getAttr_swizzle(pgColorObject *self, PyObject *attr_name)
         goto swizzle_failed;
     }
 
-    if (len == 3 || len == 4) {
-        static Uint8 rgba[] = {0, 0, 0, 255};
+    if (len == 4) {
+        static Uint8 rgba[4];
         res = (PyObject *)pgColor_New(rgba);
     }
     else {
@@ -2117,7 +2117,7 @@ _color_getAttr_swizzle(pgColorObject *self, PyObject *attr_name)
                 goto swizzle_failed;
         }
 
-        if (len == 3 || len == 4) {
+        if (len == 4) {
             ((pgColorObject *)res)->data[i] = value;
         }
         else {

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -1209,7 +1209,7 @@ class ColorTypeTest(unittest.TestCase):
     def test_swizzle_return_types(self):
         c = pygame.color.Color(10, 20, 30, 40)
 
-        self.assertEqual(type(c.rgb), pygame.color.Color)
+        self.assertEqual(type(c.rgb), tuple)
         self.assertEqual(type(c.rgba), pygame.color.Color)
         self.assertEqual(type(c.bgra), pygame.color.Color)
         self.assertEqual(type(c.bg), tuple)


### PR DESCRIPTION
Closes #1989.

Color swizzling with 3 attributes will now return a `tuple` instead of a 4-element-sized `pygame.Color`, with the alpha channel being inferred as opaque (`255`).
