### PR TITLE
Revise `repr` overload as per request in #1988

### DIFF
--- a/src_c/color.c
+++ b/src_c/color.c
@@ -718,7 +718,7 @@ _color_dealloc(pgColorObject *color)
 static PyObject *
 _color_repr(pgColorObject *color)
 {
-    return PyUnicode_FromFormat("<Color(%d, %d, %d, %d)>", color->data[0],
+    return PyUnicode_FromFormat("Color(%d, %d, %d, %d)", color->data[0],
                                 color->data[1], color->data[2],
                                 color->data[3]);
 }

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -1753,20 +1753,20 @@ static PyObject *
 vector_repr(pgVector *self)
 {
     /* The repr() of the largest possible Vector3 looks like
-     * "<Vector3({d}, {d}, {d})>" where 'd' has a maximum size of 32 bytes
+     * "Vector3({d}, {d}, {d})" where 'd' has a maximum size of 32 bytes
      *  so allocate a 16 + 3 * 32 == 112 byte buffer
      */
     char buffer[STRING_BUF_SIZE_REPR];
     int tmp;
 
     if (self->dim == 2) {
-        tmp = PyOS_snprintf(buffer, STRING_BUF_SIZE_REPR, "<Vector2(%g, %g)>",
+        tmp = PyOS_snprintf(buffer, STRING_BUF_SIZE_REPR, "Vector2(%g, %g)",
                             self->coords[0], self->coords[1]);
     }
     else if (self->dim == 3) {
-        tmp = PyOS_snprintf(buffer, STRING_BUF_SIZE_REPR,
-                            "<Vector3(%g, %g, %g)>", self->coords[0],
-                            self->coords[1], self->coords[2]);
+        tmp =
+            PyOS_snprintf(buffer, STRING_BUF_SIZE_REPR, "Vector3(%g, %g, %g)",
+                          self->coords[0], self->coords[1], self->coords[2]);
     }
     else {
         return RAISE(
@@ -2181,7 +2181,7 @@ _vector2_set(pgVector *self, PyObject *xOrSequence, PyObject *y)
                 return 0;
         }
         else if (PyUnicode_Check(xOrSequence)) {
-            char *delimiter[3] = {"<Vector2(", ", ", ")>"};
+            char *delimiter[3] = {"Vector2(", ", ", ")"};
             Py_ssize_t error_code;
             error_code = _vector_coords_from_string(xOrSequence, delimiter,
                                                     self->coords, self->dim);
@@ -2616,7 +2616,7 @@ _vector3_set(pgVector *self, PyObject *xOrSequence, PyObject *y, PyObject *z)
                 return 0;
         }
         else if (PyUnicode_Check(xOrSequence)) {
-            char *delimiter[4] = {"<Vector3(", ", ", ", ", ")>"};
+            char *delimiter[4] = {"Vector3(", ", ", ", ", ")"};
             Py_ssize_t error_code;
             error_code = _vector_coords_from_string(xOrSequence, delimiter,
                                                     self->coords, self->dim);

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -56,7 +56,7 @@
 
 #define VECTOR_EPSILON (1e-6)
 #define VECTOR_MAX_SIZE (4)
-#define STRING_BUF_SIZE_REPR (112)
+#define STRING_BUF_SIZE_REPR (110)
 #define STRING_BUF_SIZE_STR (103)
 #define SWIZZLE_ERR_NO_ERR 0
 #define SWIZZLE_ERR_DOUBLE_IDX 1
@@ -1754,7 +1754,7 @@ vector_repr(pgVector *self)
 {
     /* The repr() of the largest possible Vector3 looks like
      * "Vector3({d}, {d}, {d})" where 'd' has a maximum size of 32 bytes
-     *  so allocate a 16 + 3 * 32 == 112 byte buffer
+     *  so allocate a 14 + 3 * 32 == 110 byte buffer
      */
     char buffer[STRING_BUF_SIZE_REPR];
     int tmp;

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -1664,7 +1664,7 @@ static PyNumberMethods pg_rect_as_number = {
 static PyObject *
 pg_rect_repr(pgRectObject *self)
 {
-    return PyUnicode_FromFormat("<rect(%d, %d, %d, %d)>", self->r.x, self->r.y,
+    return PyUnicode_FromFormat("Rect(%d, %d, %d, %d)", self->r.x, self->r.y,
                                 self->r.w, self->r.h);
 }
 

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -500,8 +500,7 @@ class ColorTypeTest(unittest.TestCase):
 
     def test_repr(self):
         c = pygame.Color(68, 38, 26, 69)
-        t = "<Color(68, 38, 26, 69)>"
-        self.assertEqual(repr(c), t)
+        self.assertEqual(repr(c), "Color(68, 38, 26, 69)")
 
     def test_add(self):
         c1 = pygame.Color(0)

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -510,8 +510,8 @@ class Vector2TypeTest(unittest.TestCase):
 
     def testRepr(self):
         v = Vector2(1.2, 3.4)
-        self.assertEqual(v.__repr__(), "<Vector2(1.2, 3.4)>")
-        self.assertEqual(v, Vector2(v.__repr__()))
+        self.assertEqual(repr(v), "Vector2(1.2, 3.4)")
+        self.assertEqual(v, Vector2(repr(v)))
 
     def testIter(self):
         it = self.v1.__iter__()
@@ -1498,8 +1498,8 @@ class Vector3TypeTest(unittest.TestCase):
 
     def testRepr(self):
         v = Vector3(1.2, 3.4, -9.6)
-        self.assertEqual(v.__repr__(), "<Vector3(1.2, 3.4, -9.6)>")
-        self.assertEqual(v, Vector3(v.__repr__()))
+        self.assertEqual(repr(v), "Vector3(1.2, 3.4, -9.6)")
+        self.assertEqual(v, Vector3(repr(v)))
 
     def testIter(self):
         it = self.v1.__iter__()

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -46,6 +46,10 @@ class RectTypeTest(unittest.TestCase):
         self.assertEqual((r.left, r.centery), r.midleft)
         self.assertEqual((r.right, r.centery), r.midright)
 
+    def testRepr(self):
+        rect = Rect(12, 34, 56, 78)
+        self.assertEqual(repr(rect), "Rect(12, 34, 56, 78)")
+
     def test_rect_iter(self):
         rect = Rect(50, 100, 150, 200)
 


### PR DESCRIPTION
Closes #1988.

Revises the `repr` overload for `pygame.Color`, `pygame.Vector2`, `pygame.Vector3`, and `pygame.Rect` as @Starbuck5 has specified in #1988.