### PR TITLE
added missing versionadded tags in recent new API docs

### DIFF
--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -176,6 +176,8 @@
                 optimizations are applied if blit_sequence is a list or a tuple (using one
                 of them is recommended).
 
+      .. versionadded:: 2.1.4
+
       .. ## Surface.fblits ##
 
    .. method:: convert

--- a/docs/reST/ref/transform.rst
+++ b/docs/reST/ref/transform.rst
@@ -244,6 +244,8 @@ Instead, always begin with the original image and scale to the desired size.)
 
    Inverts each RGB pixel contained within the Surface, does not affect alpha channel. Can also be used with a destination Surface. 
 
+   .. versionadded:: 2.2.0
+
    .. ## pygame.transform.invert ##
 
 .. function:: grayscale


### PR DESCRIPTION
I merged that PR without noticing that there was no `.. versionadded::` in the docs. This corrects that