### PR TITLE
Fix issues and inconsistency with draw_line_width 

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1481,7 +1481,7 @@ static void
 draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
                 int y2, int width, int *drawn_area)
 {
-    int dx, dy, err, e2, sx, sy, y;
+    int dx, dy, err, e2, sx, sy, y, start_numx, start_numy, end_numx, end_numy;
     int start_x = surf->clip_rect.x;
     int start_y = surf->clip_rect.y;
     int end_x = surf->clip_rect.x + surf->clip_rect.w;
@@ -1506,6 +1506,8 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
         xinc = 1;
         start_x -= width;
         end_x += width;
+        start_numy = start_y;
+        end_numy = end_y;
     }
     else {
         start_y -= width;
@@ -1525,13 +1527,17 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     dy = abs(y2 - y1);
     sx = x2 > x1 ? 1 : -1;
     sy = y2 > y1 ? 1 : -1;
+    start_numy = y2 > y1 ? start_y : end_y;
+    start_numx = x2 > x1 ? start_x : end_x;
+    end_numy = y2 < y1 ? start_y : end_y;
+    end_numx = x2 < x1 ? start_x : end_x;
 
 
     err = (dx > dy ? dx : -dy) / 2;
     // draw it
     if (xinc) {
         while (y1 != (y2+sy)) {
-            if (start_y <= y1 <= end_y) {
+            if (start_numy <= y1 < end_numy) {
             for (int x = MAX((x1 - width)  + extra_width, surf->clip_rect.x); x<=MIN(surf->clip_rect.x + surf->clip_rect.w - 1, x1 + width); x++) {
 
 
@@ -1547,7 +1553,7 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     }
     else {
         while (x1 != (x2+sx)) {
-            if (start_x <= x1 <= end_x) {
+            if (start_numx <= x1 < end_numx) {
             for (int y = MAX((y1 - width) + extra_width , surf->clip_rect.y); y <= MIN(surf->clip_rect.y + surf->clip_rect.h -1, y1 + width); y++) {
 
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1088,8 +1088,8 @@ clip_line(SDL_Surface *surf, int *x1, int *y1, int *x2, int *y2, int width,
         bottom = MAX(*y1, *y2) + width;
     }
     if (surf->clip_rect.x > right || surf->clip_rect.y > bottom ||
-        surf->clip_rect.x + surf->clip_rect.w < left ||
-        surf->clip_rect.y + surf->clip_rect.h < top) {
+        surf->clip_rect.x + surf->clip_rect.w <= left ||
+        surf->clip_rect.y + surf->clip_rect.h <= top) {
         return 0;
     }
 
@@ -1469,8 +1469,6 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
                 int y2, int width, int *drawn_area)
 {
     int dx, dy, err, e2, sx, sy;
-    int start_x = surf->clip_rect.x;
-    int start_y = surf->clip_rect.y;
     int end_x = surf->clip_rect.x + surf->clip_rect.w - 1;
     int end_y = surf->clip_rect.y + surf->clip_rect.h - 1;
     int xinc = 0;
@@ -1496,7 +1494,7 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
         return;
 
     if (x1 == x2 && y1 == y2) { /* Single point */
-        for (int x = MAX((x1 - width) + extra_width, start_x);
+        for (int x = MAX((x1 - width) + extra_width, surf->clip_rect.x);
              x <= MIN(end_x, x1 + width); x++) {
             set_at_unchecked(surf, x, y1, color);
             add_pixel_to_drawn_list(x, y1, drawn_area);
@@ -1511,8 +1509,9 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     err = (dx > dy ? dx : -dy) / 2;
     if (xinc) {
         while (y1 != (y2 + sy)) {
-            if (start_y <= y1 && y1 <= end_y) {
-                for (int x = MAX((x1 - width) + extra_width, start_x);
+            if (surf->clip_rect.y <= y1 && y1 <= end_y) {
+                for (int x =
+                         MAX((x1 - width) + extra_width, surf->clip_rect.x);
                      x <= MIN(end_x, x1 + width); x++) {
                     set_at_unchecked(surf, x, y1, color);
                     add_pixel_to_drawn_list(x, y1, drawn_area);
@@ -1531,8 +1530,9 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     }
     else {
         while (x1 != (x2 + sx)) {
-            if (start_x <= x1 && x1 <= end_x) {
-                for (int y = MAX((y1 - width) + extra_width, start_y);
+            if (surf->clip_rect.x <= x1 && x1 <= end_x) {
+                for (int y =
+                         MAX((y1 - width) + extra_width, surf->clip_rect.y);
                      y <= MIN(end_y, y1 + width); y++) {
                     set_at_unchecked(surf, x1, y, color);
                     add_pixel_to_drawn_list(x1, y, drawn_area);

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1481,7 +1481,7 @@ static void
 draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
                 int y2, int width, int *drawn_area)
 {
-    int dx, dy, err, e2, sx, sy, y, start_numx, start_numy, end_numx, end_numy;
+    int dx, dy, err, e2, sx, sy;
     int start_x = surf->clip_rect.x;
     int start_y = surf->clip_rect.y;
     int end_x = surf->clip_rect.x + surf->clip_rect.w;
@@ -1506,8 +1506,6 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
         xinc = 1;
         start_x -= width;
         end_x += width;
-        start_numy = start_y;
-        end_numy = end_y;
     }
     else {
         start_y -= width;
@@ -1527,18 +1525,12 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     dy = abs(y2 - y1);
     sx = x2 > x1 ? 1 : -1;
     sy = y2 > y1 ? 1 : -1;
-    start_numy = y2 > y1 ? start_y : end_y;
-    start_numx = x2 > x1 ? start_x : end_x;
-    end_numy = y2 < y1 ? start_y : end_y;
-    end_numx = x2 < x1 ? start_x : end_x;
-
-
     err = (dx > dy ? dx : -dy) / 2;
     // draw it
     if (xinc) {
         while (y1 != (y2+sy)) {
-            if (start_numy <= y1 < end_numy) {
-            for (int x = MAX((x1 - width)  + extra_width, surf->clip_rect.x); x<=MIN(surf->clip_rect.x + surf->clip_rect.w - 1, x1 + width); x++) {
+            if (start_y <= y1 && y1 < end_y) {
+            for (int x = MAX((x1 - width) + extra_width, surf->clip_rect.x); x<=MIN(surf->clip_rect.x + surf->clip_rect.w - 1, x1 + width); x++) {
 
 
                 set_at_unchecked(surf, x, y1, color);
@@ -1553,10 +1545,8 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     }
     else {
         while (x1 != (x2+sx)) {
-            if (start_numx <= x1 < end_numx) {
+            if (start_x <= x1 && x1 < end_x) {
             for (int y = MAX((y1 - width) + extra_width , surf->clip_rect.y); y <= MIN(surf->clip_rect.y + surf->clip_rect.h -1, y1 + width); y++) {
-
-
                 set_at_unchecked(surf, x1, y, color);
                 add_pixel_to_drawn_list(x1, y, drawn_area);
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1484,8 +1484,8 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     int dx, dy, err, e2, sx, sy;
     int start_x = surf->clip_rect.x;
     int start_y = surf->clip_rect.y;
-    int end_x = surf->clip_rect.x + surf->clip_rect.w;
-    int end_y = surf->clip_rect.y + surf->clip_rect.h;
+    int end_x = surf->clip_rect.x + surf->clip_rect.w - 1;
+    int end_y = surf->clip_rect.y + surf->clip_rect.h - 1;
     int xinc = 0;
     int extra_width = 1 - (width % 2);
     //validate not point first
@@ -1504,19 +1504,14 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
         /* The line's thickness will be in the x direction. The top/bottom
          * ends of the line will be flat. */
         xinc = 1;
-        start_x -= width;
-        end_x += width;
-    }
-    else {
-        start_y -= width;
-        end_y += width;
     }
 
     if (!clip_line(surf, &x1, &y1, &x2, &y2, width, xinc)) return;
 
     if (x1 == x2 && y1 == y2) { /* Single point */
         for (int x = MAX((x1 - width)  + extra_width, start_x); x<=MIN(end_x, x1 + width); x++) {
-                set_and_check_rect(surf, x, y1, color, drawn_area);
+                set_at_unchecked(surf, x, y1, color);
+                add_pixel_to_drawn_list(x, y1, drawn_area);
             }
         return;
     }
@@ -1529,8 +1524,8 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     // draw it
     if (xinc) {
         while (y1 != (y2+sy)) {
-            if (start_y <= y1 && y1 < end_y) {
-            for (int x = MAX((x1 - width) + extra_width, surf->clip_rect.x); x<=MIN(surf->clip_rect.x + surf->clip_rect.w - 1, x1 + width); x++) {
+            if (start_y <= y1 && y1 <= end_y) {
+            for (int x = MAX((x1 - width) + extra_width, start_x); x<=MIN(end_x, x1 + width); x++) {
 
 
                 set_at_unchecked(surf, x, y1, color);
@@ -1545,8 +1540,8 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     }
     else {
         while (x1 != (x2+sx)) {
-            if (start_x <= x1 && x1 < end_x) {
-            for (int y = MAX((y1 - width) + extra_width , surf->clip_rect.y); y <= MIN(surf->clip_rect.y + surf->clip_rect.h -1, y1 + width); y++) {
+            if (start_x <= x1 && x1 <= end_x) {
+            for (int y = MAX((y1 - width) + extra_width , start_y); y <= MIN(end_y, y1 + width); y++) {
                 set_at_unchecked(surf, x1, y, color);
                 add_pixel_to_drawn_list(x1, y, drawn_area);
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -993,12 +993,6 @@ compare_int(const void *a, const void *b)
     return (*(const int *)a) - (*(const int *)b);
 }
 
-static int
-sign(int x, int y)
-{
-    return (x > 0) ? 1 : ((x < 0) ? -1 : y);
-}
-
 static Uint32
 get_antialiased_color(SDL_Surface *surf, int x, int y, Uint32 original_color,
                       float brightness, int blend)

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1482,7 +1482,6 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
                 int y2, int width, int *drawn_area)
 {
     int dx, dy, err, e2, sx, sy, y;
-    int left_top, right_bottom;
     int start_x = surf->clip_rect.x;
     int start_y = surf->clip_rect.y;
     int end_x = surf->clip_rect.x + surf->clip_rect.w;
@@ -1526,33 +1525,36 @@ draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2,
     dy = abs(y2 - y1);
     sx = x2 > x1 ? 1 : -1;
     sy = y2 > y1 ? 1 : -1;
+
+
     err = (dx > dy ? dx : -dy) / 2;
     // draw it
     if (xinc) {
-        while (y1 < start_y || y1 > end_y) {
-            e2 = err;
-            if (e2 >-dx) { err -= dy; x1 += sx; }
-            if (e2 < dy) { err += dx; y1 += sy; }
-        }
         while (y1 != (y2+sy)) {
-            for (int x = MAX((x1 - width)  + extra_width, start_x); x<=MIN(end_x, x1 + width); x++) {
-                set_and_check_rect(surf, x, y1, color, drawn_area);
+            if (start_y <= y1 <= end_y) {
+            for (int x = MAX((x1 - width)  + extra_width, surf->clip_rect.x); x<=MIN(surf->clip_rect.x + surf->clip_rect.w - 1, x1 + width); x++) {
+
+
+                set_at_unchecked(surf, x, y1, color);
+                add_pixel_to_drawn_list(x, y1, drawn_area);
 
             }
+             }
             e2 = err;
             if (e2 >-dx) { err -= dy; x1 += sx; }
             if (e2 < dy) { err += dx; y1 += sy; }
         }
     }
     else {
-        while (x1 < start_x || x1 > end_x) {
-            e2 = err;
-            if (e2 >-dx) { err -= dy; x1 += sx; }
-            if (e2 < dy) { err += dx; y1 += sy; }
-        }
         while (x1 != (x2+sx)) {
-            for (int y = MAX((y1 - width) + extra_width , start_y); y <= MIN(end_y, y1 + width); y++) {
-                set_and_check_rect(surf, x1, y, color, drawn_area);
+            if (start_x <= x1 <= end_x) {
+            for (int y = MAX((y1 - width) + extra_width , surf->clip_rect.y); y <= MIN(surf->clip_rect.y + surf->clip_rect.h -1, y1 + width); y++) {
+
+
+                set_at_unchecked(surf, x1, y, color);
+                add_pixel_to_drawn_list(x1, y, drawn_area);
+
+            }
             }
             e2 = err;
             if (e2 >-dx) { err -= dy; x1 += sx; }

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1791,6 +1791,61 @@ class DrawLineTest(LineMixin, DrawTestCase):
         check_white_line((50, 50), (0, 120))
         check_white_line((50, 50), (199, 198))
 
+    def test_line_clipping_with_thickness(self):
+        width = 200
+        height = 200
+        start_points = [
+            (-50, -50),
+            (-50, 50),
+            (50, 50),
+            (250, 250),
+            (200, 203),
+            (-29, 131),
+            (203, 0),
+            (-10, -10),
+            (-10, 210),
+        ]
+        end_points = [
+            (20, 200),
+            (20, -20),
+            (-20, -10),
+            (120, 20),
+            (0, 202),
+            (21, 106),
+            (200, 200),
+            (210, 210),
+            (100, 150),
+        ]
+        check_points = [
+            ((2, 126), (255, 255, 255)),
+            ((2, 3), (255, 255, 255)),
+            ((50, 55), (255, 255, 255)),
+            ((199, 165), (255, 255, 255)),
+            ((99, 198), (255, 255, 255)),
+            ((70, 80), (0, 0, 0)),
+            ((199, 0), (255, 255, 255)),
+            ((105, 100), (255, 255, 255)),
+            ((5, 198), (255, 255, 255)),
+        ]
+
+        surf = pygame.Surface((width, height), pygame.SRCALPHA)
+        for n in range(len(start_points)):
+            surf.fill((0, 0, 0))
+            pygame.draw.line(surf, (255, 255, 255), start_points[n], end_points[n], 10)
+            self.assertEqual(
+                surf.get_at(check_points[n][0]),
+                check_points[n][1],
+                "start={}, end={}".format(start_points[n], end_points[n]),
+            )
+            surf.fill((0, 0, 0))
+            pygame.draw.line(surf, (255, 255, 255), end_points[n], start_points[n], 10)
+
+            self.assertEqual(
+                surf.get_at(check_points[n][0]),
+                check_points[n][1],
+                "start={}, end={}".format(end_points[n], start_points[n]),
+            )
+
 
 ### Lines Testing #############################################################
 


### PR DESCRIPTION
This change resolves issues #1968 and https://github.com/pygame/pygame/issues/3199 through a rewrite of the draw_line_width function. Drawing lines from a to b should now also be the same as drawing from b to a.