### PR TITLE
Change mixer to use FileNotFoundError and fix related tests

### DIFF
--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -34,6 +34,7 @@ MP3 in most cases.
    the type of music data in the object. For example: :code:`load(fileobj, "ogg")`.
 
    .. versionchanged:: 2.0.2 Added optional ``namehint`` argument
+   .. versionchanged:: 2.2.0 Raises ``FileNotFoundError`` instead of :exc:`pygame.error` if file cannot be found
 
    .. ## pygame.mixer.music.load ##
 
@@ -243,6 +244,7 @@ MP3 in most cases.
        pygame.mixer.music.queue('mozart.ogg')
 
    .. versionchanged:: 2.0.2 Added optional ``namehint`` argument
+   .. versionchanged:: 2.2.0 Raises ``FileNotFoundError`` instead of :exc:`pygame.error` if file cannot be found
 
    .. ## pygame.mixer.music.queue ##
 

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -382,12 +382,7 @@ _load_music(PyObject *obj, char *namehint)
     MIXER_INIT_CHECK();
 
     rw = pgRWops_FromObject(obj, &ext);
-    if (rw ==
-        NULL) { /* stop on NULL, error already set is what we SHOULD do */
-        PyErr_Fetch(&_type, &error, &_traceback);
-        PyErr_SetObject(PyExc_FileNotFoundError, error);
-        Py_XDECREF(_type);
-        Py_XDECREF(_traceback);
+    if (rw == NULL) {
         return NULL;
     }
     if (namehint) {

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -375,9 +375,6 @@ _load_music(PyObject *obj, char *namehint)
     Mix_Music *new_music = NULL;
     char *ext = NULL, *type = NULL;
     SDL_RWops *rw = NULL;
-    PyObject *_type = NULL;
-    PyObject *error = NULL;
-    PyObject *_traceback = NULL;
 
     MIXER_INIT_CHECK();
 

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -385,7 +385,7 @@ _load_music(PyObject *obj, char *namehint)
     if (rw ==
         NULL) { /* stop on NULL, error already set is what we SHOULD do */
         PyErr_Fetch(&_type, &error, &_traceback);
-        PyErr_SetObject(pgExc_SDLError, error);
+        PyErr_SetObject(PyExc_FileNotFoundError, error);
         Py_XDECREF(_type);
         Py_XDECREF(_traceback);
         return NULL;

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -174,7 +174,7 @@ class MixerMusicModuleTest(unittest.TestCase):
 
     def test_queue__invalid_filename(self):
         """Ensures queue() correctly handles invalid filenames."""
-        with self.assertRaises(pygame.error):
+        with self.assertRaises(FileNotFoundError):
             pygame.mixer.music.queue("")
 
     def test_music_pause__unpause(self):

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -93,7 +93,7 @@ class MixerModuleTest(unittest.TestCase):
             frequency, size, channels = init_conf.values()
             if (frequency, size) == (22050, 16):
                 continue
-            mixer.init(frequency, size, channels)
+            mixer.init(frequency, size, channels, allowedchanges=0)
 
             mixer_conf = mixer.get_init()
 


### PR DESCRIPTION
This resolves https://github.com/pygame/pygame/issues/2792 by changing the error emitted and the test checking the error. This also fixes an issue with a test incorrectly failing because "allowedchanges" was not set to 0.