### PR TITLE
Add test that the surface to be pre-multiplied has pixels

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3155,10 +3155,15 @@ surf_premul_alpha(pgSurfaceObject *self, PyObject *_null)
     pgSurface_Prep(self);
     // Make a copy of the surface first
     newsurf = SDL_ConvertSurface(surf, surf->format, 0);
-    if (premul_surf_color_by_alpha(surf, newsurf) != 0) {
-        return RAISE(PyExc_ValueError,
-                     "source surface to be alpha pre-multiplied must have "
-                     "alpha channel");
+
+    if ((surf->w > 0 && surf->h > 0)){
+        // If the surface has no pixels we don't need to premul
+        // just return the copy.
+        if (premul_surf_color_by_alpha(surf, newsurf) != 0) {
+            return RAISE(PyExc_ValueError,
+                         "source surface to be alpha pre-multiplied must have "
+                         "alpha channel");
+        }
     }
     pgSurface_Unprep(self);
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3156,7 +3156,7 @@ surf_premul_alpha(pgSurfaceObject *self, PyObject *_null)
     // Make a copy of the surface first
     newsurf = SDL_ConvertSurface(surf, surf->format, 0);
 
-    if ((surf->w > 0 && surf->h > 0)){
+    if ((surf->w > 0 && surf->h > 0)) {
         // If the surface has no pixels we don't need to premul
         // just return the copy.
         if (premul_surf_color_by_alpha(surf, newsurf) != 0) {


### PR DESCRIPTION
This prevents a crash when you try to pre-multiply a surface with zero pixels.