### PR TITLE
Fix the segfault of `Surface.convert()`.

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1562,11 +1562,11 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
     }
     else {
         newsurf = pg_DisplayFormat(surf);
-        if (newsurf == NULL) {
-            SDL_FreeSurface(newsurf);
-            return RAISE(pgExc_SDLError, SDL_GetError());
-        }
         SDL_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_NONE);
+    }
+
+    if (newsurf == NULL) {
+        return RAISE(pgExc_SDLError, SDL_GetError());
     }
 
     if (has_colorkey) {

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1562,6 +1562,10 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
     }
     else {
         newsurf = pg_DisplayFormat(surf);
+        if (newsurf == NULL) {
+            SDL_FreeSurface(newsurf);
+            return RAISE(pgExc_SDLError, SDL_GetError());
+        }
         SDL_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_NONE);
     }
 

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1096,6 +1096,8 @@ class GeneralSurfaceTests(unittest.TestCase):
         for surf.convert()."""
         pygame.display.quit()
         surf = pygame.Surface((1, 1))
+        filename = example_path(os.path.join("data", "alien3.png"))  # 8bit PNG
+        surf8bit = pygame.image.load(filename)
 
         self.assertRaisesRegex(pygame.error, "display initialized", surf.convert)
 
@@ -1109,6 +1111,7 @@ class GeneralSurfaceTests(unittest.TestCase):
                     self.fail("convert() should not raise an exception here.")
 
             self.assertRaisesRegex(pygame.error, "No video mode", surf.convert)
+            self.assertRaisesRegex(pygame.error, "No video mode", surf8bit.convert)
 
             pygame.display.set_mode((640, 480))
             try:


### PR DESCRIPTION
Fix the segfault on converting an 8-bit surface.
**Test Code:**
```python
import pygame

pygame.display.init()

filename='alien3.png' # 8bit PNG (from /pygame/example/data)
#filename='lena.png' # 32bit PNG

img=pygame.image.load(filename)
img.convert()
# ↑ Should get a 'pygame.error: No video mode has been set'
```