### PR TITLE
Fix text input example

### DIFF
--- a/examples/textinput.py
+++ b/examples/textinput.py
@@ -28,9 +28,9 @@ class TextInput:
         "notosanscjktcregular",
         "notosansmonocjktcregular",
         "notosansregular",
-        "microsoftjhenghei,microsoftjhengheiuilight",
-        "microsoftyahei,microsoftyaheiuilight",
-        "msgothic,msuigothic,mspgothic",
+        "microsoftjhenghei",
+        "microsoftyahei",
+        "msgothic",
         "msmincho",
         "Arial",
     ]

--- a/examples/textinput.py
+++ b/examples/textinput.py
@@ -27,10 +27,10 @@ class TextInput:
     FONT_NAMES = [
         "notosanscjktcregular",
         "notosansmonocjktcregular",
-        "notosansregular,",
-        "microsoftjhengheimicrosoftjhengheiuilight",
-        "microsoftyaheimicrosoftyaheiuilight",
-        "msgothicmsuigothicmspgothic",
+        "notosansregular",
+        "microsoftjhenghei,microsoftjhengheiuilight",
+        "microsoftyahei,microsoftyaheiuilight",
+        "msgothic,msuigothic,mspgothic",
         "msmincho",
         "Arial",
     ]


### PR DESCRIPTION
Fonts `microsoftjhenghei` ,`microsoftyahei` and `msgothic` were not set correctly and could never be selected. 
**Before:**
```
pygame-ce 2.2.0.dev1 (SDL 2.0.22, Python 3.10.6)
Using font: Arial
```
![image](https://user-images.githubusercontent.com/31395137/224323568-5ac1fd21-34f1-4b2a-bea5-992c34852c14.png)

**After:**
```
pygame-ce 2.2.0.dev1 (SDL 2.0.22, Python 3.10.6)
Using font: Microsoft YaHei
```
![image](https://user-images.githubusercontent.com/31395137/224321684-f11eecde-dd2b-4fad-940f-d64b7d0854ac.png)

