### PR TITLE
Renamed "`the_args`" to "`blend_flags`" everywhere

### DIFF
--- a/docs/reST/c_api/surface.rst
+++ b/docs/reST/c_api/surface.rst
@@ -42,11 +42,11 @@ Header file: src_c/include/pygame.h
    This is a macro. Argument *x* is assumed to be a Surface, or subclass of
    Surface, instance.
 
-.. c:function:: int pgSurface_Blit(PyObject *dstobj, PyObject *srcobj, SDL_Rect *dstrect, SDL_Rect *srcrect, int the_args)
+.. c:function:: int pgSurface_Blit(PyObject *dstobj, PyObject *srcobj, SDL_Rect *dstrect, SDL_Rect *srcrect, int blend_flags)
 
    Blit the *srcrect* portion of Surface *srcobj* onto Surface *dstobj* at *srcobj*
 
-   Argument *the_args* indicates the type of blit to perform:
+   Argument *blend_flags* indicates the type of blit to perform:
    Normal blit (``0``), ``PYGAME_BLEND_ADD``, ``PYGAME_BLEND_SUB``,
    ``PYGAME_BLEND_SUB``, ``PYGAME_BLEND_MULT``, ``PYGAME_BLEND_MIN``,
    ``PYGAME_BLEND_MAX``, ``PYGAME_BLEND_RGBA_ADD``, ``PYGAME_BLEND_RGBA_SUB``,

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -116,7 +116,7 @@ blit_blend_premultiplied_mmx(SDL_BlitInfo *info);
 
 static int
 SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
-               SDL_Rect *dstrect, int the_args);
+               SDL_Rect *dstrect, int blend_flags);
 extern int
 SDL_RLESurface(SDL_Surface *surface);
 extern void
@@ -124,7 +124,7 @@ SDL_UnRLESurface(SDL_Surface *surface, int recode);
 
 static int
 SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
-               SDL_Rect *dstrect, int the_args)
+               SDL_Rect *dstrect, int blend_flags)
 {
     int okay;
     int src_locked;
@@ -202,13 +202,13 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
             }
             /* Convert alpha multiply blends to regular blends if either of
              the surfaces don't have alpha channels */
-            if (the_args == PYGAME_BLEND_RGBA_MULT &&
+            if (blend_flags == PYGAME_BLEND_RGBA_MULT &&
                 (info.src_blend == SDL_BLENDMODE_NONE ||
                  info.dst_blend == SDL_BLENDMODE_NONE)) {
-                the_args = PYGAME_BLEND_MULT;
+                blend_flags = PYGAME_BLEND_MULT;
             }
 
-            switch (the_args) {
+            switch (blend_flags) {
                 case 0: {
                     if (info.src_blend != SDL_BLENDMODE_NONE &&
                         src->format->Amask) {
@@ -2839,7 +2839,7 @@ alphablit_solid(SDL_BlitInfo *info)
 /*we assume the "dst" has pixel alpha*/
 int
 pygame_Blit(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
-            SDL_Rect *dstrect, int the_args)
+            SDL_Rect *dstrect, int blend_flags)
 {
     SDL_Rect fulldst;
     int srcx, srcy, w, h;
@@ -2925,7 +2925,7 @@ pygame_Blit(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
         sr.y = srcy;
         sr.w = dstrect->w = w;
         sr.h = dstrect->h = h;
-        return SoftBlitPyGame(src, &sr, dst, dstrect, the_args);
+        return SoftBlitPyGame(src, &sr, dst, dstrect, blend_flags);
     }
     dstrect->w = dstrect->h = 0;
     return 0;
@@ -2933,9 +2933,9 @@ pygame_Blit(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
 
 int
 pygame_AlphaBlit(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
-                 SDL_Rect *dstrect, int the_args)
+                 SDL_Rect *dstrect, int blend_flags)
 {
-    return pygame_Blit(src, srcrect, dst, dstrect, the_args);
+    return pygame_Blit(src, srcrect, dst, dstrect, blend_flags);
 }
 
 int

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1900,7 +1900,7 @@ surf_blits(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
     int dx, dy, result;
     SDL_Rect dest_rect;
     int sx, sy;
-    int the_args = 0;
+    int blend_flags = 0;
 
     PyObject *blitsequence;
     PyObject *iterator = NULL;

--- a/src_c/surface.h
+++ b/src_c/surface.h
@@ -346,11 +346,11 @@ surface_respect_clip_rect(SDL_Surface *surface, SDL_Rect *rect);
 
 int
 pygame_AlphaBlit(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
-                 SDL_Rect *dstrect, int the_args);
+                 SDL_Rect *dstrect, int blend_flags);
 
 int
 pygame_Blit(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
-            SDL_Rect *dstrect, int the_args);
+            SDL_Rect *dstrect, int blend_flags);
 
 int
 premul_surf_color_by_alpha(SDL_Surface *src, SDL_Surface *dst);


### PR DESCRIPTION
I renamed “the_args” to “blend_flags” because they are not regular arguments but flags for blending modes. However, I’m not sure how to handle the discrepancy between the python code and the C code. The python code expects “special_flags” as an argument name in all blit functions, but the C code uses “blend_flags” as a variable name when parsing. How should we resolve this?