### PR TITLE
Add unifont to the font list of examples/textinput.py

### DIFF
--- a/examples/textinput.py
+++ b/examples/textinput.py
@@ -32,6 +32,7 @@ class TextInput:
         "microsoftyahei",
         "msgothic",
         "msmincho",
+        "unifont",
         "Arial",
     ]
 


### PR DESCRIPTION
Fix https://github.com/pygame-community/pygame-ce/pull/2009#issuecomment-1465155888
![image](https://user-images.githubusercontent.com/31395137/224541502-11a1f7e4-5b76-4332-8b73-809f8ac6a711.png)
