### PR TITLE
AVX2 alpha blitters

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -220,7 +220,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                             src->format->Gmask == dst->format->Gmask &&
                             src->format->Bmask == dst->format->Bmask) {
 /* If our source and destination are the same ARGB 32bit
-   format we can use SSE2/NEON to speed up the blend */
+   format we can use SSE2/NEON/AVX2 to speed up the blend */
 #if PG_ENABLE_SSE_NEON
                             if ((pg_HasSSE_NEON()) && (src != dst)) {
                                 if (info.src_blanket_alpha != 255) {
@@ -232,6 +232,10 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                                             dst->format->format) &&
                                         info.dst_blend != SDL_BLENDMODE_NONE) {
                                         alphablit_alpha_sse2_argb_no_surf_alpha(
+                                            &info);
+                                    }
+                                    else if (SDL_HasAVX2()) {
+                                        alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(
                                             &info);
                                     }
                                     else {

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -224,14 +224,20 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
 #if PG_ENABLE_SSE_NEON
                             if ((pg_HasSSE_NEON()) && (src != dst)) {
                                 if (info.src_blanket_alpha != 255) {
-                                    alphablit_alpha_sse2_argb_surf_alpha(
-                                        &info);
+                                    if (pg_has_avx2() && 1) {
+                                        alphablit_alpha_avx2_argb_surf_alpha(
+                                            &info);
+                                    }
+                                    else {
+                                        alphablit_alpha_sse2_argb_surf_alpha(
+                                            &info);
+                                    }
                                 }
                                 else {
                                     if (SDL_ISPIXELFORMAT_ALPHA(
                                             dst->format->format) &&
                                         info.dst_blend != SDL_BLENDMODE_NONE) {
-                                        if (SDL_HasAVX2()) {
+                                        if (pg_has_avx2()) {
                                             alphablit_alpha_avx2_argb_no_surf_alpha(
                                                 &info);
                                         }
@@ -240,7 +246,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                                                 &info);
                                         }
                                     }
-                                    else if (SDL_HasAVX2()) {
+                                    else if (pg_has_avx2()) {
                                         alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(
                                             &info);
                                     }

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -224,7 +224,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
 #if PG_ENABLE_SSE_NEON
                             if ((pg_HasSSE_NEON()) && (src != dst)) {
                                 if (info.src_blanket_alpha != 255) {
-                                    if (pg_has_avx2() && 1) {
+                                    if (pg_has_avx2()) {
                                         alphablit_alpha_avx2_argb_surf_alpha(
                                             &info);
                                     }

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -231,8 +231,14 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                                     if (SDL_ISPIXELFORMAT_ALPHA(
                                             dst->format->format) &&
                                         info.dst_blend != SDL_BLENDMODE_NONE) {
-                                        alphablit_alpha_sse2_argb_no_surf_alpha(
-                                            &info);
+                                        if (SDL_HasAVX2()) {
+                                            alphablit_alpha_avx2_argb_no_surf_alpha(
+                                                &info);
+                                        }
+                                        else {
+                                            alphablit_alpha_sse2_argb_no_surf_alpha(
+                                                &info);
+                                        }
                                     }
                                     else if (SDL_HasAVX2()) {
                                         alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -219,46 +219,48 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                             src->format->Rmask == dst->format->Rmask &&
                             src->format->Gmask == dst->format->Gmask &&
                             src->format->Bmask == dst->format->Bmask) {
-/* If our source and destination are the same ARGB 32bit
-   format we can use SSE2/NEON/AVX2 to speed up the blend */
-#if PG_ENABLE_SSE_NEON
-                            if ((pg_HasSSE_NEON()) && (src != dst)) {
+                            /* If our source and destination are the same ARGB
+                               32bit format we can use SSE2/NEON/AVX2 to speed
+                               up the blend */
+                            if (pg_has_avx2() && (src != dst)) {
                                 if (info.src_blanket_alpha != 255) {
-                                    if (pg_has_avx2()) {
-                                        alphablit_alpha_avx2_argb_surf_alpha(
-                                            &info);
-                                    }
-                                    else {
-                                        alphablit_alpha_sse2_argb_surf_alpha(
-                                            &info);
-                                    }
+                                    alphablit_alpha_avx2_argb_surf_alpha(
+                                        &info);
+                                }
+                                else if (SDL_ISPIXELFORMAT_ALPHA(
+                                             dst->format->format) &&
+                                         info.dst_blend !=
+                                             SDL_BLENDMODE_NONE) {
+                                    alphablit_alpha_avx2_argb_no_surf_alpha(
+                                        &info);
                                 }
                                 else {
-                                    if (SDL_ISPIXELFORMAT_ALPHA(
-                                            dst->format->format) &&
-                                        info.dst_blend != SDL_BLENDMODE_NONE) {
-                                        if (pg_has_avx2()) {
-                                            alphablit_alpha_avx2_argb_no_surf_alpha(
-                                                &info);
-                                        }
-                                        else {
-                                            alphablit_alpha_sse2_argb_no_surf_alpha(
-                                                &info);
-                                        }
-                                    }
-                                    else if (pg_has_avx2()) {
-                                        alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(
-                                            &info);
-                                    }
-                                    else {
-                                        alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst(
-                                            &info);
-                                    }
+                                    alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(
+                                        &info);
                                 }
                                 break;
                             }
-#endif /* PG_ENABLE_SSE_NEON */
+#if PG_ENABLE_SSE_NEON
+                            if ((pg_HasSSE_NEON()) && (src != dst)) {
+                                if (info.src_blanket_alpha != 255) {
+                                    alphablit_alpha_sse2_argb_surf_alpha(
+                                        &info);
+                                }
+                                else if (SDL_ISPIXELFORMAT_ALPHA(
+                                             dst->format->format) &&
+                                         info.dst_blend !=
+                                             SDL_BLENDMODE_NONE) {
+                                    alphablit_alpha_sse2_argb_no_surf_alpha(
+                                        &info);
+                                }
+                                else {
+                                    alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst(
+                                        &info);
+                                }
+                                break;
+                            }
                         }
+#endif /* PG_ENABLE_SSE_NEON */
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
                         alphablit_alpha(&info);

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -259,8 +259,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                                 }
                                 break;
                             }
-                        }
 #endif /* PG_ENABLE_SSE_NEON */
+                        }
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
                         alphablit_alpha(&info);

--- a/src_c/simd_blitters.h
+++ b/src_c/simd_blitters.h
@@ -63,6 +63,8 @@ premul_surf_color_by_alpha_sse2(SDL_Surface *src, SDL_Surface *dst);
 int
 pg_has_avx2();
 void
+alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info);
+void
 blit_blend_rgba_mul_avx2(SDL_BlitInfo *info);
 void
 blit_blend_rgb_mul_avx2(SDL_BlitInfo *info);

--- a/src_c/simd_blitters.h
+++ b/src_c/simd_blitters.h
@@ -65,6 +65,10 @@ pg_has_avx2();
 void
 alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info);
 void
+alphablit_alpha_avx2_argb_no_surf_alpha(SDL_BlitInfo *info);
+void
+alphablit_alpha_avx2_argb_surf_alpha(SDL_BlitInfo *info);
+void
 blit_blend_rgba_mul_avx2(SDL_BlitInfo *info);
 void
 blit_blend_rgb_mul_avx2(SDL_BlitInfo *info);

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -43,6 +43,205 @@ pg_avx2_at_runtime_but_uncompiled()
     return 0;
 }
 
+/* just prints the first/lower 128 bits, in two chunks */
+// static void
+// _debug_print256_num(__m256i var, const char *msg)
+// {
+//     printf("%s\n", msg);
+//     Uint64 *z = (Uint64 *)&var;
+//     printf("l: %llX\n", *z);
+//     printf("h: %llX\n", *(z + 1));
+// }
+
+#if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
+    !defined(SDL_DISABLE_IMMINTRIN_H)
+void
+alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info)
+{
+    int n;
+    int width = info->width;
+    int height = info->height;
+
+    Uint32 *srcp = (Uint32 *)info->s_pixels;
+    int srcskip = info->s_skip >> 2;
+    int srcpxskip = info->s_pxskip >> 2;
+
+    Uint32 *dstp = (Uint32 *)info->d_pixels;
+    int dstskip = info->d_skip >> 2;
+    int dstpxskip = info->d_pxskip >> 2;
+
+    int pre_8_width = width % 8;
+    int post_8_width = width / 8;
+
+    __m256i *srcp256 = (__m256i *)info->s_pixels;
+    __m256i *dstp256 = (__m256i *)info->d_pixels;
+
+    __m256i mm256_src, mm256_srcA, mm256_srcB, mm256_dst, mm256_dstA,
+        mm256_dstB, mm256_shuff_mask_A, mm256_shuff_mask_B, shuffle_out,
+        mm256_srcAlpha, temp, mm256_mask;
+
+    mm256_shuff_mask_A =
+        _mm256_set_epi8(0x80, 23, 0x80, 22, 0x80, 21, 0x80, 20, 0x80, 19, 0x80,
+                        18, 0x80, 17, 0x80, 16, 0x80, 7, 0x80, 6, 0x80, 5,
+                        0x80, 4, 0x80, 3, 0x80, 2, 0x80, 1, 0x80, 0);
+    mm256_shuff_mask_B =
+        _mm256_set_epi8(0x80, 31, 0x80, 30, 0x80, 29, 0x80, 28, 0x80, 27, 0x80,
+                        26, 0x80, 25, 0x80, 24, 0x80, 15, 0x80, 14, 0x80, 13,
+                        0x80, 12, 0x80, 11, 0x80, 10, 0x80, 9, 0x80, 8);
+
+    shuffle_out =
+        _mm256_set_epi8(0x80, 14, 0x80, 14, 0x80, 14, 0x80, 14, 0x80, 6, 0x80,
+                        6, 0x80, 6, 0x80, 6, 0x80, 14, 0x80, 14, 0x80, 14,
+                        0x80, 14, 0x80, 6, 0x80, 6, 0x80, 6, 0x80, 6);
+
+    mm256_mask = _mm256_set_epi32(0x00, (pre_8_width > 6) ? 0x80000000 : 0x00,
+                                  (pre_8_width > 5) ? 0x80000000 : 0x00,
+                                  (pre_8_width > 4) ? 0x80000000 : 0x00,
+                                  (pre_8_width > 3) ? 0x80000000 : 0x00,
+                                  (pre_8_width > 2) ? 0x80000000 : 0x00,
+                                  (pre_8_width > 1) ? 0x80000000 : 0x00,
+                                  (pre_8_width > 0) ? 0x80000000 : 0x00);
+
+    /* Original 'Straight Alpha' blending equation:
+       --------------------------------------------
+       dstRGB = (srcRGB * srcA) + (dstRGB * (1-srcA))
+         dstA = srcA + (dstA * (1-srcA))
+
+       We use something slightly different to simulate
+       SDL1, as follows:
+       dstRGB = (((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) >> 8)
+         dstA = srcA + dstA - ((srcA * dstA) / 255);
+    */
+
+    /* Alpha blend procedure in this blitter:
+       --------------------------------------
+        srcRGBA = 16 bit interspersed source pixels
+            i.e. [0][A][0][R][0][G][0][B]
+        srcA = 16 bit interspersed alpha channel
+            i.e. [0][A][0][A][0][A][0][A]
+        As you can see, each pixel is moved out into 64 bits of register for
+        processing. This blitter loads in 8 pixels at once, but processes
+        4 at a time (4x64=256 bits).
+
+        Order of operations:
+            temp1 = srcRGBA - dstRGBA
+            temp1 *= srcA
+            dstRGBA <<= 8
+            dstRGBA += temp1
+            dstRGBA += srcRGBA
+            dstRGBA >>= 8
+     */
+
+    while (height--) {
+        if (pre_8_width > 0) {
+            /* ==== load 1-7 pixels into AVX registers ==== */
+            mm256_src = _mm256_maskload_epi32((int *)srcp, mm256_mask);
+            mm256_dst = _mm256_maskload_epi32((int *)dstp, mm256_mask);
+
+            /* ==== shuffle pixels out into two registers each, src
+             * and dst set up for 16 bit math, like 0A0R0G0B ==== */
+            mm256_srcA = _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_A);
+            mm256_srcB = _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_B);
+
+            mm256_dstA = _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_A);
+            mm256_dstB = _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_B);
+
+            /* ==== alpha blend opaque dst on A pixels ==== */
+            mm256_srcAlpha = _mm256_shuffle_epi8(mm256_srcA, shuffle_out);
+
+            temp = _mm256_sub_epi16(mm256_srcA, mm256_dstA);
+            temp = _mm256_mullo_epi16(temp, mm256_srcAlpha);
+
+            mm256_dstA = _mm256_slli_epi16(mm256_dstA, 8);
+            mm256_dstA = _mm256_add_epi16(mm256_dstA, temp);
+            mm256_dstA = _mm256_add_epi16(mm256_dstA, mm256_srcA);
+            mm256_dstA = _mm256_srli_epi16(mm256_dstA, 8);
+
+            /* ==== alpha blend opaque dst on B pixels ==== */
+            mm256_srcAlpha = _mm256_shuffle_epi8(mm256_srcB, shuffle_out);
+
+            temp = _mm256_sub_epi16(mm256_srcB, mm256_dstB);
+            temp = _mm256_mullo_epi16(temp, mm256_srcAlpha);
+
+            mm256_dstB = _mm256_slli_epi16(mm256_dstB, 8);
+            mm256_dstB = _mm256_add_epi16(mm256_dstB, temp);
+            mm256_dstB = _mm256_add_epi16(mm256_dstB, mm256_srcB);
+            mm256_dstB = _mm256_srli_epi16(mm256_dstB, 8);
+
+            /* ==== recombine A and B pixels and store ==== */
+            mm256_dst = _mm256_packus_epi16(mm256_dstA, mm256_dstB);
+            _mm256_maskstore_epi32((int *)dstp, mm256_mask, mm256_dst);
+
+            srcp += srcpxskip * pre_8_width;
+            dstp += dstpxskip * pre_8_width;
+        }
+        srcp256 = (__m256i *)srcp;
+        dstp256 = (__m256i *)dstp;
+        if (post_8_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    /* ==== load 8 pixels into AVX registers ==== */
+                    mm256_src = _mm256_loadu_si256(srcp256);
+                    mm256_dst = _mm256_loadu_si256(dstp256);
+
+                    /* ==== shuffle pixels out into two registers each, src
+                     * and dst set up for 16 bit math, like 0A0R0G0B ==== */
+                    mm256_srcA =
+                        _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_A);
+                    mm256_srcB =
+                        _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_B);
+
+                    mm256_dstA =
+                        _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_A);
+                    mm256_dstB =
+                        _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_B);
+
+                    /* ==== alpha blend opaque dst on A pixels ==== */
+                    mm256_srcAlpha =
+                        _mm256_shuffle_epi8(mm256_srcA, shuffle_out);
+
+                    temp = _mm256_sub_epi16(mm256_srcA, mm256_dstA);
+                    temp = _mm256_mullo_epi16(temp, mm256_srcAlpha);
+
+                    mm256_dstA = _mm256_slli_epi16(mm256_dstA, 8);
+                    mm256_dstA = _mm256_add_epi16(mm256_dstA, temp);
+                    mm256_dstA = _mm256_add_epi16(mm256_dstA, mm256_srcA);
+                    mm256_dstA = _mm256_srli_epi16(mm256_dstA, 8);
+
+                    /* ==== alpha blend opaque dst on B pixels ==== */
+                    mm256_srcAlpha =
+                        _mm256_shuffle_epi8(mm256_srcB, shuffle_out);
+
+                    temp = _mm256_sub_epi16(mm256_srcB, mm256_dstB);
+                    temp = _mm256_mullo_epi16(temp, mm256_srcAlpha);
+
+                    mm256_dstB = _mm256_slli_epi16(mm256_dstB, 8);
+                    mm256_dstB = _mm256_add_epi16(mm256_dstB, temp);
+                    mm256_dstB = _mm256_add_epi16(mm256_dstB, mm256_srcB);
+                    mm256_dstB = _mm256_srli_epi16(mm256_dstB, 8);
+
+                    /* ==== recombine A and B pixels and store ==== */
+                    mm256_dst = _mm256_packus_epi16(mm256_dstA, mm256_dstB);
+                    _mm256_storeu_si256(dstp256, mm256_dst);
+
+                    srcp256++;
+                    dstp256++;
+                },
+                n, post_8_width);
+        }
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
+    }
+}
+#else
+void
+alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info)
+{
+    BAD_AVX2_FUNCTION_CALL;
+}
+#endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
+          !defined(SDL_DISABLE_IMMINTRIN_H) */
+
 #if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
     !defined(SDL_DISABLE_IMMINTRIN_H)
 void

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -53,8 +53,6 @@ pg_avx2_at_runtime_but_uncompiled()
 //    printf("h: %llX\n", *(z + 1));
 //}
 
-#define __AVX2__ 1
-
 /* Setup for RUN_AVX2_BLITTER */
 #define SETUP_AVX2_BLITTER                                                \
     int n;                                                                \

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -55,7 +55,6 @@ pg_avx2_at_runtime_but_uncompiled()
 
 /* Setup for RUN_AVX2_BLITTER */
 #define SETUP_AVX2_BLITTER                                                \
-    int n;                                                                \
     int width = info->width;                                              \
     int height = info->height;                                            \
                                                                           \

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -53,185 +53,161 @@ pg_avx2_at_runtime_but_uncompiled()
 //     printf("h: %llX\n", *(z + 1));
 // }
 
+#define __AVX2__ 1
+
+#define SETUP_AVX2_BLITTER                                                    \
+    int n;                                                                    \
+    int width = info->width;                                                  \
+    int height = info->height;                                                \
+                                                                              \
+    Uint32 *srcp = (Uint32 *)info->s_pixels;                                  \
+    int srcskip = info->s_skip >> 2;                                          \
+    int srcpxskip = info->s_pxskip >> 2;                                      \
+                                                                              \
+    Uint32 *dstp = (Uint32 *)info->d_pixels;                                  \
+    int dstskip = info->d_skip >> 2;                                          \
+    int dstpxskip = info->d_pxskip >> 2;                                      \
+                                                                              \
+    int pre_8_width = width % 8;                                              \
+    int post_8_width = width / 8;                                             \
+                                                                              \
+    __m256i *srcp256 = (__m256i *)info->s_pixels;                             \
+    __m256i *dstp256 = (__m256i *)info->d_pixels;                             \
+                                                                              \
+    __m256i mm256_shuff_mask_A =                                              \
+        _mm256_set_epi8(0x80, 23, 0x80, 22, 0x80, 21, 0x80, 20, 0x80, 19,     \
+                        0x80, 18, 0x80, 17, 0x80, 16, 0x80, 7, 0x80, 6, 0x80, \
+                        5, 0x80, 4, 0x80, 3, 0x80, 2, 0x80, 1, 0x80, 0);      \
+                                                                              \
+    __m256i mm256_shuff_mask_B = _mm256_set_epi8(                             \
+        0x80, 31, 0x80, 30, 0x80, 29, 0x80, 28, 0x80, 27, 0x80, 26, 0x80, 25, \
+        0x80, 24, 0x80, 15, 0x80, 14, 0x80, 13, 0x80, 12, 0x80, 11, 0x80, 10, \
+        0x80, 9, 0x80, 8);                                                    \
+                                                                              \
+    __m256i shuffle_out =                                                     \
+        _mm256_set_epi8(0x80, 14, 0x80, 14, 0x80, 14, 0x80, 14, 0x80, 6,      \
+                        0x80, 6, 0x80, 6, 0x80, 6, 0x80, 14, 0x80, 14, 0x80,  \
+                        14, 0x80, 14, 0x80, 6, 0x80, 6, 0x80, 6, 0x80, 6);    \
+                                                                              \
+    __m256i mm256_mask =                                                      \
+        _mm256_set_epi32(0x00, (pre_8_width > 6) ? 0x80000000 : 0x00,         \
+                         (pre_8_width > 5) ? 0x80000000 : 0x00,               \
+                         (pre_8_width > 4) ? 0x80000000 : 0x00,               \
+                         (pre_8_width > 3) ? 0x80000000 : 0x00,               \
+                         (pre_8_width > 2) ? 0x80000000 : 0x00,               \
+                         (pre_8_width > 1) ? 0x80000000 : 0x00,               \
+                         (pre_8_width > 0) ? 0x80000000 : 0x00);              \
+                                                                              \
+    __m256i mm256_src, mm256_dst;
+
+#define RUN_AVX2_BLITTER(BLITTER_CODE)                                  \
+    while (height--) {                                                  \
+        for (int i = post_8_width; i > 0; i--) {                        \
+            /* ==== load 8 pixels into AVX registers ==== */            \
+            mm256_src = _mm256_loadu_si256(srcp256);                    \
+            mm256_dst = _mm256_loadu_si256(dstp256);                    \
+                                                                        \
+            {BLITTER_CODE}                                              \
+                                                                        \
+            /* ==== store 8 pixels from AVX registers ==== */           \
+            _mm256_storeu_si256(dstp256, mm256_dst);                    \
+                                                                        \
+            srcp256++;                                                  \
+            dstp256++;                                                  \
+        }                                                               \
+        srcp = (Uint32 *)srcp256;                                       \
+        dstp = (Uint32 *)dstp256;                                       \
+        if (pre_8_width > 0) {                                          \
+            mm256_src = _mm256_maskload_epi32((int *)srcp, mm256_mask); \
+            mm256_dst = _mm256_maskload_epi32((int *)dstp, mm256_mask); \
+                                                                        \
+            {BLITTER_CODE}                                              \
+                                                                        \
+            /* ==== store 1-7 pixels from AVX registers ==== */         \
+            _mm256_maskstore_epi32((int *)dstp, mm256_mask, mm256_dst); \
+                                                                        \
+            srcp += srcpxskip * pre_8_width;                            \
+            dstp += dstpxskip * pre_8_width;                            \
+        }                                                               \
+                                                                        \
+        srcp256 = (__m256i *)srcp + srcskip;                            \
+        dstp256 = (__m256i *)dstp + dstskip;                            \
+    }
+
 #if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
     !defined(SDL_DISABLE_IMMINTRIN_H)
 void
 alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info)
 {
-    int n;
-    int width = info->width;
-    int height = info->height;
+    SETUP_AVX2_BLITTER
 
-    Uint32 *srcp = (Uint32 *)info->s_pixels;
-    int srcskip = info->s_skip >> 2;
-    int srcpxskip = info->s_pxskip >> 2;
+    __m256i mm256_srcA, mm256_srcB, mm256_dstA, mm256_dstB, mm256_srcAlpha,
+        temp;
 
-    Uint32 *dstp = (Uint32 *)info->d_pixels;
-    int dstskip = info->d_skip >> 2;
-    int dstpxskip = info->d_pxskip >> 2;
-
-    int pre_8_width = width % 8;
-    int post_8_width = width / 8;
-
-    __m256i *srcp256 = (__m256i *)info->s_pixels;
-    __m256i *dstp256 = (__m256i *)info->d_pixels;
-
-    __m256i mm256_src, mm256_srcA, mm256_srcB, mm256_dst, mm256_dstA,
-        mm256_dstB, mm256_shuff_mask_A, mm256_shuff_mask_B, shuffle_out,
-        mm256_srcAlpha, temp, mm256_mask;
-
-    mm256_shuff_mask_A =
-        _mm256_set_epi8(0x80, 23, 0x80, 22, 0x80, 21, 0x80, 20, 0x80, 19, 0x80,
-                        18, 0x80, 17, 0x80, 16, 0x80, 7, 0x80, 6, 0x80, 5,
-                        0x80, 4, 0x80, 3, 0x80, 2, 0x80, 1, 0x80, 0);
-    mm256_shuff_mask_B =
-        _mm256_set_epi8(0x80, 31, 0x80, 30, 0x80, 29, 0x80, 28, 0x80, 27, 0x80,
-                        26, 0x80, 25, 0x80, 24, 0x80, 15, 0x80, 14, 0x80, 13,
-                        0x80, 12, 0x80, 11, 0x80, 10, 0x80, 9, 0x80, 8);
-
-    shuffle_out =
-        _mm256_set_epi8(0x80, 14, 0x80, 14, 0x80, 14, 0x80, 14, 0x80, 6, 0x80,
-                        6, 0x80, 6, 0x80, 6, 0x80, 14, 0x80, 14, 0x80, 14,
-                        0x80, 14, 0x80, 6, 0x80, 6, 0x80, 6, 0x80, 6);
-
-    mm256_mask = _mm256_set_epi32(0x00, (pre_8_width > 6) ? 0x80000000 : 0x00,
-                                  (pre_8_width > 5) ? 0x80000000 : 0x00,
-                                  (pre_8_width > 4) ? 0x80000000 : 0x00,
-                                  (pre_8_width > 3) ? 0x80000000 : 0x00,
-                                  (pre_8_width > 2) ? 0x80000000 : 0x00,
-                                  (pre_8_width > 1) ? 0x80000000 : 0x00,
-                                  (pre_8_width > 0) ? 0x80000000 : 0x00);
+    printf("inside avx2 alpha blitter\n");
+    printf("rshift=%i\n", info->src->Rshift / 8);
+    printf("gshift=%i\n", info->src->Gshift / 8);
+    printf("bshift=%i\n", info->src->Bshift / 8);
+    printf("ashift=%i\n", info->src->Ashift / 8);
 
     /* Original 'Straight Alpha' blending equation:
-       --------------------------------------------
-       dstRGB = (srcRGB * srcA) + (dstRGB * (1-srcA))
-         dstA = srcA + (dstA * (1-srcA))
+        --------------------------------------------
+        dstRGB = (srcRGB * srcA) + (dstRGB * (1-srcA))
+            dstA = srcA + (dstA * (1-srcA))
 
-       We use something slightly different to simulate
-       SDL1, as follows:
-       dstRGB = (((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) >> 8)
-         dstA = srcA + dstA - ((srcA * dstA) / 255);
+        We use something slightly different to simulate
+        SDL1, as follows:
+        dstRGB = (((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) >> 8)
+            dstA = srcA + dstA - ((srcA * dstA) / 255);
     */
 
     /* Alpha blend procedure in this blitter:
-       --------------------------------------
+        --------------------------------------
         srcRGBA = 16 bit interspersed source pixels
             i.e. [0][A][0][R][0][G][0][B]
         srcA = 16 bit interspersed alpha channel
             i.e. [0][A][0][A][0][A][0][A]
-        As you can see, each pixel is moved out into 64 bits of register for
-        processing. This blitter loads in 8 pixels at once, but processes
-        4 at a time (4x64=256 bits).
+        As you can see, each pixel is moved out into 64 bits of register
+        for processing. This blitter loads in 8 pixels at once, but
+        processes 4 at a time (4x64=256 bits).
 
         Order of operations:
-            temp1 = srcRGBA - dstRGBA
-            temp1 *= srcA
+            temp = srcRGBA - dstRGBA
+            temp *= srcA
             dstRGBA <<= 8
-            dstRGBA += temp1
+            dstRGBA += temp
             dstRGBA += srcRGBA
             dstRGBA >>= 8
-     */
+        */
 
-    while (height--) {
-        if (pre_8_width > 0) {
-            /* ==== load 1-7 pixels into AVX registers ==== */
-            mm256_src = _mm256_maskload_epi32((int *)srcp, mm256_mask);
-            mm256_dst = _mm256_maskload_epi32((int *)dstp, mm256_mask);
+    RUN_AVX2_BLITTER(
+        /* ==== shuffle pixels out into two registers each, src
+         * and dst set up for 16 bit math, like 0A0R0G0B ==== */
+        mm256_srcA = _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_A);
+        mm256_srcB = _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_B);
+        mm256_dstA = _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_A);
+        mm256_dstB = _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_B);
 
-            /* ==== shuffle pixels out into two registers each, src
-             * and dst set up for 16 bit math, like 0A0R0G0B ==== */
-            mm256_srcA = _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_A);
-            mm256_srcB = _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_B);
+        /* ==== alpha blend opaque dst on A pixels ==== */
+        mm256_srcAlpha = _mm256_shuffle_epi8(mm256_srcA, shuffle_out);
+        temp = _mm256_sub_epi16(mm256_srcA, mm256_dstA);
+        temp = _mm256_mullo_epi16(temp, mm256_srcAlpha);
+        mm256_dstA = _mm256_slli_epi16(mm256_dstA, 8);
+        mm256_dstA = _mm256_add_epi16(mm256_dstA, temp);
+        mm256_dstA = _mm256_add_epi16(mm256_dstA, mm256_srcA);
+        mm256_dstA = _mm256_srli_epi16(mm256_dstA, 8);
 
-            mm256_dstA = _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_A);
-            mm256_dstB = _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_B);
+        /* ==== alpha blend opaque dst on B pixels ==== */
+        mm256_srcAlpha = _mm256_shuffle_epi8(mm256_srcB, shuffle_out);
+        temp = _mm256_sub_epi16(mm256_srcB, mm256_dstB);
+        temp = _mm256_mullo_epi16(temp, mm256_srcAlpha);
+        mm256_dstB = _mm256_slli_epi16(mm256_dstB, 8);
+        mm256_dstB = _mm256_add_epi16(mm256_dstB, temp);
+        mm256_dstB = _mm256_add_epi16(mm256_dstB, mm256_srcB);
+        mm256_dstB = _mm256_srli_epi16(mm256_dstB, 8);
 
-            /* ==== alpha blend opaque dst on A pixels ==== */
-            mm256_srcAlpha = _mm256_shuffle_epi8(mm256_srcA, shuffle_out);
-
-            temp = _mm256_sub_epi16(mm256_srcA, mm256_dstA);
-            temp = _mm256_mullo_epi16(temp, mm256_srcAlpha);
-
-            mm256_dstA = _mm256_slli_epi16(mm256_dstA, 8);
-            mm256_dstA = _mm256_add_epi16(mm256_dstA, temp);
-            mm256_dstA = _mm256_add_epi16(mm256_dstA, mm256_srcA);
-            mm256_dstA = _mm256_srli_epi16(mm256_dstA, 8);
-
-            /* ==== alpha blend opaque dst on B pixels ==== */
-            mm256_srcAlpha = _mm256_shuffle_epi8(mm256_srcB, shuffle_out);
-
-            temp = _mm256_sub_epi16(mm256_srcB, mm256_dstB);
-            temp = _mm256_mullo_epi16(temp, mm256_srcAlpha);
-
-            mm256_dstB = _mm256_slli_epi16(mm256_dstB, 8);
-            mm256_dstB = _mm256_add_epi16(mm256_dstB, temp);
-            mm256_dstB = _mm256_add_epi16(mm256_dstB, mm256_srcB);
-            mm256_dstB = _mm256_srli_epi16(mm256_dstB, 8);
-
-            /* ==== recombine A and B pixels and store ==== */
-            mm256_dst = _mm256_packus_epi16(mm256_dstA, mm256_dstB);
-            _mm256_maskstore_epi32((int *)dstp, mm256_mask, mm256_dst);
-
-            srcp += srcpxskip * pre_8_width;
-            dstp += dstpxskip * pre_8_width;
-        }
-        srcp256 = (__m256i *)srcp;
-        dstp256 = (__m256i *)dstp;
-        if (post_8_width > 0) {
-            LOOP_UNROLLED4(
-                {
-                    /* ==== load 8 pixels into AVX registers ==== */
-                    mm256_src = _mm256_loadu_si256(srcp256);
-                    mm256_dst = _mm256_loadu_si256(dstp256);
-
-                    /* ==== shuffle pixels out into two registers each, src
-                     * and dst set up for 16 bit math, like 0A0R0G0B ==== */
-                    mm256_srcA =
-                        _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_A);
-                    mm256_srcB =
-                        _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_B);
-
-                    mm256_dstA =
-                        _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_A);
-                    mm256_dstB =
-                        _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_B);
-
-                    /* ==== alpha blend opaque dst on A pixels ==== */
-                    mm256_srcAlpha =
-                        _mm256_shuffle_epi8(mm256_srcA, shuffle_out);
-
-                    temp = _mm256_sub_epi16(mm256_srcA, mm256_dstA);
-                    temp = _mm256_mullo_epi16(temp, mm256_srcAlpha);
-
-                    mm256_dstA = _mm256_slli_epi16(mm256_dstA, 8);
-                    mm256_dstA = _mm256_add_epi16(mm256_dstA, temp);
-                    mm256_dstA = _mm256_add_epi16(mm256_dstA, mm256_srcA);
-                    mm256_dstA = _mm256_srli_epi16(mm256_dstA, 8);
-
-                    /* ==== alpha blend opaque dst on B pixels ==== */
-                    mm256_srcAlpha =
-                        _mm256_shuffle_epi8(mm256_srcB, shuffle_out);
-
-                    temp = _mm256_sub_epi16(mm256_srcB, mm256_dstB);
-                    temp = _mm256_mullo_epi16(temp, mm256_srcAlpha);
-
-                    mm256_dstB = _mm256_slli_epi16(mm256_dstB, 8);
-                    mm256_dstB = _mm256_add_epi16(mm256_dstB, temp);
-                    mm256_dstB = _mm256_add_epi16(mm256_dstB, mm256_srcB);
-                    mm256_dstB = _mm256_srli_epi16(mm256_dstB, 8);
-
-                    /* ==== recombine A and B pixels and store ==== */
-                    mm256_dst = _mm256_packus_epi16(mm256_dstA, mm256_dstB);
-                    _mm256_storeu_si256(dstp256, mm256_dst);
-
-                    srcp256++;
-                    dstp256++;
-                },
-                n, post_8_width);
-        }
-        srcp = (Uint32 *)srcp256 + srcskip;
-        dstp = (Uint32 *)dstp256 + dstskip;
-    }
+        /* ==== recombine A and B pixels ==== */
+        mm256_dst = _mm256_packus_epi16(mm256_dstA, mm256_dstB);)
 }
 #else
 void

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -184,6 +184,12 @@ pg_avx2_at_runtime_but_uncompiled()
         8 + _a_off, 0x80, 8 + _a_off, 0x80, 0 + _a_off, 0x80, 0 + _a_off, \
         0x80, 0 + _a_off, 0x80, 0 + _a_off);
 
+/* Divides each element in input mm256i by 255
+ * See: https://stackoverflow.com/a/35286833/13816541 */
+#define DO_AVX2_DIV255_U16(MM256I) \
+    _mm256_srli_epi16(             \
+        _mm256_mulhi_epu16(MM256I, _mm256_set1_epi16((short)0x8081)), 7);
+
 #if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
     !defined(SDL_DISABLE_IMMINTRIN_H)
 void
@@ -281,8 +287,7 @@ alphablit_alpha_avx2_argb_no_surf_alpha(SDL_BlitInfo *info)
 
         // figure out alpha
         temp = _mm256_mullo_epi16(src_alpha, dst_alpha);
-        temp = _mm256_srli_epi16(
-            _mm256_mulhi_epu16(temp, _mm256_set1_epi16((short)0x8081)), 7);
+        temp = DO_AVX2_DIV255_U16(temp);
         new_dst_alpha = _mm256_sub_epi16(dst_alpha, temp);
         new_dst_alpha = _mm256_add_epi16(src_alpha, new_dst_alpha);
 
@@ -364,8 +369,7 @@ alphablit_alpha_avx2_argb_surf_alpha(SDL_BlitInfo *info)
 
         // figure out alpha
         temp = _mm256_mullo_epi16(src_alpha, dst_alpha);
-        temp = _mm256_srli_epi16(
-            _mm256_mulhi_epu16(temp, _mm256_set1_epi16((short)0x8081)), 7);
+        temp = DO_AVX2_DIV255_U16(temp);
         new_dst_alpha = _mm256_sub_epi16(dst_alpha, temp);
         new_dst_alpha = _mm256_add_epi16(src_alpha, new_dst_alpha);
 

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -45,13 +45,13 @@ pg_avx2_at_runtime_but_uncompiled()
 
 /* just prints the first/lower 128 bits, in two chunks */
 // static void
-_debug_print256_num(__m256i var, const char *msg)
-{
-    printf("%s\n", msg);
-    Uint64 *z = (Uint64 *)&var;
-    printf("l: %llX\n", *z);
-    printf("h: %llX\n", *(z + 1));
-}
+//_debug_print256_num(__m256i var, const char *msg)
+//{
+//    printf("%s\n", msg);
+//    Uint64 *z = (Uint64 *)&var;
+//    printf("l: %llX\n", *z);
+//    printf("h: %llX\n", *(z + 1));
+//}
 
 #define __AVX2__ 1
 
@@ -353,7 +353,8 @@ alphablit_alpha_avx2_argb_surf_alpha(SDL_BlitInfo *info)
         // src_alpha = src_alpha * module_alpha / 255
         src_alpha = _mm256_mullo_epi16(src_alpha, modulate_alpha);
         src_alpha = _mm256_srli_epi16(
-            _mm256_mulhi_epu16(src_alpha, _mm256_set1_epi16((short)0x8081)), 7);
+            _mm256_mulhi_epu16(src_alpha, _mm256_set1_epi16((short)0x8081)),
+            7);
 
         dst_alpha = _mm256_shuffle_epi8(shuff_dst, shuff_out_alpha);
 

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -346,51 +346,49 @@ alphablit_alpha_avx2_argb_surf_alpha(SDL_BlitInfo *info)
      dstA = srcA + dstA - ((srcA * dstA) / 255);
      */
 
-    RUN_AVX2_BLITTER(
-        RUN_16BIT_SHUFFLE_OUT(
-            src_alpha = _mm256_shuffle_epi8(shuff_src, shuff_out_alpha);
+    RUN_AVX2_BLITTER(RUN_16BIT_SHUFFLE_OUT(
+        src_alpha = _mm256_shuffle_epi8(shuff_src, shuff_out_alpha);
 
-            // src_alpha = src_alpha * module_alpha / 255
-            src_alpha = _mm256_mullo_epi16(src_alpha, modulate_alpha);
-            src_alpha = _mm256_srli_epi16(
-                _mm256_mulhi_epu16(src_alpha,
-                                   _mm256_set1_epi16((short)0x8081)),
-                7);
+        // src_alpha = src_alpha * module_alpha / 255
+        src_alpha = _mm256_mullo_epi16(src_alpha, modulate_alpha);
+        src_alpha = _mm256_srli_epi16(
+            _mm256_mulhi_epu16(src_alpha, _mm256_set1_epi16((short)0x8081)),
+            7);
 
-            dst_alpha = _mm256_shuffle_epi8(shuff_dst, shuff_out_alpha);
-            // if the destination is opaque, it takes the max of each alpha
-            // with 255 otherwise it takes with the max with 0. This is
-            // equivalent to if opaque: alpha = 255
-            dst_alpha = _mm256_max_epi16(dst_alpha,
-                                         _mm256_set1_epi16(dst_alpha_offset));
+        dst_alpha = _mm256_shuffle_epi8(shuff_dst, shuff_out_alpha);
+        // if the destination is opaque, it takes the max of each alpha
+        // with 255 otherwise it takes with the max with 0. This is
+        // equivalent to if opaque: alpha = 255
+        dst_alpha =
+            _mm256_max_epi16(dst_alpha, _mm256_set1_epi16(dst_alpha_offset));
 
-            // figure out alpha
-            temp = _mm256_mullo_epi16(src_alpha, dst_alpha);
-            temp = _mm256_srli_epi16(
-                _mm256_mulhi_epu16(temp, _mm256_set1_epi16((short)0x8081)), 7);
-            new_dst_alpha = _mm256_sub_epi16(dst_alpha, temp);
-            new_dst_alpha = _mm256_add_epi16(src_alpha, new_dst_alpha);
+        // figure out alpha
+        temp = _mm256_mullo_epi16(src_alpha, dst_alpha);
+        temp = _mm256_srli_epi16(
+            _mm256_mulhi_epu16(temp, _mm256_set1_epi16((short)0x8081)), 7);
+        new_dst_alpha = _mm256_sub_epi16(dst_alpha, temp);
+        new_dst_alpha = _mm256_add_epi16(src_alpha, new_dst_alpha);
 
-            // if preexisting dst alpha is 0, src alpha should be set to 255
-            // enforces that dest alpha 0 means "copy source RGB"
-            // happens after real src alpha values used to calculate dst alpha
-            // compares each 16 bit block to zeroes, yielding 0xFFFF or
-            // 0x0000-- shifts out bottom 8 bits to get to 0x00FF or 0x0000.
-            dst_alpha = _mm256_cmpeq_epi16(dst_alpha, _mm256_setzero_si256());
-            dst_alpha = _mm256_srli_epi16(dst_alpha, 8);
-            src_alpha = _mm256_max_epu8(dst_alpha, src_alpha);
+        // if preexisting dst alpha is 0, src alpha should be set to 255
+        // enforces that dest alpha 0 means "copy source RGB"
+        // happens after real src alpha values used to calculate dst alpha
+        // compares each 16 bit block to zeroes, yielding 0xFFFF or
+        // 0x0000-- shifts out bottom 8 bits to get to 0x00FF or 0x0000.
+        dst_alpha = _mm256_cmpeq_epi16(dst_alpha, _mm256_setzero_si256());
+        dst_alpha = _mm256_srli_epi16(dst_alpha, 8);
+        src_alpha = _mm256_max_epu8(dst_alpha, src_alpha);
 
-            // figure out RGB
-            temp = _mm256_sub_epi16(shuff_src, shuff_dst);
-            temp = _mm256_mullo_epi16(temp, src_alpha);
-            temp = _mm256_add_epi16(temp, shuff_src);
-            shuff_dst = _mm256_slli_epi16(shuff_dst, 8);
-            shuff_dst = _mm256_add_epi16(shuff_dst, temp);
-            shuff_dst = _mm256_srli_epi16(shuff_dst, 8);
+        // figure out RGB
+        temp = _mm256_sub_epi16(shuff_src, shuff_dst);
+        temp = _mm256_mullo_epi16(temp, src_alpha);
+        temp = _mm256_add_epi16(temp, shuff_src);
+        shuff_dst = _mm256_slli_epi16(shuff_dst, 8);
+        shuff_dst = _mm256_add_epi16(shuff_dst, temp);
+        shuff_dst = _mm256_srli_epi16(shuff_dst, 8);
 
-            // blend together dstRGB and dstA
-            shuff_dst = _mm256_blendv_epi8(shuff_dst, new_dst_alpha,
-                                           combine_rgba_mask);))
+        // blend together dstRGB and dstA
+        shuff_dst =
+            _mm256_blendv_epi8(shuff_dst, new_dst_alpha, combine_rgba_mask);))
 }
 #else
 void

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -337,6 +337,8 @@ alphablit_alpha_avx2_argb_surf_alpha(SDL_BlitInfo *info)
 
     __m256i src_alpha, temp, dst_alpha, new_dst_alpha;
 
+    int dst_alpha_offset = (info->dst->Amask ? 0 : 255);
+
     __m256i modulate_alpha = _mm256_set1_epi16(info->src_blanket_alpha);
 
     /*
@@ -354,6 +356,10 @@ alphablit_alpha_avx2_argb_surf_alpha(SDL_BlitInfo *info)
             7);
 
         dst_alpha = _mm256_shuffle_epi8(shuff_dst, shuff_out_alpha);
+        // if the destination is opaque, it takes the max of each alpha with 255
+        // otherwise it takes with the max with 0. This is equivalent to
+        // if opaque: alpha = 255
+        dst_alpha = _mm256_max_epi16(dst_alpha, _mm256_set1_epi16(dst_alpha_offset));
 
         // figure out alpha
         temp = _mm256_mullo_epi16(src_alpha, dst_alpha);

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -346,48 +346,51 @@ alphablit_alpha_avx2_argb_surf_alpha(SDL_BlitInfo *info)
      dstA = srcA + dstA - ((srcA * dstA) / 255);
      */
 
-    RUN_AVX2_BLITTER(RUN_16BIT_SHUFFLE_OUT(
-        src_alpha = _mm256_shuffle_epi8(shuff_src, shuff_out_alpha);
+    RUN_AVX2_BLITTER(
+        RUN_16BIT_SHUFFLE_OUT(
+            src_alpha = _mm256_shuffle_epi8(shuff_src, shuff_out_alpha);
 
-        // src_alpha = src_alpha * module_alpha / 255
-        src_alpha = _mm256_mullo_epi16(src_alpha, modulate_alpha);
-        src_alpha = _mm256_srli_epi16(
-            _mm256_mulhi_epu16(src_alpha, _mm256_set1_epi16((short)0x8081)),
-            7);
+            // src_alpha = src_alpha * module_alpha / 255
+            src_alpha = _mm256_mullo_epi16(src_alpha, modulate_alpha);
+            src_alpha = _mm256_srli_epi16(
+                _mm256_mulhi_epu16(src_alpha,
+                                   _mm256_set1_epi16((short)0x8081)),
+                7);
 
-        dst_alpha = _mm256_shuffle_epi8(shuff_dst, shuff_out_alpha);
-        // if the destination is opaque, it takes the max of each alpha with 255
-        // otherwise it takes with the max with 0. This is equivalent to
-        // if opaque: alpha = 255
-        dst_alpha = _mm256_max_epi16(dst_alpha, _mm256_set1_epi16(dst_alpha_offset));
+            dst_alpha = _mm256_shuffle_epi8(shuff_dst, shuff_out_alpha);
+            // if the destination is opaque, it takes the max of each alpha
+            // with 255 otherwise it takes with the max with 0. This is
+            // equivalent to if opaque: alpha = 255
+            dst_alpha = _mm256_max_epi16(dst_alpha,
+                                         _mm256_set1_epi16(dst_alpha_offset));
 
-        // figure out alpha
-        temp = _mm256_mullo_epi16(src_alpha, dst_alpha);
-        temp = _mm256_srli_epi16(
-            _mm256_mulhi_epu16(temp, _mm256_set1_epi16((short)0x8081)), 7);
-        new_dst_alpha = _mm256_sub_epi16(dst_alpha, temp);
-        new_dst_alpha = _mm256_add_epi16(src_alpha, new_dst_alpha);
+            // figure out alpha
+            temp = _mm256_mullo_epi16(src_alpha, dst_alpha);
+            temp = _mm256_srli_epi16(
+                _mm256_mulhi_epu16(temp, _mm256_set1_epi16((short)0x8081)), 7);
+            new_dst_alpha = _mm256_sub_epi16(dst_alpha, temp);
+            new_dst_alpha = _mm256_add_epi16(src_alpha, new_dst_alpha);
 
-        // if preexisting dst alpha is 0, src alpha should be set to 255
-        // enforces that dest alpha 0 means "copy source RGB"
-        // happens after real src alpha values used to calculate dst alpha
-        // compares each 16 bit block to zeroes, yielding 0xFFFF or 0x0000--
-        // shifts out bottom 8 bits to get to 0x00FF or 0x0000.
-        dst_alpha = _mm256_cmpeq_epi16(dst_alpha, _mm256_setzero_si256());
-        dst_alpha = _mm256_srli_epi16(dst_alpha, 8);
-        src_alpha = _mm256_max_epu8(dst_alpha, src_alpha);
+            // if preexisting dst alpha is 0, src alpha should be set to 255
+            // enforces that dest alpha 0 means "copy source RGB"
+            // happens after real src alpha values used to calculate dst alpha
+            // compares each 16 bit block to zeroes, yielding 0xFFFF or
+            // 0x0000-- shifts out bottom 8 bits to get to 0x00FF or 0x0000.
+            dst_alpha = _mm256_cmpeq_epi16(dst_alpha, _mm256_setzero_si256());
+            dst_alpha = _mm256_srli_epi16(dst_alpha, 8);
+            src_alpha = _mm256_max_epu8(dst_alpha, src_alpha);
 
-        // figure out RGB
-        temp = _mm256_sub_epi16(shuff_src, shuff_dst);
-        temp = _mm256_mullo_epi16(temp, src_alpha);
-        temp = _mm256_add_epi16(temp, shuff_src);
-        shuff_dst = _mm256_slli_epi16(shuff_dst, 8);
-        shuff_dst = _mm256_add_epi16(shuff_dst, temp);
-        shuff_dst = _mm256_srli_epi16(shuff_dst, 8);
+            // figure out RGB
+            temp = _mm256_sub_epi16(shuff_src, shuff_dst);
+            temp = _mm256_mullo_epi16(temp, src_alpha);
+            temp = _mm256_add_epi16(temp, shuff_src);
+            shuff_dst = _mm256_slli_epi16(shuff_dst, 8);
+            shuff_dst = _mm256_add_epi16(shuff_dst, temp);
+            shuff_dst = _mm256_srli_epi16(shuff_dst, 8);
 
-        // blend together dstRGB and dstA
-        shuff_dst =
-            _mm256_blendv_epi8(shuff_dst, new_dst_alpha, combine_rgba_mask);))
+            // blend together dstRGB and dstA
+            shuff_dst = _mm256_blendv_epi8(shuff_dst, new_dst_alpha,
+                                           combine_rgba_mask);))
 }
 #else
 void


### PR DESCRIPTION
Adds an AVX2 version of all 3 SSE2 alpha blitter variants.

Shares heritage with predecessor https://github.com/pygame/pygame/pull/3425, but is much better.

Approach: use masked load/store to enable stride switching using all full width AVX2 instructions to reduce code repetition. Further use macros to reduce code repetition and increase readability by leaving only the important stuff in the top level. Use alpha mask and alpha shift to allow dynamic position of the alpha channel rather than restricting the blitter to ARGB-- pulling out or inserting the alpha channel requires special care, but all operations occur in "native pixelformat space" (ofc stretched out to 16 bits per channel for calculations). Of course the source and destination need to have the same RGB channel positions still.

Benchmarking results:
```
# LARGE_SURF
# OPAQUE_DST and not GLOBAL_ALPHA_SRC: 1.61 seconds -> 1.10 seconds (45% faster)
# OPAQUE_DST and GLOBAL_ALPHA_SRC: 5.62 seconds -> 1.26 seconds (345% faster)
# not OPAQUE_DST and not GLOBAL_ALPHA_SRC: 2.79 seconds -> 1.15 seconds (140% faster)
# not OPAQUE_DST and GLOBAL_ALPHA_SRC: 5.58 seconds -> 1.30 seconds (330% faster)
```

Performance test script:
```py
import pygame
import time

# MODES
LARGE_SURF=True

OPAQUE_DST=True
GLOBAL_ALPHA_SRC=False

# OPAQUE_DST and not GLOBAL_ALPHA_SRC -> alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst
# OPAQUE_DST and GLOBAL_ALPHA_SRC -> alphablit_alpha_avx2_argb_surf_alpha
# not OPAQUE_DST and not GLOBAL_ALPHA_SRC -> alphablit_alpha_avx2_argb_no_surf_alpha
# not OPAQUE_DST and GLOBAL_ALPHA_SRC -> alphablit_alpha_avx2_argb_surf_alpha

pygame.init()

if LARGE_SURF:
    surf_size = (1920,1080)
    test_iterations = 1000
else:
    surf_size = (50,50)
    test_iterations = 100000

#screen = pygame.Surface(surf_size, 0 if OPAQUE_DST else pygame.SRCALPHA, depth=32)
screen = pygame.Surface(surf_size, depth=32)
screen.fill((60, 70, 80))

surf = pygame.Surface(surf_size, pygame.SRCALPHA, depth=32)
surf.fill((5,216,77,120))
if GLOBAL_ALPHA_SRC:
    surf.set_alpha(124)

print("== Surface information ==")
print(screen, surf)
print(screen.get_shifts(), surf.get_shifts())

start = time.time()
for _ in range(test_iterations):
    screen.blit(surf, (0, 0))    

print("== Time ==")
print(time.time() - start)
```
Edit: edited performance script and re ran benchmarks because I had OPAQUE=True mapping to using SRCALPHA, which is incorrect.