### PR TITLE
Raise `ValueError` when bluring an indexed surface.

### DIFF
--- a/docs/reST/ref/transform.rst
+++ b/docs/reST/ref/transform.rst
@@ -211,6 +211,9 @@ Instead, always begin with the original image and scale to the desired size.)
 
    Returns the blurred surface using box blur algorithm.
 
+   This function does not work for indexed surfaces.
+   An exception will be thrown if the input is an indexed surface.
+
    .. versionadded:: 2.2.0
 
    .. ## pygame.transform.box_blur ##
@@ -222,6 +225,9 @@ Instead, always begin with the original image and scale to the desired size.)
 
    Returns the blurred surface using gaussian blur algorithm.
    Slower than `box_blur()`.
+
+   This function does not work for indexed surfaces.
+   An exception will be thrown if the input is an indexed surface.
 
    .. versionadded:: 2.2.0
 

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -3242,6 +3242,10 @@ blur(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int radius,
 
     src = pgSurface_AsSurface(srcobj);
 
+    if (src->format->palette) {
+        return RAISE(PyExc_ValueError, "Indexed surfaces connot be blurred.");
+    }
+
     if (!dstobj) {
         retsurf = newsurf_fromsurf(src, src->w, src->h);
         if (!retsurf)

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1406,6 +1406,14 @@ class TransformDisplayModuleTest(unittest.TestCase):
     def tearDown(self):
         pygame.display.quit()
 
+    def test_blur_indexed_surface(self):
+        data_fname = example_path("data")
+        path = os.path.join(data_fname, "alien3.png")
+        sf = pygame.image.load(path)  # Get an indexed surface.
+
+        self.assertRaises(ValueError, lambda: pygame.transform.box_blur(sf, 10))
+        self.assertRaises(ValueError, lambda: pygame.transform.gaussian_blur(sf, 10))
+
     def test_box_blur(self):
         data1 = {
             (1, 29): (67, 58, 26, 255),


### PR DESCRIPTION
Fix https://github.com/pygame-community/pygame-ce/issues/2025