### PR TITLE
Fix the 8-bit convertion of `Surface.convert()`

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1486,10 +1486,10 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
                 else {
                     Amask = 0;
                     switch (bpp) {
-                        case 8:
-                            Rmask = 0;
-                            Gmask = 0;
-                            Bmask = 0;
+                        case 8:  // Convert to RGB332
+                            Rmask = 0xE0;
+                            Gmask = 0x1C;
+                            Bmask = 0x03;
                             break;
                         case 12:
                             Rmask = 0xFF >> 4 << 8;


### PR DESCRIPTION
**Issue:** https://github.com/pygame/pygame/issues/2477
**Before:**
![image](https://user-images.githubusercontent.com/31395137/225921913-e8ffb7e7-9d34-4e7f-8dbb-433864e034df.png)
**After:**
![image](https://user-images.githubusercontent.com/31395137/225922120-47205408-1da9-4a35-a407-83cf979e728e.png)
**TestCode:**
```python
import pygame

dsf=pygame.display.set_mode((1280,720))

sf=pygame.image.load('lena.png') # 32bit png
sf8b=sf.convert(8)

dsf.fill((0,150,0))
dsf.blit(sf,(0,0,1,1))
dsf.blit(sf8b,(600,0,1,1))

pygame.display.update()

while 1:pygame.event.get()
```
**Notice the converted surface is a RGB332 surface, not a indexed surface. It doesn't have a palette**