### PR TITLE
Fix issue with converting surfaces to 8 bit surfaces with palettes

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1457,6 +1457,7 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
             /* will be updated later, initialize to make static analyzer happy
              */
             int bpp = 0;
+            SDL_Palette *palette = SDL_AllocPalette(default_palette_size);
             SDL_PixelFormat format;
 
             memcpy(&format, surf->format, sizeof(format));
@@ -1566,8 +1567,6 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
                     /* Give the surface something other than an all white
                      * palette.
                      */
-                    SDL_Palette *palette =
-                        SDL_AllocPalette(default_palette_size);
                     SDL_SetPaletteColors(palette, default_palette_colors, 0,
                                          default_palette_size);
                     format.palette = palette;
@@ -1575,6 +1574,7 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
             }
             newsurf = SDL_ConvertSurface(surf, &format, 0);
             SDL_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_NONE);
+            SDL_FreePalette(palette);
         }
     }
     else {

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1567,9 +1567,9 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
                      * palette.
                      */
                     SDL_Palette *palette =
-                        SDL_AllocPalette(default_palette_size - 1);
+                        SDL_AllocPalette(default_palette_size);
                     SDL_SetPaletteColors(palette, default_palette_colors, 0,
-                                         default_palette_size - 1);
+                                         default_palette_size);
                     format.palette = palette;
                 }
             }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1556,6 +1556,17 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
                  * that at least one entry is not black.
                  */
                 format.palette = NULL;
+            if (SDL_ISPIXELFORMAT_INDEXED(SDL_MasksToPixelFormatEnum(
+                    format.BitsPerPixel, format.Rmask, format.Gmask,
+                    format.Bmask, format.Amask))) {
+                /* Give the surface something other than an all white palette.
+                 */
+                SDL_Palette *palette =
+                    SDL_AllocPalette(default_palette_size - 1);
+                SDL_SetPaletteColors(palette, default_palette_colors, 0,
+                                     default_palette_size - 1);
+                format.palette = palette;
+            }
             newsurf = SDL_ConvertSurface(surf, &format, 0);
             SDL_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_NONE);
         }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1559,13 +1559,19 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
             if (SDL_ISPIXELFORMAT_INDEXED(SDL_MasksToPixelFormatEnum(
                     format.BitsPerPixel, format.Rmask, format.Gmask,
                     format.Bmask, format.Amask))) {
-                /* Give the surface something other than an all white palette.
-                 */
-                SDL_Palette *palette =
-                    SDL_AllocPalette(default_palette_size - 1);
-                SDL_SetPaletteColors(palette, default_palette_colors, 0,
-                                     default_palette_size - 1);
-                format.palette = palette;
+                if (SDL_ISPIXELFORMAT_INDEXED(surf->format->format)) {
+                    format.palette = surf->format->palette;
+                }
+                else {
+                    /* Give the surface something other than an all white
+                     * palette.
+                     */
+                    SDL_Palette *palette =
+                        SDL_AllocPalette(default_palette_size - 1);
+                    SDL_SetPaletteColors(palette, default_palette_colors, 0,
+                                         default_palette_size - 1);
+                    format.palette = palette;
+                }
             }
             newsurf = SDL_ConvertSurface(surf, &format, 0);
             SDL_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_NONE);

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1561,7 +1561,7 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
                     format.BitsPerPixel, format.Rmask, format.Gmask,
                     format.Bmask, format.Amask))) {
                 if (SDL_ISPIXELFORMAT_INDEXED(surf->format->format)) {
-                    format.palette = surf->format->palette;
+                    SDL_SetPixelFormatPalette(&format, surf->format->palette);
                 }
                 else {
                     /* Give the surface something other than an all white
@@ -1569,7 +1569,7 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
                      */
                     SDL_SetPaletteColors(palette, default_palette_colors, 0,
                                          default_palette_size);
-                    format.palette = palette;
+                    SDL_SetPixelFormatPalette(&format, palette);
                 }
             }
             newsurf = SDL_ConvertSurface(surf, &format, 0);

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1153,6 +1153,22 @@ class GeneralSurfaceTests(unittest.TestCase):
         finally:
             pygame.display.quit()
 
+    def test_convert_palettize(self):
+        pygame.display.init()
+        try:
+            pygame.display.set_mode((640, 480))
+
+            surf = pygame.Surface((150, 250))
+            surf.fill((255, 50, 0))
+            surf = surf.convert(8)
+            surf2 = pygame.Surface((150, 250), depth=8)
+            surf2.fill((255, 50, 0))
+
+            self.assertEqual(surf.get_at((50, 50)), surf2.get_at((50, 50)))
+
+        finally:
+            pygame.display.quit()
+
     def test_src_alpha_issue_1289(self):
         """blit should be white."""
         surf1 = pygame.Surface((1, 1), pygame.SRCALPHA, 32)


### PR DESCRIPTION
This resolves issue https://github.com/pygame/pygame/issues/2477 by checking if the new surface needs a palette and creating the default one for it if it does. 