### PR TITLE
fixed banding bug with draw.circle

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2019,7 +2019,6 @@ draw_circle_filled(SDL_Surface *surf, int x0, int y0, int radius, Uint32 color,
     int ddF_y = -2 * radius;
     int x = 0;
     int y = radius;
-    int xmin = INT_MAX;
     int xmax = INT_MIN;
 
     if (x0 < 0) {
@@ -2042,15 +2041,14 @@ draw_circle_filled(SDL_Surface *surf, int x0, int y0, int radius, Uint32 color,
         /* optimisation to avoid overdrawing and repeated return rect checks:
            only draw a line if y-step is about to be decreased. */
         if (f >= 0) {
-            drawhorzlineclipbounding(surf, color, x0 - MIN(x, xmin),
-                                     y0 + y - 1, x0 + MIN(x - 1, xmax),
-                                     drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 - MIN(x, xmin), y0 - y,
+            drawhorzlineclipbounding(surf, color, x0 - x, y0 + y - 1,
+                                     x0 + MIN(x - 1, xmax), drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - x, y0 - y,
                                      x0 + MIN(x - 1, xmax), drawn_area);
         }
-        drawhorzlineclipbounding(surf, color, x0 - MIN(y, xmin), y0 + x - 1,
+        drawhorzlineclipbounding(surf, color, x0 - y, y0 + x - 1,
                                  x0 + MIN(y - 1, xmax), drawn_area);
-        drawhorzlineclipbounding(surf, color, x0 - MIN(y, xmin), y0 - x,
+        drawhorzlineclipbounding(surf, color, x0 - y, y0 - x,
                                  x0 + MIN(y - 1, xmax), drawn_area);
     }
 }

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2023,7 +2023,7 @@ draw_circle_filled(SDL_Surface *surf, int x0, int y0, int radius, Uint32 color,
     int xmax = INT_MIN;
 
     if (x0 < 0) {
-        xmin = x0 + INT_MAX + 1;
+        xmax = x0 + INT_MAX + 1;
     }
     else {
         xmax = INT_MAX - x0;

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -5617,7 +5617,18 @@ class DrawCircleMixin:
             bounding_rect = self.draw_circle(surf, color, center, radius, width)
             self.assertEqual(bounding_rect.width, radius * 2)
             self.assertEqual(bounding_rect.height, radius * 2)
-
+            
+    def test_circle__no_band(self):
+        """ Ensures that drawing a circle with the center off-screen doesn't create a
+        solid band across the screen
+        """
+        surf = pygame.Surface((200, 200))
+        radius = 10
+        center = (-1, 100)
+        self.draw_circle(surf, "white", center, radius)
+        
+        # pixel at (50, 100) should be black, not white
+        self.assertEqual(surf.get_at((50, 100))[0:3], (0, 0, 0))
 
 class DrawCircleTest(DrawCircleMixin, DrawTestCase):
     """Test draw module function circle.

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -5623,12 +5623,17 @@ class DrawCircleMixin:
         solid band across the screen
         """
         surf = pygame.Surface((200, 200))
+        surf_center = surf.get_rect().center
         radius = 10
-        center = (-1, 100)
-        self.draw_circle(surf, "white", center, radius)
 
-        # pixel at (50, 100) should be black, not white
-        self.assertEqual(surf.get_at((50, 100))[0:3], (0, 0, 0))
+        # one pixel outside the screen on the center of each edge
+        test_centers = [(-1, 100), (201, 100), (100, -1), (100, 201)]
+        for center in test_centers:
+            surf.fill("black")
+            self.draw_circle(surf, "white", center, radius)
+
+            # pixel at the center should be black, not white
+            self.assertEqual(surf.get_at(surf_center)[0:3], (0, 0, 0))
 
 
 class DrawCircleTest(DrawCircleMixin, DrawTestCase):

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -5640,8 +5640,11 @@ class DrawCircleMixin:
             surf.fill("black")
             self.draw_circle(surf, "white", center, radius)
 
-            # pixel at the center should be black, not white
-            self.assertEqual(surf.get_at(surf_center)[0:3], (0, 0, 0))
+            self.assertEqual(
+                surf.get_at(surf_center)[0:3],
+                (0, 0, 0),
+                msg="pixel at center should be black, not white",
+            )
 
     def test_circle__no_band(self):
         """Ensures that drawing a circle with the center off-screen doesn't create a
@@ -5666,8 +5669,11 @@ class DrawCircleMixin:
             surf.fill("black")
             self.draw_circle(surf, "white", center, radius)
 
-            # pixel at the center should be black, not white
-            self.assertEqual(surf.get_at(surf_center)[0:3], (0, 0, 0))
+            self.assertEqual(
+                surf.get_at(surf_center)[0:3],
+                (0, 0, 0),
+                msg="pixel at center should be black, not white",
+            )
 
 
 class DrawCircleTest(DrawCircleMixin, DrawTestCase):

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -5622,12 +5622,19 @@ class DrawCircleMixin:
         """Ensures that drawing a circle with the center off-screen doesn't create a
         solid band across the screen
         """
-        surf = pygame.Surface((200, 200))
+        width = 200
+        height = 200
+        surf = pygame.Surface((width, height))
         surf_center = surf.get_rect().center
         radius = 10
 
         # one pixel outside the screen on the center of each edge
-        test_centers = [(-1, 100), (201, 100), (100, -1), (100, 201)]
+        test_centers = [
+            (-1, height / 2),
+            (width + 1, height / 2),
+            (width / 2, -1),
+            (width / 2, height + 1),
+        ]
         for center in test_centers:
             surf.fill("black")
             self.draw_circle(surf, "white", center, radius)

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -5618,9 +5618,36 @@ class DrawCircleMixin:
             self.assertEqual(bounding_rect.width, radius * 2)
             self.assertEqual(bounding_rect.height, radius * 2)
 
+    def test_circle__offscreen(self):
+        """Ensures that drawing a circle completely off-screen doesn't create
+        a solid band across the screen
+        see https://github.com/pygame/pygame/issues/3143
+        """
+        width = 200
+        height = 200
+        surf = pygame.Surface((width, height))
+        surf_center = surf.get_rect().center
+        radius = 10
+
+        # way way outside the screen
+        test_centers = [
+            (-1e30, height / 2),
+            (1e30, height / 2),
+            (width / 2, -1e30),
+            (width / 2, 1e30),
+        ]
+        for center in test_centers:
+            surf.fill("black")
+            self.draw_circle(surf, "white", center, radius)
+
+            # pixel at the center should be black, not white
+            self.assertEqual(surf.get_at(surf_center)[0:3], (0, 0, 0))
+
     def test_circle__no_band(self):
         """Ensures that drawing a circle with the center off-screen doesn't create a
         solid band across the screen
+        This tests a bug introduced in
+        https://github.com/pygame-community/pygame-ce/commit/c88a1d8f7b31099cec84dc5cb7aeebdada783e83
         """
         width = 200
         height = 200

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -5617,18 +5617,19 @@ class DrawCircleMixin:
             bounding_rect = self.draw_circle(surf, color, center, radius, width)
             self.assertEqual(bounding_rect.width, radius * 2)
             self.assertEqual(bounding_rect.height, radius * 2)
-            
+
     def test_circle__no_band(self):
-        """ Ensures that drawing a circle with the center off-screen doesn't create a
+        """Ensures that drawing a circle with the center off-screen doesn't create a
         solid band across the screen
         """
         surf = pygame.Surface((200, 200))
         radius = 10
         center = (-1, 100)
         self.draw_circle(surf, "white", center, radius)
-        
+
         # pixel at (50, 100) should be black, not white
         self.assertEqual(surf.get_at((50, 100))[0:3], (0, 0, 0))
+
 
 class DrawCircleTest(DrawCircleMixin, DrawTestCase):
     """Test draw module function circle.


### PR DESCRIPTION
When `draw.circle` is fed a circle centered to the left of the screen's left edge, a band appears across the entire screen. I tracked it to [this commit](https://github.com/pygame-community/pygame-ce/commit/046efe181375a9f0078f07c880ac7b2e304e0e01). I fixed the bug and added a test case to prevent regression.

Test code:
```python
import pygame

screen = pygame.display.set_mode((500, 500))

running = True
while running:
    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            running = False
            
    screen.fill("black")
    pygame.draw.circle(screen, "white", (-1, 250), 10)
    pygame.display.flip()
```
Result on current `main`:
![broken](https://user-images.githubusercontent.com/49015102/226135338-1fe72cec-faec-4f38-89e1-227fd266351f.png)

Result after this PR:
![fixed](https://user-images.githubusercontent.com/49015102/226135411-ab255830-7114-4c04-9cdb-5619badc19e3.png)
