### PR TITLE
Made `Rect/FRect` `move/move_ip` FASTCALL

### DIFF
--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -54,7 +54,7 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
 #define RectExport_new pg_rect_new
 #define RectExport_dealloc pg_rect_dealloc
 #define RectExport_normalize pg_rect_normalize
-#define RectExport_pgCoord_FromFastcallArgs pgCoord_FromFastcallArgs_i
+#define RectExport_pgTwoValues_FromFastcallArgs pgCoord_FromFastcallArgs_i
 #define RectExport_move pg_rect_move
 #define RectExport_moveIp pg_rect_move_ip
 #define RectExport_inflate pg_rect_inflate
@@ -163,7 +163,7 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
 #define RectExport_dealloc pg_frect_dealloc
 #define RectExport_normalize pg_frect_normalize
 #define RectExport_move pg_frect_move
-#define RectExport_pgCoord_FromFastcallArgs pgCoord_FromFastcallArgs_f
+#define RectExport_pgTwoValues_FromFastcallArgs pgCoord_FromFastcallArgs_f
 #define RectExport_moveIp pg_frect_move_ip
 #define RectExport_inflate pg_frect_inflate
 #define RectExport_inflateIp pg_frect_inflate_ip

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -54,7 +54,7 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
 #define RectExport_new pg_rect_new
 #define RectExport_dealloc pg_rect_dealloc
 #define RectExport_normalize pg_rect_normalize
-#define RectExport_pgTwoValues_FromFastcallArgs pgCoord_FromFastcallArgs_i
+#define RectExport_pgTwoValuesFromFastcallArgs pgTwoValuesFromFastcallArgs_i
 #define RectExport_move pg_rect_move
 #define RectExport_moveIp pg_rect_move_ip
 #define RectExport_inflate pg_rect_inflate
@@ -163,7 +163,7 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
 #define RectExport_dealloc pg_frect_dealloc
 #define RectExport_normalize pg_frect_normalize
 #define RectExport_move pg_frect_move
-#define RectExport_pgTwoValues_FromFastcallArgs pgCoord_FromFastcallArgs_f
+#define RectExport_pgTwoValuesFromFastcallArgs pgTwoValuesFromFastcallArgs_f
 #define RectExport_moveIp pg_frect_move_ip
 #define RectExport_inflate pg_frect_inflate
 #define RectExport_inflateIp pg_frect_inflate_ip

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -54,6 +54,7 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
 #define RectExport_new pg_rect_new
 #define RectExport_dealloc pg_rect_dealloc
 #define RectExport_normalize pg_rect_normalize
+#define RectExport_pgCoord_FromFastcallArgs pgCoord_FromFastcallArgs_i
 #define RectExport_move pg_rect_move
 #define RectExport_moveIp pg_rect_move_ip
 #define RectExport_inflate pg_rect_inflate
@@ -162,6 +163,7 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
 #define RectExport_dealloc pg_frect_dealloc
 #define RectExport_normalize pg_frect_normalize
 #define RectExport_move pg_frect_move
+#define RectExport_pgCoord_FromFastcallArgs pgCoord_FromFastcallArgs_f
 #define RectExport_moveIp pg_frect_move_ip
 #define RectExport_inflate pg_frect_inflate
 #define RectExport_inflateIp pg_frect_inflate_ip
@@ -449,13 +451,13 @@ static struct PyMethodDef pg_rect_methods[] = {
      DOC_RECT_CLAMPIP},
     {"copy", (PyCFunction)pg_rect_copy, METH_NOARGS, DOC_RECT_COPY},
     {"fit", (PyCFunction)pg_rect_fit, METH_VARARGS, DOC_RECT_FIT},
-    {"move", (PyCFunction)pg_rect_move, METH_VARARGS, DOC_RECT_MOVE},
+    {"move", (PyCFunction)pg_rect_move, METH_FASTCALL, DOC_RECT_MOVE},
     {"update", (PyCFunction)pg_rect_update, METH_VARARGS, DOC_RECT_UPDATE},
     {"inflate", (PyCFunction)pg_rect_inflate, METH_VARARGS, DOC_RECT_INFLATE},
     {"union", (PyCFunction)pg_rect_union, METH_VARARGS, DOC_RECT_UNION},
     {"unionall", (PyCFunction)pg_rect_unionall, METH_VARARGS,
      DOC_RECT_UNIONALL},
-    {"move_ip", (PyCFunction)pg_rect_move_ip, METH_VARARGS, DOC_RECT_MOVEIP},
+    {"move_ip", (PyCFunction)pg_rect_move_ip, METH_FASTCALL, DOC_RECT_MOVEIP},
     {"inflate_ip", (PyCFunction)pg_rect_inflate_ip, METH_VARARGS,
      DOC_RECT_INFLATEIP},
     {"union_ip", (PyCFunction)pg_rect_union_ip, METH_VARARGS,
@@ -495,13 +497,13 @@ static struct PyMethodDef pg_frect_methods[] = {
      DOC_RECT_CLAMPIP},
     {"copy", (PyCFunction)pg_frect_copy, METH_NOARGS, DOC_RECT_COPY},
     {"fit", (PyCFunction)pg_frect_fit, METH_VARARGS, DOC_RECT_FIT},
-    {"move", (PyCFunction)pg_frect_move, METH_VARARGS, DOC_RECT_MOVE},
+    {"move", (PyCFunction)pg_frect_move, METH_FASTCALL, DOC_RECT_MOVE},
     {"update", (PyCFunction)pg_frect_update, METH_VARARGS, DOC_RECT_UPDATE},
     {"inflate", (PyCFunction)pg_frect_inflate, METH_VARARGS, DOC_RECT_INFLATE},
     {"union", (PyCFunction)pg_frect_union, METH_VARARGS, DOC_RECT_UNION},
     {"unionall", (PyCFunction)pg_frect_unionall, METH_VARARGS,
      DOC_RECT_UNIONALL},
-    {"move_ip", (PyCFunction)pg_frect_move_ip, METH_VARARGS, DOC_RECT_MOVEIP},
+    {"move_ip", (PyCFunction)pg_frect_move_ip, METH_FASTCALL, DOC_RECT_MOVEIP},
     {"inflate_ip", (PyCFunction)pg_frect_inflate_ip, METH_VARARGS,
      DOC_RECT_INFLATEIP},
     {"union_ip", (PyCFunction)pg_frect_union_ip, METH_VARARGS,

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -50,8 +50,8 @@
 #ifndef RectExport_normalize
 #error RectExport_normalize needs to be defined
 #endif
-#ifndef RectExport_pgTwoValues_FromFastcallArgs
-#error RectExport_pgTwoValues_FromFastcallArgs needs to be defined
+#ifndef RectExport_pgTwoValuesFromFastcallArgs
+#error RectExport_pgTwoValuesFromFastcallArgs needs to be defined
 #endif
 #ifndef RectExport_move
 #error RectExport_move needs to be defined
@@ -366,6 +366,7 @@
 #define RectFromObject RectExport_RectFromObject
 #define subtype_new4 RectExport_subtypeNew4
 #define primitiveFromObjIndex RectImport_primitiveFromObjIndex
+#define pgTwoValuesFromFastcallArgs RectExport_pgTwoValuesFromFastcallArgs
 #define twoPrimitivesFromObj RectImport_twoPrimitivesFromObj
 #define fourPrimivitesFromObj RectImport_fourPrimiviteFromObj
 #define PrimitiveFromObj RectImport_PrimitiveFromObj
@@ -419,9 +420,8 @@ RectExport_Normalize(InnerRect *rect);
 static PyObject *
 RectExport_normalize(RectObject *self, PyObject *args);
 static int
-RectExport_pgTwoValues_FromFastcallArgs(PyObject *const *args,
-                                        Py_ssize_t nargs, PrimitiveType *x,
-                                        PrimitiveType *y);
+RectExport_pgTwoValuesFromFastcallArgs(PyObject *const *args, Py_ssize_t nargs,
+                                       PrimitiveType *x, PrimitiveType *y);
 static PyObject *
 RectExport_move(RectObject *self, PyObject *const *args, Py_ssize_t nargs);
 static PyObject *
@@ -800,17 +800,45 @@ RectExport_normalize(RectObject *self, PyObject *args)
 }
 
 static int
-RectExport_pgTwoValues_FromFastcallArgs(PyObject *const *args,
-                                        Py_ssize_t nargs, PrimitiveType *x,
-                                        PrimitiveType *y)
+RectExport_pgTwoValuesFromFastcallArgs(PyObject *const *args, Py_ssize_t nargs,
+                                       PrimitiveType *x, PrimitiveType *y)
 {
     /*Check if there is only one argument*/
     if (nargs == 1) {
         /*Attempt to convert the argument to two floats/integers*/
         if (!twoPrimitivesFromObj(args[0], x, y)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "Invalid argument. Must be a two-element "
-                            "sequence of numbers");
+            if (!PySequence_Check(args[0])) {
+                PyErr_Format(
+                    PyExc_TypeError,
+                    "Invalid argument. Expected a sequence but got: '%s'",
+                    Py_TYPE(args[0])->tp_name);
+                return 0;
+            }
+
+            Py_ssize_t size = PySequence_Size(args[0]);
+            if (size != 2) {
+                PyErr_Format(
+                    PyExc_TypeError,
+                    "Invalid sequence size. Expected size 2 but got: %d",
+                    (int)size);
+                return 0;
+            }
+
+            PyObject *xobj, *yobj;
+            if (!(xobj = PySequence_GetItem(args[0], 0))) {
+                return 0;
+            }
+            if (!(yobj = PySequence_GetItem(args[0], 1))) {
+                Py_DECREF(xobj);
+                return 0;
+            }
+
+            PyErr_Format(PyExc_TypeError,
+                         "Invalid sequence values. Expected two numeric "
+                         "values but got: '%s', '%s'",
+                         Py_TYPE(xobj)->tp_name, Py_TYPE(yobj)->tp_name);
+            Py_DECREF(xobj);
+            Py_DECREF(yobj);
             return 0;
         }
         return 1;
@@ -819,23 +847,23 @@ RectExport_pgTwoValues_FromFastcallArgs(PyObject *const *args,
     else if (nargs == 2) {
         /*Attempt to convert the first argument to an float/integer*/
         if (!PrimitiveFromObj(args[0], x)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "Invalid argument. The first argument must be a "
-                            "numeric value");
+            PyErr_Format(PyExc_TypeError,
+                         "The first argument must be numeric (got: '%s')",
+                         Py_TYPE(args[0])->tp_name);
             return 0;
         }
         /*Attempt to convert the second argument to a float/integer*/
         if (!PrimitiveFromObj(args[1], y)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "Invalid argument. The second argument must be a "
-                            "numeric value");
+            PyErr_Format(PyExc_TypeError,
+                         "The second argument must be numeric (got: '%s')",
+                         Py_TYPE(args[1])->tp_name);
             return 0;
         }
         return 1;
     }
     /*Raise a TypeError for invalid number of arguments*/
     PyErr_Format(PyExc_TypeError,
-                 "function takes at most 2 arguments (%d given)", (int)nargs);
+                 "Function takes at most 2 arguments (%d given)", (int)nargs);
     return 0;
 }
 
@@ -844,7 +872,7 @@ RectExport_move(RectObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PrimitiveType x, y;
 
-    if (!RectExport_pgTwoValues_FromFastcallArgs(args, nargs, &x, &y)) {
+    if (!pgTwoValuesFromFastcallArgs(args, nargs, &x, &y)) {
         return NULL;
     }
 
@@ -857,7 +885,7 @@ RectExport_moveIp(RectObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PrimitiveType x, y;
 
-    if (!RectExport_pgTwoValues_FromFastcallArgs(args, nargs, &x, &y)) {
+    if (!pgTwoValuesFromFastcallArgs(args, nargs, &x, &y)) {
         return NULL;
     }
 
@@ -1052,7 +1080,7 @@ RectExport_collidepoint(RectObject *self, PyObject *const *args,
     InnerRect srect = self->r;
     InnerPoint p;
 
-    if (!RectExport_pgTwoValues_FromFastcallArgs(args, nargs, &p.x, &p.y)) {
+    if (!pgTwoValuesFromFastcallArgs(args, nargs, &p.x, &p.y)) {
         return NULL;
     }
 
@@ -2588,7 +2616,7 @@ RectExport_iterator(RectObject *self)
 #undef RectExport_new
 #undef RectExport_dealloc
 #undef RectExport_normalize
-#undef RectExport_pgTwoValues_FromFastcallArgs
+#undef pgTwoValuesFromFastcallArgs
 #undef RectExport_move
 #undef RectExport_moveIp
 #undef RectExport_inflate

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -366,6 +366,7 @@
 #define RectFromObject RectExport_RectFromObject
 #define subtype_new4 RectExport_subtypeNew4
 #define primitiveFromObjIndex RectImport_primitiveFromObjIndex
+#define pgTwoValuesFromFastcallArgs RectExport_pgTwoValuesFromFastcallArgs
 #define twoPrimitivesFromObj RectImport_twoPrimitivesFromObj
 #define fourPrimivitesFromObj RectImport_fourPrimiviteFromObj
 #define PrimitiveFromObj RectImport_PrimitiveFromObj
@@ -871,7 +872,7 @@ RectExport_move(RectObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PrimitiveType x, y;
 
-    if (!RectExport_pgTwoValuesFromFastcallArgs(args, nargs, &x, &y)) {
+    if (!pgTwoValuesFromFastcallArgs(args, nargs, &x, &y)) {
         return NULL;
     }
 
@@ -884,7 +885,7 @@ RectExport_moveIp(RectObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PrimitiveType x, y;
 
-    if (!RectExport_pgTwoValuesFromFastcallArgs(args, nargs, &x, &y)) {
+    if (!pgTwoValuesFromFastcallArgs(args, nargs, &x, &y)) {
         return NULL;
     }
 
@@ -1079,7 +1080,7 @@ RectExport_collidepoint(RectObject *self, PyObject *const *args,
     InnerRect srect = self->r;
     InnerPoint p;
 
-    if (!RectExport_pgTwoValuesFromFastcallArgs(args, nargs, &p.x, &p.y)) {
+    if (!pgTwoValuesFromFastcallArgs(args, nargs, &p.x, &p.y)) {
         return NULL;
     }
 
@@ -2615,6 +2616,7 @@ RectExport_iterator(RectObject *self)
 #undef RectExport_new
 #undef RectExport_dealloc
 #undef RectExport_normalize
+#undef pgTwoValuesFromFastcallArgs
 #undef RectExport_move
 #undef RectExport_moveIp
 #undef RectExport_inflate

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -804,10 +804,10 @@ RectExport_pgCoord_FromFastcallArgs(PyObject *const *args, Py_ssize_t nargs,
 {
     /*Check if there is only one argument*/
     if (nargs == 1) {
-        /*Attempt to convert the argument to two integers*/
+        /*Attempt to convert the argument to two floats/integers*/
         if (!twoPrimitivesFromObj(args[0], x, y)) {
             PyErr_SetString(PyExc_TypeError,
-                            "Invalid position. Must be a two-element "
+                            "Invalid argument. Must be a two-element "
                             "sequence of numbers");
             return 0;
         }
@@ -815,12 +815,12 @@ RectExport_pgCoord_FromFastcallArgs(PyObject *const *args, Py_ssize_t nargs,
     }
     /*Check if there are two arguments*/
     else if (nargs == 2) {
-        /*Attempt to convert the first argument to an integer*/
+        /*Attempt to convert the first argument to an float/integer*/
         if (!PrimitiveFromObj(args[0], x)) {
             PyErr_SetString(PyExc_TypeError, "x must be a numeric value");
             return 0;
         }
-        /*Attempt to convert the second argument to an integer*/
+        /*Attempt to convert the second argument to a float/integer*/
         if (!PrimitiveFromObj(args[1], y)) {
             PyErr_SetString(PyExc_TypeError, "y must be a numeric value");
             return 0;
@@ -828,8 +828,8 @@ RectExport_pgCoord_FromFastcallArgs(PyObject *const *args, Py_ssize_t nargs,
         return 1;
     }
     /*Raise a TypeError for invalid number of arguments*/
-    PyErr_SetString(PyExc_TypeError,
-                    "Invalid arguments number, must either be 1 or 2");
+    PyErr_Format(PyExc_TypeError,
+                 "function takes at most 2 arguments (%d given)", (int)nargs);
     return 0;
 }
 

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -366,7 +366,6 @@
 #define RectFromObject RectExport_RectFromObject
 #define subtype_new4 RectExport_subtypeNew4
 #define primitiveFromObjIndex RectImport_primitiveFromObjIndex
-#define pgTwoValuesFromFastcallArgs RectExport_pgTwoValuesFromFastcallArgs
 #define twoPrimitivesFromObj RectImport_twoPrimitivesFromObj
 #define fourPrimivitesFromObj RectImport_fourPrimiviteFromObj
 #define PrimitiveFromObj RectImport_PrimitiveFromObj
@@ -872,7 +871,7 @@ RectExport_move(RectObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PrimitiveType x, y;
 
-    if (!pgTwoValuesFromFastcallArgs(args, nargs, &x, &y)) {
+    if (!RectExport_pgTwoValuesFromFastcallArgs(args, nargs, &x, &y)) {
         return NULL;
     }
 
@@ -885,7 +884,7 @@ RectExport_moveIp(RectObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PrimitiveType x, y;
 
-    if (!pgTwoValuesFromFastcallArgs(args, nargs, &x, &y)) {
+    if (!RectExport_pgTwoValuesFromFastcallArgs(args, nargs, &x, &y)) {
         return NULL;
     }
 
@@ -1080,7 +1079,7 @@ RectExport_collidepoint(RectObject *self, PyObject *const *args,
     InnerRect srect = self->r;
     InnerPoint p;
 
-    if (!pgTwoValuesFromFastcallArgs(args, nargs, &p.x, &p.y)) {
+    if (!RectExport_pgTwoValuesFromFastcallArgs(args, nargs, &p.x, &p.y)) {
         return NULL;
     }
 
@@ -2616,7 +2615,6 @@ RectExport_iterator(RectObject *self)
 #undef RectExport_new
 #undef RectExport_dealloc
 #undef RectExport_normalize
-#undef pgTwoValuesFromFastcallArgs
 #undef RectExport_move
 #undef RectExport_moveIp
 #undef RectExport_inflate

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -50,8 +50,8 @@
 #ifndef RectExport_normalize
 #error RectExport_normalize needs to be defined
 #endif
-#ifndef RectExport_pgCoord_FromFastcallArgs
-#error RectExport_pgCoord_FromFastcallArgs needs to be defined
+#ifndef RectExport_pgTwoValues_FromFastcallArgs
+#error RectExport_pgTwoValues_FromFastcallArgs needs to be defined
 #endif
 #ifndef RectExport_move
 #error RectExport_move needs to be defined
@@ -419,8 +419,9 @@ RectExport_Normalize(InnerRect *rect);
 static PyObject *
 RectExport_normalize(RectObject *self, PyObject *args);
 static int
-RectExport_pgCoord_FromFastcallArgs(PyObject *const *args, Py_ssize_t nargs,
-                                    PrimitiveType *x, PrimitiveType *y);
+RectExport_pgTwoValues_FromFastcallArgs(PyObject *const *args,
+                                        Py_ssize_t nargs, PrimitiveType *x,
+                                        PrimitiveType *y);
 static PyObject *
 RectExport_move(RectObject *self, PyObject *const *args, Py_ssize_t nargs);
 static PyObject *
@@ -799,8 +800,9 @@ RectExport_normalize(RectObject *self, PyObject *args)
 }
 
 static int
-RectExport_pgCoord_FromFastcallArgs(PyObject *const *args, Py_ssize_t nargs,
-                                    PrimitiveType *x, PrimitiveType *y)
+RectExport_pgTwoValues_FromFastcallArgs(PyObject *const *args,
+                                        Py_ssize_t nargs, PrimitiveType *x,
+                                        PrimitiveType *y)
 {
     /*Check if there is only one argument*/
     if (nargs == 1) {
@@ -817,12 +819,16 @@ RectExport_pgCoord_FromFastcallArgs(PyObject *const *args, Py_ssize_t nargs,
     else if (nargs == 2) {
         /*Attempt to convert the first argument to an float/integer*/
         if (!PrimitiveFromObj(args[0], x)) {
-            PyErr_SetString(PyExc_TypeError, "x must be a numeric value");
+            PyErr_SetString(PyExc_TypeError,
+                            "Invalid argument. The first argument must be a "
+                            "numeric value");
             return 0;
         }
         /*Attempt to convert the second argument to a float/integer*/
         if (!PrimitiveFromObj(args[1], y)) {
-            PyErr_SetString(PyExc_TypeError, "y must be a numeric value");
+            PyErr_SetString(PyExc_TypeError,
+                            "Invalid argument. The second argument must be a "
+                            "numeric value");
             return 0;
         }
         return 1;
@@ -838,7 +844,7 @@ RectExport_move(RectObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PrimitiveType x, y;
 
-    if (!RectExport_pgCoord_FromFastcallArgs(args, nargs, &x, &y)) {
+    if (!RectExport_pgTwoValues_FromFastcallArgs(args, nargs, &x, &y)) {
         return NULL;
     }
 
@@ -851,7 +857,7 @@ RectExport_moveIp(RectObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PrimitiveType x, y;
 
-    if (!RectExport_pgCoord_FromFastcallArgs(args, nargs, &x, &y)) {
+    if (!RectExport_pgTwoValues_FromFastcallArgs(args, nargs, &x, &y)) {
         return NULL;
     }
 
@@ -1046,7 +1052,7 @@ RectExport_collidepoint(RectObject *self, PyObject *const *args,
     InnerRect srect = self->r;
     InnerPoint p;
 
-    if (!RectExport_pgCoord_FromFastcallArgs(args, nargs, &p.x, &p.y)) {
+    if (!RectExport_pgTwoValues_FromFastcallArgs(args, nargs, &p.x, &p.y)) {
         return NULL;
     }
 
@@ -2582,7 +2588,7 @@ RectExport_iterator(RectObject *self)
 #undef RectExport_new
 #undef RectExport_dealloc
 #undef RectExport_normalize
-#undef RectExport_pgCoord_FromFastcallArgs
+#undef RectExport_pgTwoValues_FromFastcallArgs
 #undef RectExport_move
 #undef RectExport_moveIp
 #undef RectExport_inflate

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -2635,6 +2635,7 @@ RectExport_iterator(RectObject *self)
 #undef RectExport_collideobjectsall
 #undef RectExport_collideobjects
 #undef RectExport_RectFromObjectAndKeyFunc
+#undef RectExport_pgTwoValuesFromFastcallArgs
 #undef RectExport_clip
 #undef RectExport_clipline
 #undef RectExport_do_rects_intresect


### PR DESCRIPTION
I have ported #1958 since the last addition of FRect. As I am still adapting, this may not be the ideal implementation. Please let me know if you know better methods. I have also added more benchmarks for FRect to account for these changes in the code.

**Results (columns show old/new):**
`Move`
| Case | Rect (s) | Uplift (%) | Frect (s) | Uplift (%) |
| --- | --- | --- | --- | --- |
| 1 arg tup inside tup | 0.10717282 / 0.08810694 | 21.6 | 0.08717053 / 0.06963296 | 25.1 |
| 1 arg tup | 0.10452923 / 0.0842131 | 24.1 | 0.08617208 / 0.06879297 | 25.2 |
| 1 arg lst | 0.13279415 / 0.11934226 | 11.2| 0.1210619 / 0.10032487 | 20.6|
| 2 args | 0.10887068 / 0.07456696 | 46.0| 0.08739826 / 0.05937409 | 47.1|

`Move_ip`
| Case | Rect (s) | Uplift (%) | Frect (s) | Uplift (%) |
| --- | --- | --- | --- | --- |
| 1 arg tup inside tup | 0.09123963 / 0.0729865 | 25.0| 0.06778982 / 0.05828947 | 16.3|
| 1 arg tup | 0.09867253 / 0.06984699 | 41.2| 0.06575731 / 0.05717076 | 15.0|
| 1 arg lst | 0.12765383 / 0.09541213 | 33.8| 0.09919653 / 0.07748874 | 28.0|
| 2 args | 0.08948597 / 0.05262832 | 70.0| 0.06839517 / 0.04137996 | 65.2|

Not part of this PR but can be taken as a reference:
| Case | Rect (s) | Frect (s) |
| --- | --- | --- | 
| ref move by attribs | 0.17353| 0.14476007

The code I used:
```Python
from pygame import Rect, FRect

from statistics import fmean
from timeit import repeat

r = Rect(0, 0, 33, 33)
fr = FRect(0, 0, 33, 33)
rep = 10

glob = globals()


def test(test_name: str, func: str) -> float:
    value = fmean(repeat(func, globals=glob, repeat=rep))
    print("-) " + test_name + f": {round(value, 8)}")


print("--- Rect Move ---")
test("1 arg tup inside tup", "r.move(((1, 1),))")
test("1 arg tup", "r.move((1, 1))")
test("1 arg lst", "r.move([1, 1])")
test("2 args", "r.move(1, 1)")
print("--- Rect Move_ip ---")
test("1 arg tup inside tup", "r.move_ip(((1, 1),))")
test("1 arg tup", "r.move_ip((1, 1))")
test("1 arg lst", "r.move_ip([1, 1])")
test("2 args", "r.move_ip(1, 1)")

print("--- Rect attribute move ---")
test("move(ip) by attribs", "r.x += 1; r.y += 1")

print("=====================================")

print("--- FRect Move ---")
test("1 arg tup inside tup", "fr.move(((1.0, 1.0),))")
test("1 arg tup", "fr.move((1.0, 1.0))")
test("1 arg lst", "fr.move([1.0, 1.0])")
test("2 args", "fr.move(1.0, 1.0)")

print("--- FRect Move_ip ---")
test("1 arg tup inside tup", "fr.move_ip(((1.0, 1.0),))")
test("1 arg tup", "fr.move_ip((1.0, 1.0))")
test("1 arg lst", "fr.move_ip([1.0, 1.0])")
test("2 args", "fr.move_ip(1.0, 1.0)")

print("--- FRect attribute move ---")
test("move(ip) by attribs", "fr.x += 1.0; fr.y += 1.0")
```


