### PR TITLE
Use PyMem_Free instead of PyMem_Del

### DIFF
--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -489,7 +489,7 @@ pgRWops_ReleaseObject(SDL_RWops *context)
             Py_XDECREF(helper->read);
             Py_XDECREF(helper->close);
             Py_DECREF(fileobj);
-            PyMem_Del(helper);
+            PyMem_Free(helper);
             SDL_FreeRW(context);
         }
         else {

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -135,7 +135,7 @@ _pg_remove_event_timer(pgEventObject *ev)
         else
             pg_event_timer = hunt->next;
         Py_DECREF(hunt->event);
-        PyMem_Del(hunt);
+        PyMem_Free(hunt);
     }
     /* Chances of it failing here are next to zero, dont do anything */
     SDL_UnlockMutex(timermutex);


### PR DESCRIPTION
Super simple PR, just moving PyMem_Del to the (equivalent) PyMem_Free.

Why? Because PyMem_Free is in the stable ABI, so we might as well use it instead of PyMem_Del. This change was suggested by https://github.com/python/pythoncapi-compat.

Docs backing up their equivalence: https://docs.python.org/3/c-api/memory.html#c.PyMem_Free