### PR TITLE
Retarget old wiki links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,7 +194,7 @@ See docs/licenses for licenses of dependencies.
 .. _pygame: https://pyga.me
 .. _Simple DirectMedia Layer library: https://www.libsdl.org
 .. _We need your help: https://www.pygame.org/contribute.html
-.. _Compilation wiki page: https://www.pygame.org/wiki/Compilation
+.. _Compilation wiki page: https://github.com/pygame-community/pygame-ce/wiki#compiling
 .. _docs page: https://pyga.me/docs
 .. _GNU LGPL version 2.1: https://www.gnu.org/copyleft/lesser.html
 

--- a/docs/reST/index.rst
+++ b/docs/reST/index.rst
@@ -43,10 +43,6 @@ Documents
 `Readme`_
   Basic information about pygame: what it is, who is involved, and where to find it.
 
-`Install`_
-  Steps needed to compile pygame on several platforms.
-  Also help on finding and installing prebuilt binaries for your system.
-
 :doc:`filepaths`
   How pygame handles file system paths.
 
@@ -212,8 +208,6 @@ Reference
 :ref:`search`
   Search pygame documents by keyword.
 
-.. _Readme: ../wiki/about
-
-.. _Install: ../wiki/GettingStarted#Pygame%20Installation
+.. _Readme: https://github.com/pygame-community/pygame-ce#readme
 
 .. _LGPL License: LGPL.txt

--- a/docs/readmes/README.zh-cn.rst
+++ b/docs/readmes/README.zh-cn.rst
@@ -155,7 +155,7 @@ pygame显然依赖于SDL和Python。此外pygame还嵌入了几个较小的库�
 .. _pygame: https://www.pyga.me
 .. _Simple DirectMedia Layer library: https://www.libsdl.org
 .. _We need your help: https://www.pygame.org/contribute.html
-.. _Compilation wiki page: https://www.pygame.org/wiki/Compilation
+.. _Compilation wiki page: https://github.com/pygame-community/pygame-ce/wiki#compiling
 .. _docs page: https://pyga.me/docs
 .. _GNU LGPL version 2.1: https://www.gnu.org/copyleft/lesser.html
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # This is the distutils setup script for pygame.
-# Full instructions are in https://www.pygame.org/wiki/GettingStarted
+# Full instructions are in https://github.com/pygame-community/pygame-ce/wiki
 #
 # To configure, compile, install, just run this script.
 #     python setup.py install
@@ -134,33 +134,14 @@ IS_PYPY = '__pypy__' in sys.builtin_module_names
 def compilation_help():
     """ On failure point people to a web page for help.
     """
-    the_system = platform.system()
-    if the_system == 'Linux':
-        if hasattr(platform, 'linux_distribution'):
-            distro = platform.linux_distribution()
-            if distro[0].lower() == 'ubuntu':
-                the_system = 'Ubuntu'
-            elif distro[0].lower() == 'debian':
-                the_system = 'Debian'
-
     help_urls = {
-        'Linux': 'https://www.pygame.org/wiki/Compilation',
-        'Ubuntu': 'https://www.pygame.org/wiki/CompileUbuntu',
-        'Windows': 'https://www.pygame.org/wiki/CompileWindows',
-        'Darwin': 'https://www.pygame.org/wiki/MacCompile',
-        'RedHat': 'https://www.pygame.org/wiki/CompileRedHat',
-        # TODO There is nothing in the following pages yet
-        'Suse': 'https://www.pygame.org/wiki/CompileSuse',
-        'Python (from pypy.org)': 'https://www.pygame.org/wiki/CompilePyPy',
-        'Free BSD': 'https://www.pygame.org/wiki/CompileFreeBSD',
-        'Debian': 'https://www.pygame.org/wiki/CompileDebian',
+        'Linux': 'https://github.com/pygame-community/pygame-ce/wiki/Compiling-on-Linux',
+        'Windows': 'https://github.com/pygame-community/pygame-ce/wiki/Compiling-on-Windows',
+        'Darwin': 'https://github.com/pygame-community/pygame-ce/wiki/Compiling-on-macOS',
     }
 
-    default = 'https://www.pygame.org/wiki/Compilation'
-    url = help_urls.get(the_system, default)
-
-    if IS_PYPY:
-        url += '\n    https://www.pygame.org/wiki/CompilePyPy'
+    default = 'https://github.com/pygame-community/pygame-ce/wiki#compiling'
+    url = help_urls.get(platform.system(), default)
 
     print('\n---')
     print('For help with compilation see:')


### PR DESCRIPTION
Fixes #2051

Decided to get rid of distro specific links, because even in the old wiki the CompileUbuntu one was the only one with actual content.