### PR TITLE
Deprecate pygame.image.tostring and fromstring

### DIFF
--- a/docs/reST/ref/image.rst
+++ b/docs/reST/ref/image.rst
@@ -166,7 +166,7 @@ following formats.
    | :sl:`transfer image to byte buffer`
    | :sg:`tostring(Surface, format, flipped=False) -> bytes`
 
-   DEPRECATED: Use tobytes() instead.
+   DEPRECATED: This function has the same functionality as :func:`tobytes()`, which is preferred and should be used.
 
    .. deprecated:: 2.3.0
 
@@ -219,7 +219,7 @@ following formats.
    | :sl:`create new Surface from a byte buffer`
    | :sg:`fromstring(bytes, size, format, flipped=False, pitch=-1) -> Surface`
 
-   DEPRECATED: Use frombytes() instead.
+   DEPRECATED: This function has the same functionality as :func:`frombytes()`, which is preferred and should be used.
 
    .. deprecated:: 2.3.0
 

--- a/docs/reST/ref/image.rst
+++ b/docs/reST/ref/image.rst
@@ -166,37 +166,9 @@ following formats.
    | :sl:`transfer image to byte buffer`
    | :sg:`tostring(Surface, format, flipped=False) -> bytes`
 
-   Creates a string of bytes that can be transferred with the ``fromstring``
-   or ``frombytes`` methods in other Python imaging packages. Some Python
-   image packages prefer their images in bottom-to-top format (PyOpenGL for
-   example). If you pass ``True`` for the flipped argument, the byte buffer
-   will be vertically flipped.
+   DEPRECATED: Use tobytes() instead.
 
-   The format argument is a string of one of the following values. Note that
-   only 8-bit Surfaces can use the "P" format. The other formats will work for
-   any Surface. Also note that other Python image packages support more formats
-   than pygame.
-
-      * ``P``, 8-bit palettized Surfaces
-
-      * ``RGB``, 24-bit image
-
-      * ``RGBX``, 32-bit image with unused space
-
-      * ``RGBA``, 32-bit image with an alpha channel
-
-      * ``ARGB``, 32-bit image with alpha channel first
-      
-      * ``BGRA``, 32-bit image with alpha channel, red and blue channels swapped
-
-      * ``RGBA_PREMULT``, 32-bit image with colors scaled by alpha channel
-
-      * ``ARGB_PREMULT``, 32-bit image with colors scaled by alpha channel, alpha channel first
-
-   .. note:: it is preferred to use :func:`tobytes` as of pygame 2.1.3
-
-   .. versionadded:: 2.1.3 BGRA format
-   .. versionchanged:: 2.2.0 Now supports keyword arguments.
+   .. deprecated:: 2.3.0
 
    .. ## pygame.image.tostring ##
 
@@ -232,8 +204,7 @@ following formats.
 
       * ``ARGB_PREMULT``, 32-bit image with colors scaled by alpha channel, alpha channel first
    
-   .. note:: this function is an alias for :func:`tostring`. The use of this
-             function is recommended over :func:`tostring` as of pygame 2.1.3.
+   .. note:: The use of this function is recommended over :func:`tostring` as of pygame 2.1.3.
              This function was introduced so it matches nicely with other 
              libraries (PIL, numpy, etc), and with people's expectations.
 
@@ -248,26 +219,9 @@ following formats.
    | :sl:`create new Surface from a byte buffer`
    | :sg:`fromstring(bytes, size, format, flipped=False, pitch=-1) -> Surface`
 
-   This function takes arguments similar to :func:`pygame.image.tostring()`.
-   The size argument is a pair of numbers representing the width and height.
-   Once the new Surface is created it is independent from the memory of the
-   bytes passed in.
+   DEPRECATED: Use frombytes() instead.
 
-   The bytes and format passed must compute to the exact size of image
-   specified. Otherwise a ``ValueError`` will be raised.
-
-   The 'pitch' argument can be used specify the pitch/stride per horizontal line
-   of the image bytes in bytes. It must be equal to or greater than how many bytes
-   the pixel data of each horizontal line in the image bytes occupies without any
-   extra padding. By default, it is ``-1``, which means that the pitch/stride is 
-   the same size as how many bytes the pure pixel data of each horizontal line takes.
-
-   See the :func:`pygame.image.frombuffer()` method for a potentially faster
-   way to transfer images into pygame.
-
-   .. note:: it is preferred to use :func:`frombytes` as of pygame 2.1.3
-
-   .. versionadded:: 2.1.4 Added a 'pitch' argument and support for keyword arguments.
+   .. deprecated:: 2.3.0
 
    .. ## pygame.image.fromstring ##
 
@@ -293,8 +247,7 @@ following formats.
    See the :func:`pygame.image.frombuffer()` method for a potentially faster
    way to transfer images into pygame.
 
-   .. note:: this function is an alias for :func:`fromstring`. The use of this
-             function is recommended over :func:`fromstring` as of pygame 2.1.3.
+   .. note:: The use of this function is recommended over :func:`fromstring` as of pygame 2.1.3.
              This function was introduced so it matches nicely with other 
              libraries (PIL, numpy, etc), and with people's expectations.
 

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1230,12 +1230,7 @@ image_tostring(PyObject *self, PyObject *arg, PyObject *kwarg)
         return NULL;
     }
 
-    PyObject *result = image_tobytes(self, arg, kwarg);
-    if (result == NULL) {
-        return NULL;
-    }
-
-    return result;
+    return image_tobytes(self, arg, kwarg);
 }
 
 PyObject *
@@ -1247,12 +1242,7 @@ image_fromstring(PyObject *self, PyObject *arg, PyObject *kwarg)
         return NULL;
     }
 
-    PyObject *result = image_frombytes(self, arg, kwarg);
-    if (result == NULL) {
-        return NULL;
-    }
-
-    return result;
+    return image_frombytes(self, arg, kwarg);
 }
 
 static int

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1221,6 +1221,38 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
     return (PyObject *)pgSurface_New(surf);
 }
 
+PyObject *
+image_tostring(PyObject *self, PyObject *arg, PyObject *kwarg) {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning, 
+                     "pygame.image.tostring deprecated since 2.3.0",
+                     1) == -1) {
+        return NULL;
+    }
+
+    PyObject *result = image_tobytes(self, arg, kwarg);
+    if (result == NULL) {
+        return NULL;
+    }
+
+    return result;
+}
+
+PyObject *
+image_fromstring(PyObject *self, PyObject *arg, PyObject *kwarg) {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning, 
+                     "pygame.image.fromstring deprecated since 2.3.0",
+                     1) == -1) {
+        return NULL;
+    }
+
+    PyObject *result = image_frombytes(self, arg, kwarg);
+    if (result == NULL) {
+        return NULL;
+    }
+
+    return result;
+}
+
 static int
 _as_read_buffer(PyObject *obj, const void **buffer, Py_ssize_t *buffer_len)
 {
@@ -1700,11 +1732,11 @@ static PyMethodDef _image_methods[] = {
     {"get_sdl_image_version", (PyCFunction)image_get_sdl_image_version,
      METH_VARARGS | METH_KEYWORDS, DOC_IMAGE_GETSDLIMAGEVERSION},
 
-    {"tostring", (PyCFunction)image_tobytes, METH_VARARGS | METH_KEYWORDS,
+    {"tostring", (PyCFunction)image_tostring, METH_VARARGS | METH_KEYWORDS,
      DOC_IMAGE_TOSTRING},
     {"tobytes", (PyCFunction)image_tobytes, METH_VARARGS | METH_KEYWORDS,
      DOC_IMAGE_TOBYTES},
-    {"fromstring", (PyCFunction)image_frombytes, METH_VARARGS | METH_KEYWORDS,
+    {"fromstring", (PyCFunction)image_fromstring, METH_VARARGS | METH_KEYWORDS,
      DOC_IMAGE_FROMSTRING},
     {"frombytes", (PyCFunction)image_frombytes, METH_VARARGS | METH_KEYWORDS,
      DOC_IMAGE_FROMBYTES},

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1222,8 +1222,9 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
 }
 
 PyObject *
-image_tostring(PyObject *self, PyObject *arg, PyObject *kwarg) {
-    if (PyErr_WarnEx(PyExc_DeprecationWarning, 
+image_tostring(PyObject *self, PyObject *arg, PyObject *kwarg)
+{
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
                      "pygame.image.tostring deprecated since 2.3.0",
                      1) == -1) {
         return NULL;
@@ -1238,8 +1239,9 @@ image_tostring(PyObject *self, PyObject *arg, PyObject *kwarg) {
 }
 
 PyObject *
-image_fromstring(PyObject *self, PyObject *arg, PyObject *kwarg) {
-    if (PyErr_WarnEx(PyExc_DeprecationWarning, 
+image_fromstring(PyObject *self, PyObject *arg, PyObject *kwarg)
+{
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
                      "pygame.image.fromstring deprecated since 2.3.0",
                      1) == -1) {
         return NULL;

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -493,8 +493,8 @@ class ImageModuleTest(unittest.TestCase):
                     )
                     self.fail(msg)
 
-    def test_to_string__premultiplied(self):
-        """test to make sure we can export a surface to a premultiplied alpha string"""
+    def test_to_bytes__premultiplied(self):
+        """test to make sure we can export a surface to a premultiplied alpha bytes"""
 
         def convertRGBAtoPremultiplied(surface_to_modify):
             for x in range(surface_to_modify.get_width()):
@@ -518,19 +518,19 @@ class ImageModuleTest(unittest.TestCase):
         premultiplied_copy = test_surface.copy()
         convertRGBAtoPremultiplied(premultiplied_copy)
         self.assertPremultipliedAreEqual(
-            pygame.image.tostring(test_surface, "RGBA_PREMULT"),
-            pygame.image.tostring(premultiplied_copy, "RGBA"),
-            pygame.image.tostring(test_surface, "RGBA"),
+            pygame.image.tobytes(test_surface, "RGBA_PREMULT"),
+            pygame.image.tobytes(premultiplied_copy, "RGBA"),
+            pygame.image.tobytes(test_surface, "RGBA"),
         )
         self.assertPremultipliedAreEqual(
-            pygame.image.tostring(test_surface, "ARGB_PREMULT"),
-            pygame.image.tostring(premultiplied_copy, "ARGB"),
-            pygame.image.tostring(test_surface, "ARGB"),
+            pygame.image.tobytes(test_surface, "ARGB_PREMULT"),
+            pygame.image.tobytes(premultiplied_copy, "ARGB"),
+            pygame.image.tobytes(test_surface, "ARGB"),
         )
 
         no_alpha_surface = pygame.Surface((256, 256), 0, 24)
         self.assertRaises(
-            ValueError, pygame.image.tostring, no_alpha_surface, "RGBA_PREMULT"
+            ValueError, pygame.image.tobytes, no_alpha_surface, "RGBA_PREMULT"
         )
 
     # Custom assert method to check for identical surfaces.
@@ -560,8 +560,8 @@ class ImageModuleTest(unittest.TestCase):
                     "%s (pixel: %d, %d)" % (msg, x, y),
                 )
 
-    def test_fromstring__and_tostring(self):
-        """Ensure methods tostring() and fromstring() are symmetric."""
+    def test_frombytes__and_tobytes(self):
+        """Ensure methods tobytes() and frombytes() are symmetric."""
 
         import itertools
 
@@ -601,11 +601,11 @@ class ImageModuleTest(unittest.TestCase):
         )
 
         for pair in fmt_combinations:
-            fmt1_buf = pygame.image.tostring(test_surface, pair[0])
+            fmt1_buf = pygame.image.tobytes(test_surface, pair[0])
             fmt1_convert_buf = convert(
                 pair[1], pair[0], convert(pair[0], pair[1], fmt1_buf)
             )
-            test_convert_two_way = pygame.image.fromstring(
+            test_convert_two_way = pygame.image.frombytes(
                 fmt1_convert_buf, test_surface.get_size(), pair[0]
             )
 
@@ -616,9 +616,9 @@ class ImageModuleTest(unittest.TestCase):
             )
 
         for pair in fmt_permutations:
-            fmt1_buf = pygame.image.tostring(test_surface, pair[0])
+            fmt1_buf = pygame.image.tobytes(test_surface, pair[0])
             fmt2_convert_buf = convert(pair[0], pair[1], fmt1_buf)
-            test_convert_one_way = pygame.image.fromstring(
+            test_convert_one_way = pygame.image.frombytes(
                 fmt2_convert_buf, test_surface.get_size(), pair[1]
             )
 
@@ -629,19 +629,19 @@ class ImageModuleTest(unittest.TestCase):
             )
 
         for fmt in fmts:
-            test_buf = pygame.image.tostring(test_surface, fmt)
-            test_to_from_fmt_string = pygame.image.fromstring(
+            test_buf = pygame.image.tobytes(test_surface, fmt)
+            test_to_from_fmt_bytes = pygame.image.frombytes(
                 test_buf, test_surface.get_size(), fmt
             )
 
             self._assertSurfaceEqual(
                 test_surface,
-                test_to_from_fmt_string,
-                "tostring/fromstring functions are not "
+                test_to_from_fmt_bytes,
+                "tobytes/frombytes functions are not "
                 f"symmetric with '{fmt}' format",
             )
 
-    def test_tostring_depth_24(self):
+    def test_tobytes_depth_24(self):
         test_surface = pygame.Surface((64, 256), depth=24)
         for i in range(256):
             for j in range(16):
@@ -652,16 +652,23 @@ class ImageModuleTest(unittest.TestCase):
                 test_surface.set_at((j + 32, i), (i, i, i, intensity))
 
         fmt = "RGB"
-        fmt_buf = pygame.image.tostring(test_surface, fmt)
-        test_to_from_fmt_string = pygame.image.fromstring(
+        fmt_buf = pygame.image.tobytes(test_surface, fmt)
+        test_to_from_fmt_bytes = pygame.image.frombytes(
             fmt_buf, test_surface.get_size(), fmt
         )
 
         self._assertSurfaceEqual(
             test_surface,
-            test_to_from_fmt_string,
-            f'tostring/fromstring functions are not symmetric with "{fmt}" format',
+            test_to_from_fmt_bytes,
+            f'tobytes/frombytes functions are not symmetric with "{fmt}" format',
         )
+    
+    def test_from_to_bytes_deprecation(self):
+        test_surface = pygame.Surface((64, 256), flags=pygame.SRCALPHA, depth=32)
+        with self.assertWarns(DeprecationWarning):
+            test_surface_bytes = pygame.image.tostring(test_surface, "RGBA")
+        with self.assertWarns(DeprecationWarning):
+            reconstructed_test_surface = pygame.image.fromstring(test_surface_bytes, (64, 256), "RGBA")
 
     def test_frombuffer_8bit(self):
         """test reading pixel data from a bytes buffer"""

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -637,8 +637,7 @@ class ImageModuleTest(unittest.TestCase):
             self._assertSurfaceEqual(
                 test_surface,
                 test_to_from_fmt_bytes,
-                "tobytes/frombytes functions are not "
-                f"symmetric with '{fmt}' format",
+                "tobytes/frombytes functions are not " f"symmetric with '{fmt}' format",
             )
 
     def test_tobytes_depth_24(self):
@@ -662,13 +661,15 @@ class ImageModuleTest(unittest.TestCase):
             test_to_from_fmt_bytes,
             f'tobytes/frombytes functions are not symmetric with "{fmt}" format',
         )
-    
+
     def test_from_to_bytes_deprecation(self):
         test_surface = pygame.Surface((64, 256), flags=pygame.SRCALPHA, depth=32)
         with self.assertWarns(DeprecationWarning):
             test_surface_bytes = pygame.image.tostring(test_surface, "RGBA")
         with self.assertWarns(DeprecationWarning):
-            reconstructed_test_surface = pygame.image.fromstring(test_surface_bytes, (64, 256), "RGBA")
+            reconstructed_test_surface = pygame.image.fromstring(
+                test_surface_bytes, (64, 256), "RGBA"
+            )
 
     def test_frombuffer_8bit(self):
         """test reading pixel data from a bytes buffer"""

--- a/test/scrap_test.py
+++ b/test/scrap_test.py
@@ -99,10 +99,10 @@ class ScrapModuleTest(unittest.TestCase):
     def test_put__bmp_image(self):
         """Ensures put can place a BMP image into the clipboard."""
         sf = pygame.image.load(trunk_relative_path("examples/data/asprite.bmp"))
-        expected_string = pygame.image.tostring(sf, "RGBA")
-        scrap.put(pygame.SCRAP_BMP, expected_string)
+        expected_bytes = pygame.image.tobytes(sf, "RGBA")
+        scrap.put(pygame.SCRAP_BMP, expected_bytes)
 
-        self.assertEqual(scrap.get(pygame.SCRAP_BMP), expected_string)
+        self.assertEqual(scrap.get(pygame.SCRAP_BMP), expected_bytes)
 
     def test_put(self):
         """Ensures put can place data into the clipboard


### PR DESCRIPTION
Fixes #2085

Since `to/fromstring`'s gonna be deprecated, I also replaced usage of them in tests to `to/frombytes`
Finally, like I mentioned on the discord, because to/frombytes and to/fromstring's docs were the exact same and made it hard to follow, I replaced it with a redirection to `to/frombytes`