### PR TITLE
Start move away from format masks (prep for SDL3)

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -702,7 +702,7 @@ pg_ResizeEventWatch(void *userdata, SDL_Event *event)
                 pgSurfaceObject *display_surface =
                     pg_GetDefaultWindowSurface();
                 SDL_Surface *surf = SDL_CreateRGBSurface(
-                    SDL_SWSURFACE, w, h, 32, 0xff << 16, 0xff << 8, 0xff, 0);
+                    0, w, h, 32, 0xff << 16, 0xff << 8, 0xff, 0);
 
                 SDL_FreeSurface(display_surface->surf);
                 display_surface->surf = surf;
@@ -1158,8 +1158,8 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
 
                 So we make a fake surface.
                 */
-                surf = SDL_CreateRGBSurface(SDL_SWSURFACE, w, h, 32,
-                                            0xff << 16, 0xff << 8, 0xff, 0);
+                surf = SDL_CreateRGBSurface(0, w, h, 32, 0xff << 16, 0xff << 8,
+                                            0xff, 0);
                 newownedsurf = surf;
             }
             else {
@@ -1260,8 +1260,8 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                         pg_renderer, SDL_PIXELFORMAT_ARGB8888,
                         SDL_TEXTUREACCESS_STREAMING, w, h);
                 }
-                surf = SDL_CreateRGBSurface(SDL_SWSURFACE, w, h, 32,
-                                            0xff << 16, 0xff << 8, 0xff, 0);
+                surf = SDL_CreateRGBSurface(0, w, h, 32, 0xff << 16, 0xff << 8,
+                                            0xff, 0);
                 newownedsurf = surf;
             }
             else {

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1070,7 +1070,8 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
 
-        surf = SDL_CreateRGBSurface(0, w, h, 8, 0, 0, 0, 0);
+        surf =
+            SDL_CreateRGBSurfaceWithFormat(0, w, h, 8, SDL_PIXELFORMAT_INDEX8);
         if (!surf)
             return RAISE(pgExc_SDLError, SDL_GetError());
         SDL_LockSurface(surf);
@@ -1093,8 +1094,14 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
+
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
         surf =
-            SDL_CreateRGBSurface(0, w, h, 24, 0xFF << 16, 0xFF << 8, 0xFF, 0);
+            SDL_CreateRGBSurfaceWithFormat(0, w, h, 24, SDL_PIXELFORMAT_BGR24);
+#else
+        surf =
+            SDL_CreateRGBSurfaceWithFormat(0, w, h, 24, SDL_PIXELFORMAT_RGB24);
+#endif
         if (!surf)
             return RAISE(pgExc_SDLError, SDL_GetError());
         SDL_LockSurface(surf);
@@ -1134,7 +1141,7 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
-        surf = SDL_CreateRGBSurface((alphamult ? SDL_SRCALPHA : 0), w, h, 32,
+        surf = SDL_CreateRGBSurface(0, w, h, 32,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
                                     0xFF, 0xFF << 8, 0xFF << 16,
                                     (alphamult ? 0xFF << 24 : 0));
@@ -1167,12 +1174,8 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
-        surf = SDL_CreateRGBSurface(SDL_SRCALPHA, w, h, 32,
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                                    0xFF << 16, 0xFF << 8, 0xFF, 0xFF << 24);
-#else
-                                    0xFF << 8, 0xFF << 16, 0xFF << 24, 0xFF);
-#endif
+        surf = SDL_CreateRGBSurfaceWithFormat(0, w, h, 32,
+                                              SDL_PIXELFORMAT_BGRA32);
         if (!surf)
             return RAISE(pgExc_SDLError, SDL_GetError());
         SDL_LockSurface(surf);
@@ -1198,12 +1201,8 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
-        surf = SDL_CreateRGBSurface(SDL_SRCALPHA, w, h, 32,
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                                    0xFF << 8, 0xFF << 16, 0xFF << 24, 0xFF);
-#else
-                                    0xFF << 16, 0xFF << 8, 0xFF, 0xFF << 24);
-#endif
+        surf = SDL_CreateRGBSurfaceWithFormat(0, w, h, 32,
+                                              SDL_PIXELFORMAT_ARGB32);
         if (!surf)
             return RAISE(pgExc_SDLError, SDL_GetError());
         SDL_LockSurface(surf);
@@ -1292,7 +1291,8 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
 
-        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 8, pitch, 0, 0, 0, 0);
+        surf = SDL_CreateRGBSurfaceWithFormatFrom(data, w, h, 8, pitch,
+                                                  SDL_PIXELFORMAT_INDEX8);
     }
     else if (!strcmp(format, "RGB")) {
         if (pitch == -1) {
@@ -1385,8 +1385,6 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
                                         0xFF << 24, 0xFF << 16, 0xFF << 8,
                                         (alphamult ? 0xFF : 0));
 #endif
-        if (alphamult)
-            surf->flags |= SDL_SRCALPHA;
     }
     else if (!strcmp(format, "ARGB")) {
         if (pitch == -1) {
@@ -1402,14 +1400,8 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
-        surf =
-            SDL_CreateRGBSurfaceFrom(data, w, h, 32, pitch,
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                                     0xFF << 8, 0xFF << 16, 0xFF << 24, 0xFF);
-#else
-                                     0xFF << 16, 0xFF << 8, 0xFF, 0xFF << 24);
-#endif
-        surf->flags |= SDL_SRCALPHA;
+        surf = SDL_CreateRGBSurfaceWithFormatFrom(data, w, h, 32, pitch,
+                                                  SDL_PIXELFORMAT_ARGB32);
     }
     else
         return RAISE(PyExc_ValueError, "Unrecognized type of format");
@@ -1609,8 +1601,8 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
         }
     }
 
-    linebuf = SDL_CreateRGBSurface(SDL_SWSURFACE, surface->w, 1, h.pixel_bits,
-                                   rmask, gmask, bmask, amask);
+    linebuf = SDL_CreateRGBSurface(0, surface->w, 1, h.pixel_bits, rmask,
+                                   gmask, bmask, amask);
     if (!linebuf)
         return -1;
 

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -169,7 +169,7 @@ _make_surface(pgPixelArrayObject *array, PyObject *args)
 
     /* Create the second surface. */
 
-    temp_surf = SDL_CreateRGBSurface(surf->flags, (int)dim0, (int)dim1,
+    temp_surf = SDL_CreateRGBSurface(0, (int)dim0, (int)dim1,
                                      surf->format->BitsPerPixel,
                                      surf->format->Rmask, surf->format->Gmask,
                                      surf->format->Bmask, surf->format->Amask);
@@ -178,7 +178,7 @@ _make_surface(pgPixelArrayObject *array, PyObject *args)
     }
 
     /* Guarantee an identical format. */
-    new_surf = SDL_ConvertSurface(temp_surf, surf->format, surf->flags);
+    new_surf = SDL_ConvertSurface(temp_surf, surf->format, 0);
     SDL_FreeSurface(temp_surf);
     if (!new_surf) {
         return RAISE(pgExc_SDLError, SDL_GetError());

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -533,9 +533,8 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
         /*
          * New source surface is 32bit with a defined RGBA ordering
          */
-        rz_src =
-            SDL_CreateRGBSurface(SDL_SWSURFACE, src->w, src->h, 32, 0x000000ff,
-                                 0x0000ff00, 0x00ff0000, 0xff000000);
+        rz_src = SDL_CreateRGBSurface(0, src->w, src->h, 32, 0x000000ff,
+                                      0x0000ff00, 0x00ff0000, 0xff000000);
         SDL_BlitSurface(src, NULL, rz_src, NULL);
         src_converted = 1;
     }
@@ -585,7 +584,7 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
          * Target surface is 32bit with source RGBA/ABGR ordering
          */
         rz_dst =
-            SDL_CreateRGBSurface(SDL_SWSURFACE, dstwidth, dstheight, 32,
+            SDL_CreateRGBSurface(0, dstwidth, dstheight, 32,
                                  rz_src->format->Rmask, rz_src->format->Gmask,
                                  rz_src->format->Bmask, rz_src->format->Amask);
 
@@ -634,7 +633,7 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
          * Target surface is 32bit with source RGBA/ABGR ordering
          */
         rz_dst =
-            SDL_CreateRGBSurface(SDL_SWSURFACE, dstwidth, dstheight, 32,
+            SDL_CreateRGBSurface(0, dstwidth, dstheight, 32,
                                  rz_src->format->Rmask, rz_src->format->Gmask,
                                  rz_src->format->Bmask, rz_src->format->Amask);
 

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -127,10 +127,9 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
         return (SDL_Surface *)(RAISE(
             PyExc_ValueError, "unsupported Surface bit depth for transform"));
 
-    newsurf = SDL_CreateRGBSurface(surf->flags, width, height,
-                                   surf->format->BitsPerPixel,
-                                   surf->format->Rmask, surf->format->Gmask,
-                                   surf->format->Bmask, surf->format->Amask);
+    newsurf = SDL_CreateRGBSurface(
+        0, width, height, surf->format->BitsPerPixel, surf->format->Rmask,
+        surf->format->Gmask, surf->format->Bmask, surf->format->Amask);
     if (!newsurf)
         return (SDL_Surface *)(RAISE(pgExc_SDLError, SDL_GetError()));
 
@@ -860,9 +859,8 @@ surf_rotozoom(PyObject *self, PyObject *args, PyObject *kwargs)
     }
     else {
         Py_BEGIN_ALLOW_THREADS;
-        surf32 = SDL_CreateRGBSurface(SDL_SWSURFACE, surf->w, surf->h, 32,
-                                      0x000000ff, 0x0000ff00, 0x00ff0000,
-                                      0xff000000);
+        surf32 = SDL_CreateRGBSurface(0, surf->w, surf->h, 32, 0x000000ff,
+                                      0x0000ff00, 0x00ff0000, 0xff000000);
         SDL_BlitSurface(surf, NULL, surf32, NULL);
         Py_END_ALLOW_THREADS;
     }


### PR DESCRIPTION
The purpose of this PR is to start moving away from format masks. In SDL3, `SDL_CreateRGBSurface` and `SDL_CreateRGBSurfaceWithFormat` are both replaced with `SDL_CreateSurface`. `SDL_CreateSurface` takes SDL pixelformat enums instead of {R, G, B, A}masks.

So this is a PR to make it slightly easier to port to SDL3 when that time comes. I think small PRs like this one are a good way of eventually getting to a working SDL3 integration, without huge unreviewable PRs.

The process of reasoning about replacing masks with pixelformat enum members is greatly complicated by having to think about endianness. I did not guess, nor did I try to think each through on my own. To translate the masks into pixelformats, I checked the source of `SDL_GetPixelFormatEnumForMasks` (SDL3's version of SDL_MasksToPixelFormatEnum), as well as checking the pixelformat definitions in SDL_pixels.h.

This should keep the exact same behavior before and after this PR, little endian or big endian.

I also removed some obsolete arguments. `SDL_CreateRGBSurface` and `SDL_ConvertSurface` both have a `flags` argument inherited from SDL1, which is ignored in SDL2. I set that flag to 0 in places it wasn't zero. I also replaced a couple uses of `SDL_SRCALPHA`, an SDL1 constant removed in SDL2-- defined in a pygame header as `0`.