### PR TITLE
Fix mac wheels issue: sndfile disable lame mpeg

### DIFF
--- a/buildconfig/manylinux-build/docker_base/sndfile/build-sndfile.sh
+++ b/buildconfig/manylinux-build/docker_base/sndfile/build-sndfile.sh
@@ -13,7 +13,7 @@ tar xf ${SNDFILE}
 cd $SNDNAME
 # autoreconf -fvi
 
-./configure $ARCHS_CONFIG_FLAG
+./configure $ARCHS_CONFIG_FLAG --disable-mpeg
 make
 make install
 


### PR DESCRIPTION
Edit Starbuck5 with more context: Issue where older macs can't do anything with audio because of a failed dlload of libmp3lame, a library we don't need. See https://www.reddit.com/r/pygame/comments/12k24f0/the_example_alienspy_wont_launch_no_matter_what/