### PR TITLE
Font warning spellcheck

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -18,7 +18,6 @@
 # Pete Shinners
 # pete@shinners.org
 """sysfont, used in the font module to find system fonts"""
-import time
 import warnings
 import os
 import sys

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -391,16 +391,31 @@ def _find_fontname_typos(comparison_word: str) -> str:
     results = []
     comparison_word_len = len(comparison_word)
     for word in itertools.chain(Sysfonts, Sysalias):
-        amount = 0
         word_len = len(word)
-        if comparison_word_len != word_len:
+        if not (word_len - 1 <= comparison_word_len <= word_len + 1):
             continue
-        for i in range(word_len):
+
+        if comparison_word.startswith(word) or word.startswith(comparison_word):
+            results.append(word)
+            continue
+
+        amount = 0
+        for i in range(min(word_len, comparison_word_len)):
             if comparison_word[i] != word[i]:
                 amount += 1
-            if amount == 2:
-                break
-        if amount == 1:
+                if amount == 2:
+                    break
+                if (
+                    word[:i] + word[i + 1 :]
+                    == comparison_word[:i] + comparison_word[i + 1 :]
+                    or word[:i] + word[i + 1 :] == comparison_word
+                    or word == comparison_word[:i] + comparison_word[i + 1 :]
+                ):
+                    results.append(word)
+                    amount = 0
+                    break
+
+        if amount == 1 and comparison_word_len == word_len:
             results.append(word)
 
     if len(results) == 0:

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -407,11 +407,11 @@ def _find_fontname_typos(comparison_word: str) -> str:
     if len(results) == 0:
         return ""
     if len(results) == 1:
-        return f"Did you mean '{results[0]}'? "
+        return f"Did you mean: '{results[0]}'? "
     elif len(results) == 2:
-        return f"Did you mean '{results[0]}' or '{results[1]}'? "
+        return f"Did you mean: '{results[0]}' or '{results[1]}'? "
     else:
-        return "Did you mean '" + "', '".join(results[:-1]) + f"' or '{results[-1]}'? "
+        return "Did you mean: '" + "', '".join(results[:-1]) + f"' or '{results[-1]}'? "
 
 
 # the exported functions


### PR DESCRIPTION
In #1970 a warning was added to `Sysfont` if it couldn't find a matching font:
```
The system font 'Ariel' couldn't be found. Using the default font instead.
```
I've added a simple typo-checker to the warning, which shows potential corrections if the font name that the user entered was one letter different to a correct fontname:
```
The system font 'Ariel' couldn't be found. Did you mean: 'arial'? Using the default font instead.
```
