### PR TITLE
Raise an error when source and destination surfaces are the same (in `box_blur` and `gaussian_blur`).

### DIFF
--- a/docs/reST/ref/transform.rst
+++ b/docs/reST/ref/transform.rst
@@ -238,6 +238,9 @@ Instead, always begin with the original image and scale to the desired size.)
 
    .. versionadded:: 2.2.0
 
+   .. versionchanged:: 2.3.0
+      Passing the calling surface as destination surface raises a ``ValueError``
+
    .. ## pygame.transform.box_blur ##
 
 .. function:: gaussian_blur
@@ -256,6 +259,9 @@ Instead, always begin with the original image and scale to the desired size.)
    depth and format as the source Surface.
 
    .. versionadded:: 2.2.0
+
+   .. versionchanged:: 2.3.0
+      Passing the calling surface as destination surface raises a ``ValueError``
 
    .. ## pygame.transform.gaussian_blur ##
 

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -3144,6 +3144,11 @@ blur(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int radius,
         retsurf = pgSurface_AsSurface(dstobj);
     }
 
+    if (retsurf->pixels == src->pixels) {
+        return RAISE(PyExc_ValueError,
+                     "Source and destination surfaces are the same.");
+    }
+
     if ((retsurf->w) != (src->w) || (retsurf->h) != (src->h)) {
         return RAISE(PyExc_ValueError,
                      "Destination surface not the same size.");

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -3150,8 +3150,11 @@ blur(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int radius,
     Uint8 *src_end = src_start + src->h * src->pitch;
     if ((ret_start <= src_start && ret_end >= src_start) ||
         (src_start <= ret_start && src_end >= ret_start)) {
-        return RAISE(PyExc_ValueError,
-                     "Source and destination surfaces are overlapping.");
+        return RAISE(
+            PyExc_ValueError,
+            "Blur routines do not support dest_surfaces that share pixels "
+            "with the source surface. Likely the surfaces are the same, one "
+            "of them is a subsurface, or they are sharing the same buffer.");
     }
 
     if ((retsurf->w) != (src->w) || (retsurf->h) != (src->h)) {

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -3144,9 +3144,14 @@ blur(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int radius,
         retsurf = pgSurface_AsSurface(dstobj);
     }
 
-    if (retsurf->pixels == src->pixels) {
+    Uint8 *ret_start = retsurf->pixels;
+    Uint8 *ret_end = ret_start + retsurf->h * retsurf->pitch;
+    Uint8 *src_start = src->pixels;
+    Uint8 *src_end = src_start + src->h * src->pitch;
+    if ((ret_start <= src_start && ret_end >= src_start) ||
+        (src_start <= ret_start && src_end >= ret_start)) {
         return RAISE(PyExc_ValueError,
-                     "Source and destination surfaces are the same.");
+                     "Source and destination surfaces are overlapping.");
     }
 
     if ((retsurf->w) != (src->w) || (retsurf->h) != (src->h)) {

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1425,20 +1425,21 @@ class TransformDisplayModuleTest(unittest.TestCase):
         data_fname = example_path("data")
         path = os.path.join(data_fname, "peppers3.tif")
         sf = pygame.image.load(path)
-        sub_sf = sf.subsurface((0, 0, *sf.get_size()))
+        sub1 = sf.subsurface((0, 0, 128, 128))
+        sub2 = sf.subsurface((20, 20, 128, 128))
 
         self.assertRaises(
             ValueError, lambda: pygame.transform.box_blur(sf, 10, dest_surface=sf)
         )
         self.assertRaises(
-            ValueError, lambda: pygame.transform.box_blur(sf, 10, dest_surface=sub_sf)
+            ValueError, lambda: pygame.transform.box_blur(sub1, 10, dest_surface=sub2)
         )
         self.assertRaises(
             ValueError, lambda: pygame.transform.gaussian_blur(sf, 10, dest_surface=sf)
         )
         self.assertRaises(
             ValueError,
-            lambda: pygame.transform.gaussian_blur(sf, 10, dest_surface=sub_sf),
+            lambda: pygame.transform.gaussian_blur(sub1, 10, dest_surface=sub2),
         )
 
     def test_box_blur(self):

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1418,6 +1418,29 @@ class TransformDisplayModuleTest(unittest.TestCase):
         self.assertRaises(ValueError, lambda: pygame.transform.box_blur(sf, 10))
         self.assertRaises(ValueError, lambda: pygame.transform.gaussian_blur(sf, 10))
 
+    def test_blur_in_place(self):
+        # When source and destination surfaces are the same,
+        # A ValueError should be raised.
+
+        data_fname = example_path("data")
+        path = os.path.join(data_fname, "peppers3.tif")
+        sf = pygame.image.load(path)
+        sub_sf = sf.subsurface((0, 0, *sf.get_size()))
+
+        self.assertRaises(
+            ValueError, lambda: pygame.transform.box_blur(sf, 10, dest_surface=sf)
+        )
+        self.assertRaises(
+            ValueError, lambda: pygame.transform.box_blur(sf, 10, dest_surface=sub_sf)
+        )
+        self.assertRaises(
+            ValueError, lambda: pygame.transform.gaussian_blur(sf, 10, dest_surface=sf)
+        )
+        self.assertRaises(
+            ValueError,
+            lambda: pygame.transform.gaussian_blur(sf, 10, dest_surface=sub_sf),
+        )
+
     def test_box_blur(self):
         data1 = {
             (1, 29): (67, 58, 26, 255),


### PR DESCRIPTION
Continue from #2103
Fix #2102