### PR TITLE
Reveal `.. note::` reST block background color again

### DIFF
--- a/docs/reST/themes/classic/static/pygame.css_t
+++ b/docs/reST/themes/classic/static/pygame.css_t
@@ -694,7 +694,7 @@ p.admonition-title:after {
     content: ":";
 }
 
-dl.definition div.note, dl.definition div.seealso {
+dl.definition div.seealso {
     background: none;
     border: none;
 }

--- a/docs/reST/themes/classic/static/pygame.css_t
+++ b/docs/reST/themes/classic/static/pygame.css_t
@@ -709,11 +709,16 @@ dl.definition .admonition-title {
 
 div.note {
     background-color: {{ theme_notebgcolor }};
-    border: 1px solid #ccc;
+    border: 1px solid {{ theme_notebordercolor }};
 }
 
 .note tt {
     background: #d6d6d6;
+}
+
+.dark-theme div.note {
+    background-color: {{ theme_dark_notebgcolor }};
+    border: 1px solid {{ theme_dark_notebordercolor }};
 }
 
 div.seealso {

--- a/docs/reST/themes/classic/theme.conf
+++ b/docs/reST/themes/classic/theme.conf
@@ -51,6 +51,8 @@ dark_headertitlecolor       = #00ba10
 dark_headerlogoborder       = #00ba10
 dark_h1color                = #e1cd62
 dark_h2color                = #00b800
+dark_notebgcolor            = #555349
+dark_notebordercolor        = #6e6b5e
 
 relbarbgcolor               = #6aee28
 relbartextcolor             = #000000
@@ -75,6 +77,7 @@ codekeyword                 = #DE6C90
 
 cautionbgcolor              = #eeffcc
 notebgcolor                 = #eeeeee
+notebordercolor             = #eeeeee
 
 highlightbgcolor            = #c7c695
 logobgcolor                 = #c2fc20


### PR DESCRIPTION
The initial change was made while doing [docs style improvements](https://github.com/pygame/pygame/commit/a428c87b9644cf681742599b8954fd6b8195b815), however it is ultimately more beneficial and widespread to have `.. note::` reST blocks stand out. It makes them harder to overlook, thus making it less likely for users to miss important details.

### Before
<img width="684" alt="image" src="https://github.com/pygame-community/pygame-ce/assets/65417594/224b8d84-669b-45e9-9bc2-1459a2acaf39">


### After
<img width="709" alt="image" src="https://github.com/pygame-community/pygame-ce/assets/65417594/3010c804-3a4d-4351-9eaa-737d53d02913">
