### PR TITLE
Re-allow destsurf scale w/ diff but compatible pixelformats

### DIFF
--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -413,6 +413,7 @@ scale_to(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int width,
 {
     SDL_Surface *src = NULL;
     SDL_Surface *retsurf = NULL;
+    SDL_Surface *modsurf = NULL;
     int stretch_result_num = 0;
 
     if (width < 0 || height < 0)
@@ -421,12 +422,32 @@ scale_to(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int width,
     src = pgSurface_AsSurface(srcobj);
 
     if (!dstobj) {
-        retsurf = newsurf_fromsurf(src, width, height);
+        modsurf = retsurf = newsurf_fromsurf(src, width, height);
         if (!retsurf)
             return NULL;
     }
     else {
-        retsurf = pgSurface_AsSurface(dstobj);
+        modsurf = retsurf = pgSurface_AsSurface(dstobj);
+        if (retsurf->format->BytesPerPixel != src->format->BytesPerPixel ||
+            retsurf->format->Rmask != src->format->Rmask ||
+            retsurf->format->Gmask != src->format->Gmask ||
+            retsurf->format->Bmask != src->format->Bmask) {
+            return RAISE(PyExc_ValueError,
+                         "Source and destination surfaces need to be "
+                         "compatible formats.");
+        }
+
+        /* If the surface formats are otherwise compatible but the alpha is
+         * not the same, use a proxy surface to modify the pixels of the
+         * existing dstobj return surface. Otherwise SDL_SoftStretch
+         * rejects the input.
+         * For example, RGBA and RGBX surfaces are compatible in this way. */
+        if (retsurf->format->Amask != src->format->Amask) {
+            modsurf = SDL_CreateRGBSurfaceWithFormatFrom(
+                retsurf->pixels, retsurf->w, retsurf->h,
+                retsurf->format->BitsPerPixel, retsurf->pitch,
+                src->format->format);
+        }
     }
 
     if (retsurf->w != width || retsurf->h != height) {
@@ -442,10 +463,14 @@ scale_to(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int width,
         pgSurface_Lock(srcobj);
         Py_BEGIN_ALLOW_THREADS;
 
-        stretch_result_num = SDL_SoftStretch(src, NULL, retsurf, NULL);
+        stretch_result_num = SDL_SoftStretch(src, NULL, modsurf, NULL);
 
         Py_END_ALLOW_THREADS;
         pgSurface_Unlock(srcobj);
+
+        if (modsurf != retsurf) {
+            SDL_FreeSurface(modsurf);
+        }
 
         if (stretch_result_num < 0) {
             return (SDL_Surface *)(RAISE(pgExc_SDLError, SDL_GetError()));

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -99,7 +99,7 @@ class TransformModuleTest(unittest.TestCase):
     def test_scale__destination(self):
         """see if the destination surface can be passed in to use."""
 
-        s = pygame.Surface((32, 32))
+        s = pygame.Surface((32, 32), depth=32)
         s2 = pygame.transform.scale(s, (64, 64))
         s3 = s2.copy()
 
@@ -119,6 +119,18 @@ class TransformModuleTest(unittest.TestCase):
 
         # the wrong size surface is past in.  Should raise an error.
         self.assertRaises(ValueError, pygame.transform.smoothscale, s, (33, 64), s3)
+
+        alpha_surf = pygame.Surface((64, 64), pygame.SRCALPHA)
+        pygame.transform.scale(alpha_surf, (32, 32), s)
+
+        alpha_surf_weird = pygame.Surface(
+            (64, 64), pygame.SRCALPHA, 32, (0xFF000000, 0xFF0000, 0xFF00, 0xFF)
+        )
+        assert alpha_surf_weird.get_shifts() != alpha_surf.get_shifts()
+
+        self.assertRaises(
+            ValueError, pygame.transform.scale, alpha_surf_weird, (32, 32), s
+        )
 
     def test_scale__vector2(self):
         s = pygame.Surface((32, 32))


### PR DESCRIPTION
Fixes #2116 

So, in #1884 I replaced our bespoke scaling code with a call to SDL_SoftStretch. I also removed our explicit source bitdepth == dest bitdepth check when a dest surface is provided, because I knew SDL_SoftStretch would do that error for us.

What I failed to take into account is that there are in fact times when a dest surface would be used (with the same bitdepth) but with a different pixelformat.

For example, scaling a RGBA image onto an RGBX destination surface. It was able to handle that before, and a few people used that functionality.

So I had a few ideas:
- Revert my previous changes (This would get rid of the speedups too, and people like speedups)
- Trick SDL_SoftStretch into thinking it had a surface of one type when it didn't, by overwriting the pixelformat and then replacing it later (Hacky)
- Give SDL_SoftStretch a real surface to modify with the equivalent pixelformat.

I went with the third option, using CreateSurfaceFrom to share the pixel data with the existing destination surface.