### PR TITLE
Manually bump actions/cache, minor usage updates

### DIFF
--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Cache Cython
       id: cache-cython
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       with:
         path: ${{ env.WHEELHOUSE_CYTHON }}
         key: wasm-ubuntu-cython-${{ env.LATEST_CYTHON_COMMIT }}-path-${{ env.WHEELHOUSE_CYTHON }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -49,12 +49,13 @@ jobs:
 
       - name: Test for Mac Deps cache hit
         id: macdep-cache
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3.3.1
         with:
           path: ${{ github.workspace }}/pygame_mac_deps_${{ matrix.macarch }}
           # The hash of all files in buildconfig manylinux-build and macdependencies is 
           # the key to the cache. If anything changes here, the deps are built again
           key: macdep-${{ hashFiles('buildconfig/manylinux-build/**') }}-${{ hashFiles('buildconfig/macdependencies/*.sh') }}-${{ matrix.macarch }}
+          lookup-only: true
 
       # build mac deps on cache miss
       - name: Build Mac Deps
@@ -152,17 +153,18 @@ jobs:
       - uses: actions/checkout@v3.5.2
 
       - name: pip cache
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3.3.1
         with:
           path: ~/Library/Caches/pip  # This cache path is only right on mac
           key: pip-cache-${{ matrix.name }}
 
       - name: Fetch Mac deps
         id: macdep-cache
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3.3.1
         with:
           path: ${{ github.workspace }}/pygame_mac_deps_${{ matrix.macarch }}
           key: macdep-${{ hashFiles('buildconfig/manylinux-build/**') }}-${{ hashFiles('buildconfig/macdependencies/*.sh') }}-${{ matrix.macarch }}
+          fail-on-cache-miss: true
 
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.12.3


### PR DESCRIPTION
Should fix the deprecation warning, and ensure the action continues to run.
Also takes the opportunity to do a few minor usage updates to save a tiny bit of CI time, and make it a bit more robust.

Not really sure why dependabot missed this action while it takes care of all other actions, if someone could shed light on this would be nice

