### PR TITLE
Optimize vector coords memory

### DIFF
--- a/src_c/math.c
+++ b/src_c/math.c
@@ -24,7 +24,8 @@
  * level.
  */
 #if defined(__GNUC__) && defined(__linux__) && defined(__i386__) && \
-    __SIZEOF_POINTER__ == 4 && __GNUC__ == 4 && __GNUC_MINOR__ >= 4
+    __SIZEOF_POINTER__ == 4 &&                                      \
+    ((__GNUC__ == 4 && __GNUC_MINOR__ >= 4) || __GNUC__ >= 4)
 #pragma GCC optimize("float-store")
 #endif
 


### PR DESCRIPTION
Why do a malloc (+error checking) and a free when we don't need to?

This also improves memory usage on Vector3s (by one double), while being neutral on Vector2s.

Before Vector2 (relevant bits):
1 double*   (size = 8 bytes)
double[2] allocated     (size = 16 bytes)

After Vector2 (relevant bits):
double[3] in struct    (size = 24 bytes)

Before Vector3 (relevant bits):
1 double*   (size = 8 bytes)
double[3] allocated     (size = 24 bytes)

Now Vector3 (relevant bits):
double[3] in struct    (size = 24 bytes)


Without adjusting the float store gcc setting to apply on more modern compilers (as I believe was the intent behind the original code), I got a single rounding-error type failure on manylinux i686.