### PR TITLE
Optimize `Surface.get_(f)rect`

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2536,7 +2536,7 @@ static PyObject *
 surf_generic_get_rect(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
                       PyObject *kwnames, char *type)
 {
-    PyObject *rect;
+    PyObject *rect = NULL;
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
     if (nargs > 0) {

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2534,9 +2534,12 @@ surf_get_height(PyObject *self, PyObject *_null)
     return PyLong_FromLong(surf->h);
 }
 
+#define GET_RECT_TYPE_RECT 1
+#define GET_RECT_TYPE_FRECT 2
+
 static PyObject *
 surf_generic_get_rect(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
-                      PyObject *kwnames, char *type)
+                      PyObject *kwnames, int type)
 {
     PyObject *rect = NULL;
     SDL_Surface *surf = pgSurface_AsSurface(self);
@@ -2548,18 +2551,20 @@ surf_generic_get_rect(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
 
     SURF_INIT_CHECK(surf)
 
-    if (strcmp(type, "rect") == 0) {
-        rect = pgRect_New4(0, 0, surf->w, surf->h);
-    }
-    else if (strcmp(type, "frect") == 0) {
-        rect = pgFRect_New4(0.f, 0.f, (float)surf->w, (float)surf->h);
+    switch (type) {
+        case GET_RECT_TYPE_RECT:
+            rect = pgRect_New4(0, 0, surf->w, surf->h);
+            break;
+        case GET_RECT_TYPE_FRECT:
+            rect = pgFRect_New4(0.f, 0.f, (float)surf->w, (float)surf->h);
+            break;
     }
 
     if (rect && kwnames) {
         Py_ssize_t i, sequence_len;
         PyObject **sequence_items;
         sequence_items = PySequence_Fast_ITEMS(kwnames);
-        sequence_len = PySequence_Fast_GET_SIZE(kwnames);
+        sequence_len = PyTuple_GET_SIZE(kwnames);
 
         for (i = 0; i < sequence_len; ++i) {
             if ((PyObject_SetAttr(rect, sequence_items[i], args[i]) == -1)) {
@@ -2575,15 +2580,20 @@ static PyObject *
 surf_get_rect(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
               PyObject *kwnames)
 {
-    return surf_generic_get_rect(self, args, nargs, kwnames, "rect");
+    return surf_generic_get_rect(self, args, nargs, kwnames,
+                                 GET_RECT_TYPE_RECT);
 }
 
 static PyObject *
 surf_get_frect(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
                PyObject *kwnames)
 {
-    return surf_generic_get_rect(self, args, nargs, kwnames, "frect");
+    return surf_generic_get_rect(self, args, nargs, kwnames,
+                                 GET_RECT_TYPE_FRECT);
 }
+
+#undef GET_RECT_TYPE_RECT
+#undef GET_RECT_TYPE_FRECT
 
 static PyObject *
 surf_get_bitsize(PyObject *self, PyObject *_null)

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2534,30 +2534,14 @@ surf_get_height(PyObject *self, PyObject *_null)
     return PyLong_FromLong(surf->h);
 }
 
-#define GET_RECT_TYPE_RECT 1
-#define GET_RECT_TYPE_FRECT 2
-
-static PyObject *
-surf_generic_get_rect(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
-                      PyObject *kwnames, int type)
+static inline PyObject *
+_get_rect_helper(PyObject *rect, PyObject *const *args, Py_ssize_t nargs,
+                 PyObject *kwnames, char *type)
 {
-    PyObject *rect = NULL;
-    SDL_Surface *surf = pgSurface_AsSurface(self);
-
     if (nargs > 0) {
+        Py_DECREF(rect);
         return PyErr_Format(PyExc_TypeError,
                             "get_%s only accepts keyword arguments", type);
-    }
-
-    SURF_INIT_CHECK(surf)
-
-    switch (type) {
-        case GET_RECT_TYPE_RECT:
-            rect = pgRect_New4(0, 0, surf->w, surf->h);
-            break;
-        case GET_RECT_TYPE_FRECT:
-            rect = pgFRect_New4(0.f, 0.f, (float)surf->w, (float)surf->h);
-            break;
     }
 
     if (rect && kwnames) {
@@ -2580,20 +2564,25 @@ static PyObject *
 surf_get_rect(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
               PyObject *kwnames)
 {
-    return surf_generic_get_rect(self, args, nargs, kwnames,
-                                 GET_RECT_TYPE_RECT);
+    SDL_Surface *surf = pgSurface_AsSurface(self);
+    SURF_INIT_CHECK(surf)
+
+    PyObject *rect = pgRect_New4(0, 0, surf->w, surf->h);
+
+    return _get_rect_helper(rect, args, nargs, kwnames, "rect");
 }
 
 static PyObject *
 surf_get_frect(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
                PyObject *kwnames)
 {
-    return surf_generic_get_rect(self, args, nargs, kwnames,
-                                 GET_RECT_TYPE_FRECT);
-}
+    SDL_Surface *surf = pgSurface_AsSurface(self);
+    SURF_INIT_CHECK(surf)
 
-#undef GET_RECT_TYPE_RECT
-#undef GET_RECT_TYPE_FRECT
+    PyObject *rect = pgFRect_New4(0.f, 0.f, (float)surf->w, (float)surf->h);
+
+    return _get_rect_helper(rect, args, nargs, kwnames, "frect");
+}
 
 static PyObject *
 surf_get_bitsize(PyObject *self, PyObject *_null)

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -194,9 +194,11 @@ surf_get_height(PyObject *self, PyObject *args);
 static PyObject *
 surf_get_pitch(PyObject *self, PyObject *args);
 static PyObject *
-surf_get_rect(PyObject *self, PyObject *args, PyObject *kwargs);
+surf_get_rect(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
+              PyObject *kwnames);
 static PyObject *
-surf_get_frect(PyObject *self, PyObject *args, PyObject *kwargs);
+surf_get_frect(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
+               PyObject *kwnames);
 static PyObject *
 surf_get_width(PyObject *self, PyObject *args);
 static PyObject *

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2552,7 +2552,7 @@ surf_generic_get_rect(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
         rect = pgRect_New4(0, 0, surf->w, surf->h);
     }
     else if (strcmp(type, "frect") == 0) {
-        rect = pgFRect_New4(0, 0, surf->w, surf->h);
+        rect = pgFRect_New4(0.f, 0.f, (float)surf->w, (float)surf->h);
     }
 
     if (rect && kwnames) {


### PR DESCRIPTION
Now uses `METH_FASTCALL | METH_KEYWORDS`
Also created a generic function for less redundancy in code.

Test code I used:
```py
from timeit import timeit

import pygame

N = 10_000_000
G = globals()

surf = pygame.Surface((10, 10))

print(timeit("""
surf.get_rect()
""", number=N, globals=G))

print(timeit("""
surf.get_frect()
""", number=N, globals=G))

print(timeit("""
surf.get_rect(center=(5, 5))
""", number=N, globals=G))

print(timeit("""
surf.get_frect(center=(5, 5))
""", number=N, globals=G))
```

I managed to get an approximately 30% increase in speed for `get_rect` with a single kwarg and an approximately 20% increase in speed for `get_frect` with a single kwarg (no clue why they were different, perhaps, just some variations somewhere). (w/o kwargs was about the same as expected, didn't try with multiple kwargs but this should in theory get faster the more kwargs get added compared to what was previously)