### PR TITLE
Minor documentation updates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,9 @@ but the documentation can also be launched with `python -m pygame.docs`
 ### Generating the Documentation
 
 Steps:
-- Have Python 3.7 or higher
-- install Sphinx (`pip install Sphinx==3.5.4`)
-- fork the pygame repository, download and navigate to it in the terminal
-- run `python setup.py docs`
+- Install Sphinx (`pip install Sphinx`)
+- Fork the pygame repository, download and navigate to it in the terminal
+- Run `python setup.py docs`
 
 This will create a new folder under the `docs` folder. 
 In `docs/generated`, you will find a local copy of the pygame documentation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ but the documentation can also be launched with `python -m pygame.docs`
 
 Steps:
 - Install Sphinx (`pip install Sphinx`)
-- Fork the pygame repository, download and navigate to it in the terminal
+- Fork the pygame-ce repository, download and navigate to it in the terminal
 - Run `python setup.py docs`
 
 This will create a new folder under the `docs` folder. 

--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -129,11 +129,10 @@ required).
    The Surface that gets returned can be drawn to like a regular Surface but
    changes will eventually be seen on the monitor.
 
-   If no size is passed or is set to ``(0, 0)`` and pygame uses ``SDL``
-   version 1.2.10 or above, the created Surface will have the same size as the
-   current screen resolution. If only the width or height are set to ``0``, the
-   Surface will have the same width or height as the screen resolution. Using a
-   ``SDL`` version prior to 1.2.10 will raise an exception.
+   If no size is passed or is set to ``(0, 0)``, the created Surface will have
+   the same size as the current screen resolution. If only the width or height
+   are set to ``0``, the Surface will have the same width or height as the
+   screen resolution.
 
    It is usually best to not pass the depth argument. It will default to the
    best and fastest color depth for the system. If your game requires a

--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -198,10 +198,10 @@ MP3 in most cases.
    file, first call :func:`rewind`.
 
    Other file formats are unsupported. Newer versions of SDL_mixer have
-   better positioning support than earlier ones. An SDLError is raised if a
-   particular format does not support positioning.
+   better positioning support than earlier ones. A :exc:`pygame.error` is
+   raised if a particular format does not support positioning.
 
-   Function :func:`set_pos` calls underlining SDL_mixer function
+   Function :func:`set_pos` calls underlying SDL_mixer function
    ``Mix_SetMusicPosition``.
 
    .. versionaddedold:: 1.9.2


### PR DESCRIPTION
- A warning about an SDL version released in 2006 is not relevant
- We don't pin Sphinx anywhere else, so might as well just say `pip install sphinx`
- SDLError -> pygame.error