### PR TITLE
Surface.pblit()

### DIFF
--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -61,11 +61,11 @@ class Surface:
     ) -> Rect: ...
     @overload
     def pblit(
-        self,
-        source: Surface,
-        special_flags: int = 0,
-        /,
-        **kwargs: Any,
+            self,
+            source: Surface,
+            dest: Union[Coordinate, RectValue],
+            area: Optional[RectValue] = None,
+            special_flags: int = 0,
     ) -> Rect: ...
     @overload
     def pblit(

--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -59,6 +59,31 @@ class Surface:
         area: Optional[RectValue] = None,
         special_flags: int = 0,
     ) -> Rect: ...
+    @overload
+    def pblit(
+        self,
+        source: Surface,
+        special_flags: int = 0,
+        /,
+        **kwargs: Any,
+    ) -> Rect: ...
+    @overload
+    def pblit(
+        self,
+        source: Surface,
+        area: Optional[RectValue] = None,
+        /,
+        **kwargs: Any,
+    ) -> Rect: ...
+    @overload
+    def pblit(
+        self,
+        source: Surface,
+        area: Optional[RectValue] = None,
+        special_flags: int = 0,
+        /,
+        **kwargs: Any,
+    ) -> Rect: ...
     def blits(
         self,
         blit_sequence: Sequence[

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1940,10 +1940,13 @@ surf_pblit(pgSurfaceObject *self, PyObject *const *args, Py_ssize_t nargs,
     }
 
     if (kwnames) {
-        if (PyTuple_GET_SIZE(kwnames) > 1) {
-            return RAISE(
+        Py_ssize_t nkwargs = PyTuple_GET_SIZE(kwnames);
+        if (nkwargs > 1) {
+            PyErr_Format(
                 PyExc_TypeError,
-                "pblit() must have at most a single keyword argument");
+                "pblit() can have at most a single keyword argument, got: %zd",
+                nkwargs);
+            return NULL;
         }
     }
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1935,9 +1935,10 @@ surf_pblit(pgSurfaceObject *self, PyObject *const *args, Py_ssize_t nargs,
      * is optional and represents the blend_flag. The third argument is not
      * optional and represents the name: position kwarg. */
 
-    if (nargs < 1 || nargs > 3) {
+    if (nargs < 1 || nargs > 4) {
         PyErr_Format(PyExc_TypeError,
-                     "pblit takes 1 or 2 positional arguments but %zd were "
+                     "pblit takes a minimum of one and maximum of 4 "
+                     "positional arguments but %zd were "
                      "given",
                      nargs);
         return NULL;


### PR DESCRIPTION
The implementation of the pblit function is now complete. It is faster than using blit with a surf.get_rect() call for positioning and retains all of the blit functionality (minus all args being possible kwargs). This function can accept both a single position as a keyword argument while remaining faster than blit. 

With pblit, you won’t have to type
`blit(img, img.get_rect(center=c))`
but only
`pblit(img, center=c)`

Benchmark results show that pblit is faster than blit with get_rect and blit without get_rect. This makes it a more efficient option for blitting with an “anchor” keyword argument functionality.

The pblit function can be called in several ways. Here are all the possible ways to call this function:

- pblit(Surface, area, a_poskwarg=value)
- pblit(Surface, area, special_flag, a_poskwarg=value)
- pblit(Surface, pos, special_flag)
- pblit(Surface, pos, area)
- pblit(Surface, pos, area, special_flag)

So you can either pass a standard position that will represent the topleft pos the surface will be blitted at or a single kwarg with a position value that represents how the position should be treated. The possible names for this kwarg are all possible Rect attributes names. The function always return a rect just like blit does.

**Test program:**
```Python
import pygame
from timeit import timeit

pygame.init()

screen = pygame.display.set_mode((800, 600))
clock = pygame.time.Clock()

surf = pygame.Surface((100, 100))
surf.fill((0, 255, 0))

surf2 = pygame.Surface((100, 100))
surf2.fill((0, 0, 255))

c = (400, 300)

keep = True

r = pygame.Rect(30, 90, 34, 10)

while keep:
    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            keep = False
        elif event.type == pygame.KEYDOWN:
            if event.key == pygame.K_ESCAPE:
                keep = False

    mouse = pygame.mouse.get_pos()

    screen.fill((146, 44, 200))

    screen.pblit(surf2, r, center=c)
    # screen.blit(surf, surf.get_rect(center=c), r)

    pygame.draw.circle(screen, (255, 0, 0), c, 5)

    pygame.display.flip()

    clock.tick(60)

for _ in range(5):
    print(timeit("screen.pblit(surf, r, 1, center=c)", globals=globals(), number=100_0000))
print()

for _ in range(5):
    print(timeit("screen.blit(surf, surf.get_rect(center=c), r, 1)", globals=globals(),
                 number=100_0000))
print()
for _ in range(5):
    print(timeit(
        "screen.blit(surf, (c[0] - surf.get_width() / 2, c[1] - surf.get_height() / 2), r, 1)",
        globals=globals(), number=100_0000))

pygame.quit()
```

Benchmark results with this exact test I posted are the following on my machine:
```
pblit
0.3344177999999829
0.3031705000000784
0.31798029999981736
0.29507119999993847
0.29959920000010243

blit with get_rect
0.44990260000008675
0.4481419999999616
0.45481519999998454
0.4476395000001503
0.45073850000017046

blit without get_rect
0.5805242000001272
0.5800661999999193
0.579819900000075
0.5764452999999321
0.5774909000001571
```