### PR TITLE
Include more info in version

### DIFF
--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -25,6 +25,7 @@ Windows, macOS, OS X, BeOS, FreeBSD, IRIX, and Linux."""
 
 import os
 import sys
+import platform
 
 # Choose Windows display driver
 if os.name == "nt":
@@ -378,12 +379,13 @@ def __color_reduce(c):
 
 copyreg.pickle(Color, __color_reduce, __color_constructor)
 
-# Thanks for supporting pygame. Without support now, there won't be pygame later.
+# Thanks for supporting pygame-ce.
+# Without support now, there won't be pygame-ce later.
 if "PYGAME_HIDE_SUPPORT_PROMPT" not in os.environ:
     print(
-        "pygame-ce {} (SDL {}.{}.{}, Python {}.{}.{})".format(  # pylint: disable=consider-using-f-string
-            ver, *get_sdl_version() + sys.version_info[0:3]
-        )
+        f"pygame-ce {ver} (SDL {'.'.join(map(str, get_sdl_version()))}, "
+        f"Python {platform.python_version()})"
     )
+
 # cleanup namespace
-del pygame, os, sys, MissingModule, copyreg, packager_imports
+del pygame, os, sys, platform, MissingModule, copyreg, packager_imports


### PR DESCRIPTION
For example, 3.11.0 release candidate 2 now prints as 3.11.0rc2 instead of 3.11.0.