### PR TITLE
Fix MAC_ARCH environment variable on CI

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -117,6 +117,7 @@ jobs:
           }
 
     env:
+      MAC_ARCH: ${{ matrix.macarch }}
       # load pip config from this file. Define this in 'CIBW_ENVIRONMENT'
       # because this should not affect cibuildwheel machinery
       # also define environment variables needed for testing
@@ -130,7 +131,6 @@ jobs:
 
       # Setup MacOS dependencies
       CIBW_BEFORE_ALL: |
-        export MAC_ARCH="${{ matrix.macarch }}"
         brew install pkg-config
         cd buildconfig/macdependencies
         cp -r ${{ github.workspace }}/pygame_mac_deps_${{ matrix.macarch }} ${{ github.workspace }}/pygame_mac_deps


### PR DESCRIPTION
For whatever reason the `MAC_ARCH` environment variable was implemented in a non-githubby way in our CI and this eventually give me a warning, treated as an error while working on #2042. This changes it to work like all the other environment variables in the file.

In the interests of making that work easier to review I'm splitting off this small change which is largely unrelated to SIMD.
