### PR TITLE
Fix the large inline code sections in the dark theme

### DIFF
--- a/docs/reST/themes/classic/static/pygame.css_t
+++ b/docs/reST/themes/classic/static/pygame.css_t
@@ -538,6 +538,9 @@ dt code span.pre {
 }
 .dark-theme dt code span.pre {
     color: {{ theme_dark_h1color }};
+}
+.dark-theme dt.title code span.pre {
+    color: {{ theme_dark_h1color }};
     font-size: 1.8rem;
 }
 


### PR DESCRIPTION
Changes this:
![image](https://github.com/pygame-community/pygame-ce/assets/13382426/3eca9338-6471-4325-a639-0da1f8f68da3)

To this:

![image](https://github.com/pygame-community/pygame-ce/assets/13382426/4a2438ae-23a3-4a22-ab86-576809be0cc4)
