### PR TITLE
Added multiline text rendering to eventlist example

### DIFF
--- a/examples/eventlist.py
+++ b/examples/eventlist.py
@@ -100,8 +100,14 @@ def drawhistory(win, history):
     img = font.render("Event History Area", 1, (155, 155, 155), (0, 0, 0))
     win.blit(img, (2, 132))
 
-    img = font.render(history, 1, (50, 200, 50), (0, 0, 0), wraplength=640)
+    img = font.render("\n".join(history), 1, (50, 200, 50), (0, 0, 0), wraplength=640)
     win.blit(img, (10, 250))
+
+
+def draw_usage_in_history(history, text):
+    for line in text.split("\n"):
+        if "===" not in line and line != "":
+            history.append(line)
 
 
 def main():
@@ -118,22 +124,22 @@ def main():
     img_on_off.append(font.render("Off", 1, (0, 0, 0), (255, 50, 50)))
     img_on_off.append(font.render("On", 1, (0, 0, 0), (50, 255, 50)))
 
-    # stores multiline text representing what has gone through the event queue
-    history = ""
+    # stores lines of text representing what has gone through the event queue
+    history = []
 
     # let's turn on the joysticks just so we can play with em
     for x in range(pygame.joystick.get_count()):
         if SDL2 and pygame._sdl2.controller.is_controller(x):
             c = pygame._sdl2.controller.Controller(x)
-            txt = f"Enabled controller: {c.name}\n"
+            txt = f"Enabled controller: {c.name}"
         else:
             j = pygame.joystick.Joystick(x)
-            txt = f"Enabled joystick: {j.get_name()}\n"
+            txt = f"Enabled joystick: {j.get_name()}"
 
-        history += txt
+        history.append(txt)
 
     if not pygame.joystick.get_count():
-        history += "No Joysticks to Initialize\n"
+        history.append("No Joysticks to Initialize")
 
     going = True
     while going:
@@ -145,7 +151,7 @@ def main():
                     global last_key
                     last_key = e.key
                 if e.key == pygame.K_h:
-                    history += usage.strip().replace("=", "").replace("\n\n", "")
+                    draw_usage_in_history(history, usage)
                 if SDL2 and e.key == pygame.K_c:
                     current_state = pygame._sdl2.controller.get_eventstate()
                     pygame._sdl2.controller.set_eventstate(not current_state)
@@ -157,9 +163,9 @@ def main():
                 pygame.mouse.set_visible(not pygame.mouse.get_visible())
 
             if e.type != pygame.MOUSEMOTION:
-                txt = f"{pygame.event.event_name(e.type)}: {e.dict}\n"
-                history += txt
-                history = "\n".join(history.split("\n")[-13:])
+                txt = f"{pygame.event.event_name(e.type)}: {e.dict}"
+                history.append(txt)
+                history = history[-13:]
 
             if e.type == pygame.VIDEORESIZE:
                 win = pygame.display.set_mode(e.size, pygame.RESIZABLE)

--- a/examples/eventlist.py
+++ b/examples/eventlist.py
@@ -101,7 +101,8 @@ def drawhistory(win, history):
     win.blit(img, (2, 132))
 
     img = font.render(history, 1, (50, 200, 50), (0, 0, 0))
-    win.blit(img, (10 , 250))
+    win.blit(img, (10, 250))
+
 
 def main():
     pygame.init()

--- a/examples/eventlist.py
+++ b/examples/eventlist.py
@@ -12,7 +12,7 @@ usage = """
 Mouse Controls
 ==============
 
-- 1st button on mouse (left click) to toggle events 'grabed'.
+- 1st button on mouse (left click) to toggle events 'grabbed'.
 - 3rd button on mouse (right click) to toggle mouse visible.
 - The window can be resized.
 - Mouse the mouse around to see mouse events.
@@ -99,23 +99,9 @@ def drawstatus(win):
 def drawhistory(win, history):
     img = font.render("Event History Area", 1, (155, 155, 155), (0, 0, 0))
     win.blit(img, (2, 132))
-    ypos = 450
-    h = list(history)
-    h.reverse()
-    for line in h:
-        r = win.blit(line, (10, ypos))
-        win.fill(0, (r.right, r.top, 620, r.height))
-        ypos -= font.get_height()
 
-
-def draw_usage_in_history(history, text):
-    lines = text.split("\n")
-    for line in lines:
-        if line == "" or "===" in line:
-            continue
-        img = font.render(line, 1, (50, 200, 50), (0, 0, 0))
-        history.append(img)
-
+    img = font.render(history, 1, (50, 200, 50), (0, 0, 0))
+    win.blit(img, (10 , 250))
 
 def main():
     pygame.init()
@@ -131,23 +117,22 @@ def main():
     img_on_off.append(font.render("Off", 1, (0, 0, 0), (255, 50, 50)))
     img_on_off.append(font.render("On", 1, (0, 0, 0), (50, 255, 50)))
 
-    # stores surfaces of text representing what has gone through the event queue
-    history = []
+    # stores multiline text representing what has gone through the event queue
+    history = ""
 
     # let's turn on the joysticks just so we can play with em
     for x in range(pygame.joystick.get_count()):
         if SDL2 and pygame._sdl2.controller.is_controller(x):
             c = pygame._sdl2.controller.Controller(x)
-            txt = "Enabled controller: " + c.name
+            txt = f"Enabled controller: {c.name}\n"
         else:
             j = pygame.joystick.Joystick(x)
-            txt = "Enabled joystick: " + j.get_name()
+            txt = f"Enabled joystick: {j.get_name()}\n"
 
-        img = font.render(txt, 1, (50, 200, 50), (0, 0, 0))
-        history.append(img)
+        history += txt
+
     if not pygame.joystick.get_count():
-        img = font.render("No Joysticks to Initialize", 1, (50, 200, 50), (0, 0, 0))
-        history.append(img)
+        history += "No Joysticks to Initialize\n"
 
     going = True
     while going:
@@ -159,7 +144,7 @@ def main():
                     global last_key
                     last_key = e.key
                 if e.key == pygame.K_h:
-                    draw_usage_in_history(history, usage)
+                    history += usage.strip().replace("=", "").replace("\n\n", "")
                 if SDL2 and e.key == pygame.K_c:
                     current_state = pygame._sdl2.controller.get_eventstate()
                     pygame._sdl2.controller.set_eventstate(not current_state)
@@ -171,10 +156,9 @@ def main():
                 pygame.mouse.set_visible(not pygame.mouse.get_visible())
 
             if e.type != pygame.MOUSEMOTION:
-                txt = f"{pygame.event.event_name(e.type)}: {e.dict}"
-                img = font.render(txt, 1, (50, 200, 50), (0, 0, 0))
-                history.append(img)
-                history = history[-13:]
+                txt = f"{pygame.event.event_name(e.type)}: {e.dict}\n"
+                history += txt
+                history = "\n".join(history.split("\n")[-13:])
 
             if e.type == pygame.VIDEORESIZE:
                 win = pygame.display.set_mode(e.size, pygame.RESIZABLE)

--- a/examples/eventlist.py
+++ b/examples/eventlist.py
@@ -100,7 +100,7 @@ def drawhistory(win, history):
     img = font.render("Event History Area", 1, (155, 155, 155), (0, 0, 0))
     win.blit(img, (2, 132))
 
-    img = font.render(history, 1, (50, 200, 50), (0, 0, 0))
+    img = font.render(history, 1, (50, 200, 50), (0, 0, 0), wraplength=640)
     win.blit(img, (10, 250))
 
 


### PR DESCRIPTION
Instead of a list, history is now a string that will contain the multine text. The for loops have been replaced with a single font.render call. Also did some string operations for properly showing the "usage" text and to only display the last -13 elements. As you can see the pace between lines has become a bit bigger due to not manually setting the lines' position)

![Before after eventlist](https://github.com/pygame-community/pygame-ce/assets/48393245/ca526abc-2754-496c-8d7f-40c984afd93a)
