### PR TITLE
fix search page green background in dark theme

### DIFF
--- a/docs/reST/themes/classic/static/pygame.css_t
+++ b/docs/reST/themes/classic/static/pygame.css_t
@@ -76,12 +76,20 @@ body {
     color: {{ theme_textcolor }};
     font-style: normal;
     font-family: {{ theme_bodyfont }};
+    background-color: {{ theme_dark_bgcolor2 }};
     text-decoration: none;
     text-align: left;
     border-style: none;
+    min-height: 100%;
+    display: flex;
+    flex-direction: column;
 }
 html {
     background-color: {{ theme_bgcolor }};
+    height: 100vh;
+}
+html.dark-theme {
+    background-color: {{ theme_dark_bgcolor }};
 }
 html.dark-theme body {
     color: {{ theme_dark_textcolor }};
@@ -249,6 +257,7 @@ input[type="submit"]{
 div.document {
     background-color: {{ theme_bgcolor }};
     overflow: hidden;
+    flex-grow: 1
 }
 .dark-theme div.document {
     background-color: {{ theme_dark_bgcolor }};

--- a/docs/reST/themes/classic/theme.conf
+++ b/docs/reST/themes/classic/theme.conf
@@ -23,6 +23,7 @@ dark_relbarbgcolor          = #141414
 dark_relbartextcolor        = #00ba10
 dark_relbarlinkcolor        = #00ba10
 dark_bgcolor                = #1E1E1E
+dark_bgcolor2               = #141414
 dark_textcolor              = #EEEEEE
 dark_headbgcolor            = #f2f2f2
 dark_headtextcolor          = #20435c


### PR DESCRIPTION
fixes the weird bug that @yunline reported
![image](https://github.com/pygame-community/pygame-ce/assets/71970100/75772a95-d162-436c-b1ee-c11e815cb574)

Here's how it looks currently 
![image](https://github.com/pygame-community/pygame-ce/assets/71970100/882d93bb-79f3-4261-832c-06693b4d8549)

here's the light theme version: 
![image](https://github.com/pygame-community/pygame-ce/assets/71970100/1c848f26-ec51-43bd-9b19-479e41c7e5fd)
