### PR TITLE
Multiline examples

### DIFF
--- a/examples/dropevent.py
+++ b/examples/dropevent.py
@@ -42,7 +42,7 @@ def main():
             elif ev.type == pygame.DROPTEXT:
                 print(ev)
                 spr_file_text = font.render(
-                    ev.text, 1, (255, 255, 255), wraplength=screen_size[0] - 10
+                    ev.text, 1, 'white', 'black', screen_size[0] - 10
                 )
                 spr_file_text_rect = spr_file_text.get_rect()
                 spr_file_text_rect.center = surf.get_rect().center

--- a/examples/dropevent.py
+++ b/examples/dropevent.py
@@ -20,6 +20,7 @@ def main():
     screen_size = (640, 480)
     surf = pygame.display.set_mode(screen_size)
     font = pygame.font.SysFont("Arial", 24)
+    font.align = pygame.FONT_CENTER
     clock = pygame.Clock()
 
     spr_file_text = font.render("Feed me some file or image!", 1, (255, 255, 255))

--- a/examples/dropevent.py
+++ b/examples/dropevent.py
@@ -42,7 +42,7 @@ def main():
             elif ev.type == pygame.DROPTEXT:
                 print(ev)
                 spr_file_text = font.render(
-                    ev.text, 1, 'white', 'black', screen_size[0] - 10
+                    ev.text, 1, (255, 255, 255), wraplength=screen_size[0] - 10
                 )
                 spr_file_text_rect = spr_file_text.get_rect()
                 spr_file_text_rect.center = surf.get_rect().center

--- a/examples/dropevent.py
+++ b/examples/dropevent.py
@@ -17,7 +17,8 @@ pygame.init()
 
 def main():
     Running = True
-    surf = pygame.display.set_mode((640, 480))
+    screen_size = (640, 480)
+    surf = pygame.display.set_mode(screen_size)
     font = pygame.font.SysFont("Arial", 24)
     clock = pygame.Clock()
 
@@ -40,12 +41,16 @@ def main():
                 print("File drop complete!")
             elif ev.type == pygame.DROPTEXT:
                 print(ev)
-                spr_file_text = font.render(ev.text, 1, (255, 255, 255))
+                spr_file_text = font.render(
+                    ev.text, 1, (255, 255, 255), wraplength=screen_size[0] - 10
+                )
                 spr_file_text_rect = spr_file_text.get_rect()
                 spr_file_text_rect.center = surf.get_rect().center
             elif ev.type == pygame.DROPFILE:
                 print(ev)
-                spr_file_text = font.render(ev.file, 1, (255, 255, 255))
+                spr_file_text = font.render(
+                    ev.file, 1, (255, 255, 255), None, screen_size[0] - 10
+                )
                 spr_file_text_rect = spr_file_text.get_rect()
                 spr_file_text_rect.center = surf.get_rect().center
 

--- a/examples/font_viewer.py
+++ b/examples/font_viewer.py
@@ -100,7 +100,13 @@ class FontViewer:
         # display instructions at the top of the display
         font = pygame.font.SysFont(pygame.font.get_default_font(), font_size)
         instructions = f"Use the scroll wheel or click and drag to scroll up and down.  Fonts that don't use the Latin Alphabet might render incorrectly.  Here are your {len(fonts)} fonts"
-        surf = font.render(instructions, True, instruction_color, self.back_color, self.screen_size[0] - 20)
+        surf = font.render(
+            instructions,
+            True,
+            instruction_color,
+            self.back_color,
+            self.screen_size[0] - 20,
+        )
         font_surfaces.append((surf, total_height))
         total_height += surf.get_height() + padding
         max_width = max(max_width, surf.get_width())
@@ -113,7 +119,9 @@ class FontViewer:
                 continue
             line = text.replace("&N", name)
             try:
-                surf = font.render(line, 1, color, self.back_color, self.screen_size[0] - 20)
+                surf = font.render(
+                    line, 1, color, self.back_color, self.screen_size[0] - 20
+                )
             except pygame.error as e:
                 print(e)
                 break

--- a/examples/font_viewer.py
+++ b/examples/font_viewer.py
@@ -99,7 +99,12 @@ class FontViewer:
         # display instructions at the top of the display
         font = pygame.font.SysFont(pygame.font.get_default_font(), font_size)
         font.align = pygame.FONT_CENTER
-        instructions = f"Use the scroll wheel or click and drag to scroll up and down.  Fonts that don't use the Latin Alphabet might render incorrectly.  Here are your {len(fonts)} fonts"
+        instructions = (
+            "Use the scroll wheel or click and drag to scroll up "
+            "and down.  Fonts that don't use the Latin Alphabet "
+            "might render incorrectly.  Here are your "
+            f"{len(fonts)} fonts"
+        )
         surf = font.render(
             instructions,
             True,
@@ -155,7 +160,7 @@ class FontViewer:
                     bottom >= self.y_offset
                     and top <= self.y_offset + display.get_height()
                 ):
-                    x = (display.get_width() - surface.get_width()) // 2
+                    x = center - surface.get_width() / 2
                     display.blit(surface, (x, top - self.y_offset))
             # get input and update the screen
             if not self.handle_events():

--- a/examples/font_viewer.py
+++ b/examples/font_viewer.py
@@ -93,12 +93,12 @@ class FontViewer:
         font_surfaces = []
         total_height = 0
         max_width = 0
-        padding = font_size // 2
 
         load_font = pygame.Font if path else pygame.font.SysFont
 
         # display instructions at the top of the display
         font = pygame.font.SysFont(pygame.font.get_default_font(), font_size)
+        font.align = pygame.FONT_CENTER
         instructions = f"Use the scroll wheel or click and drag to scroll up and down.  Fonts that don't use the Latin Alphabet might render incorrectly.  Here are your {len(fonts)} fonts"
         surf = font.render(
             instructions,
@@ -108,7 +108,7 @@ class FontViewer:
             self.screen_size[0] - 20,
         )
         font_surfaces.append((surf, total_height))
-        total_height += surf.get_height() + padding
+        total_height += surf.get_height()
         max_width = max(max_width, surf.get_width())
 
         # render all the fonts and store them with the total height
@@ -128,7 +128,7 @@ class FontViewer:
 
             max_width = max(max_width, surf.get_width())
             font_surfaces.append((surf, total_height))
-            total_height += surf.get_height() + padding
+            total_height += surf.get_height()
 
         # store variables for later usage
         self.total_height = total_height
@@ -155,7 +155,8 @@ class FontViewer:
                     bottom >= self.y_offset
                     and top <= self.y_offset + display.get_height()
                 ):
-                    display.blit(surface, (10, top - self.y_offset))
+                    x = (display.get_width() - surface.get_width()) // 2
+                    display.blit(surface, (x, top - self.y_offset))
             # get input and update the screen
             if not self.handle_events():
                 break

--- a/examples/font_viewer.py
+++ b/examples/font_viewer.py
@@ -45,10 +45,9 @@ class FontViewer:
 
         # create a window that uses 80 percent of the screen
         info = pygame.display.Info()
-        w = info.current_w
-        h = info.current_h
-        pygame.display.set_mode((int(w * 0.8), int(h * 0.8)))
-        self.font_size = h // 20
+        self.screen_size = (int(info.current_w * 0.8), int(info.current_h * 0.8))
+        pygame.display.set_mode(self.screen_size)
+        self.font_size = self.screen_size[1] // 16
 
         self.clock = pygame.Clock()
         self.y_offset = 0
@@ -94,24 +93,17 @@ class FontViewer:
         font_surfaces = []
         total_height = 0
         max_width = 0
+        padding = font_size // 2
 
         load_font = pygame.Font if path else pygame.font.SysFont
 
         # display instructions at the top of the display
         font = pygame.font.SysFont(pygame.font.get_default_font(), font_size)
-        lines = (
-            "Use the scroll wheel or click and drag",
-            "to scroll up and down.",
-            "Fonts that don't use the Latin Alphabet",
-            "might render incorrectly.",
-            f"Here are your {len(fonts)} fonts",
-            "",
-        )
-        for line in lines:
-            surf = font.render(line, 1, instruction_color, self.back_color)
-            font_surfaces.append((surf, total_height))
-            total_height += surf.get_height()
-            max_width = max(max_width, surf.get_width())
+        instructions = f"Use the scroll wheel or click and drag to scroll up and down.  Fonts that don't use the Latin Alphabet might render incorrectly.  Here are your {len(fonts)} fonts"
+        surf = font.render(instructions, True, instruction_color, self.back_color, self.screen_size[0] - 20)
+        font_surfaces.append((surf, total_height))
+        total_height += surf.get_height() + padding
+        max_width = max(max_width, surf.get_width())
 
         # render all the fonts and store them with the total height
         for name in sorted(fonts):
@@ -121,14 +113,14 @@ class FontViewer:
                 continue
             line = text.replace("&N", name)
             try:
-                surf = font.render(line, 1, color, self.back_color)
+                surf = font.render(line, 1, color, self.back_color, self.screen_size[0] - 20)
             except pygame.error as e:
                 print(e)
                 break
 
             max_width = max(max_width, surf.get_width())
             font_surfaces.append((surf, total_height))
-            total_height += surf.get_height()
+            total_height += surf.get_height() + padding
 
         # store variables for later usage
         self.total_height = total_height
@@ -155,8 +147,7 @@ class FontViewer:
                     bottom >= self.y_offset
                     and top <= self.y_offset + display.get_height()
                 ):
-                    x = center - surface.get_width() // 2
-                    display.blit(surface, (x, top - self.y_offset))
+                    display.blit(surface, (10, top - self.y_offset))
             # get input and update the screen
             if not self.handle_events():
                 break

--- a/examples/joystick.py
+++ b/examples/joystick.py
@@ -72,48 +72,48 @@ def main():
         for joystick in joysticks.values():
             jid = joystick.get_instance_id()
 
-            lines.append(indent("Joystick {jid}", indentation))
+            lines.append(indent(f"Joystick {jid}", indentation))
             indentation += 1
 
             # Get the name from the OS for the controller/joystick.
             name = joystick.get_name()
-            lines.append(indent("Joystick name: {name}", indentation))
+            lines.append(indent(f"Joystick name: {name}", indentation))
 
             guid = joystick.get_guid()
-            lines.append(indent("GUID: {guid}"))
+            lines.append(indent(f"GUID: {guid}", indentation))
 
             power_level = joystick.get_power_level()
-            lines.append(indent("Joystick's power level: {power_level}", indentation))
+            lines.append(indent(f"Joystick's power level: {power_level}", indentation))
 
             # Usually axis run in pairs, up/down for one, and left/right for
             # the other. Triggers count as axes.
             axes = joystick.get_numaxes()
-            lines.append(indent("Number of axes: {axes}", indentation))
+            lines.append(indent(f"Number of axes: {axes}", indentation))
             indentation += 1
 
             for i in range(axes):
                 axis = joystick.get_axis(i)
-                lines.append(indent("Axis {i} value: {axis:>6.3f}", indentation))
+                lines.append(indent(f"Axis {i} value: {axis:>6.3f}", indentation))
             indentation -= 1
 
             buttons = joystick.get_numbuttons()
-            lines.append(indent("Number of buttons: {buttons}", indentation))
+            lines.append(indent(f"Number of buttons: {buttons}", indentation))
             indentation += 1
 
             for i in range(buttons):
                 button = joystick.get_button(i)
-                lines.append(indent("Button {i:>2} value: {button}", indentation))
+                lines.append(indent(f"Button {i:>2} value: {button}", indentation))
             indentation -= 1
 
             hats = joystick.get_numhats()
-            lines.append(indent("Number of hats: {hats}", indentation))
+            lines.append(indent(f"Number of hats: {hats}", indentation))
             indentation += 1
 
             # Hat position. All or nothing for direction, not a float like
             # get_axis(). Position is a tuple of int values (x, y).
             for i in range(hats):
                 hat = joystick.get_hat(i)
-                lines.append(indent("Hat {i} value: {str(hat)}", indentation))
+                lines.append(indent(f"Hat {i} value: {str(hat)}", indentation))
             indentation -= 2
 
         # draw the accumulated text

--- a/examples/joystick.py
+++ b/examples/joystick.py
@@ -18,7 +18,7 @@ def main():
 
     # Get ready to print.
     font = pygame.font.SysFont(None, 25)
-    wraplength = size[1] - 20
+    wraplength = size[0] - 20
 
     # This dict can be left as-is, since pygame-ce will generate a
     # pygame.JOYDEVICEADDED event for every joystick connected

--- a/examples/joystick.py
+++ b/examples/joystick.py
@@ -119,7 +119,7 @@ def main():
         # draw the accumulated text
         lines = [indent(text, indentation_level) for indentation_level, text in lines]
         text = "\n".join(lines)
-        screen.blit(font.render(text, True, 'black', 'white', wraplength), (10, 10))
+        screen.blit(font.render(text, True, "black", "white", wraplength), (10, 10))
 
         # Go ahead and update the screen with what we've drawn.
         pygame.display.flip()

--- a/examples/joystick.py
+++ b/examples/joystick.py
@@ -3,41 +3,22 @@ import pygame
 pygame.init()
 
 
-# This is a simple class that will help us print to the screen.
-# It has nothing to do with the joysticks, just outputting the
-# information.
-class TextPrint:
-    def __init__(self):
-        self.reset()
-        self.font = pygame.Font(None, 25)
-
-    def tprint(self, screen, text):
-        text_bitmap = self.font.render(text, True, (0, 0, 0))
-        screen.blit(text_bitmap, (self.x, self.y))
-        self.y += self.line_height
-
-    def reset(self):
-        self.x = 10
-        self.y = 10
-        self.line_height = 15
-
-    def indent(self):
-        self.x += 10
-
-    def unindent(self):
-        self.x -= 10
+def indent(text, indentation_level=0):
+    return ("    " * indentation_level) + text
 
 
 def main():
-    # Set the width and height of the screen (width, height), and name the window.
-    screen = pygame.display.set_mode((500, 700))
+    # Set the size of the screen (width, height), and name the window.
+    size = (500, 700)
+    screen = pygame.display.set_mode(size)
     pygame.display.set_caption("Joystick example")
 
     # Used to manage how fast the screen updates.
     clock = pygame.Clock()
 
     # Get ready to print.
-    text_print = TextPrint()
+    font = pygame.font.SysFont(None, 25)
+    wraplength = size[1] - 20
 
     # This dict can be left as-is, since pygame-ce will generate a
     # pygame.JOYDEVICEADDED event for every joystick connected
@@ -79,63 +60,66 @@ def main():
         # First, clear the screen to white. Don't put other drawing commands
         # above this, or they will be erased with this command.
         screen.fill((255, 255, 255))
-        text_print.reset()
+        indentation = 0
+        lines = []
 
         # Get count of joysticks.
         joystick_count = pygame.joystick.get_count()
-
-        text_print.tprint(screen, f"Number of joysticks: {joystick_count}")
-        text_print.indent()
+        lines.append((indentation, f"Number of joysticks: {joystick_count}"))
+        indentation += 1
 
         # For each joystick:
         for joystick in joysticks.values():
             jid = joystick.get_instance_id()
 
-            text_print.tprint(screen, f"Joystick {jid}")
-            text_print.indent()
+            lines.append((indentation, f"Joystick {jid}"))
+            indentation += 1
 
             # Get the name from the OS for the controller/joystick.
             name = joystick.get_name()
-            text_print.tprint(screen, f"Joystick name: {name}")
+            lines.append((indentation, f"Joystick name: {name}"))
 
             guid = joystick.get_guid()
-            text_print.tprint(screen, f"GUID: {guid}")
+            lines.append((indentation, f"GUID: {guid}"))
 
             power_level = joystick.get_power_level()
-            text_print.tprint(screen, f"Joystick's power level: {power_level}")
+            lines.append((indentation, f"Joystick's power level: {power_level}"))
 
             # Usually axis run in pairs, up/down for one, and left/right for
             # the other. Triggers count as axes.
             axes = joystick.get_numaxes()
-            text_print.tprint(screen, f"Number of axes: {axes}")
-            text_print.indent()
+            lines.append((indentation, f"Number of axes: {axes}"))
+            indentation += 1
 
             for i in range(axes):
                 axis = joystick.get_axis(i)
-                text_print.tprint(screen, f"Axis {i} value: {axis:>6.3f}")
-            text_print.unindent()
+                lines.append((indentation, f"Axis {i} value: {axis:>6.3f}"))
+            indentation -= 1
 
             buttons = joystick.get_numbuttons()
-            text_print.tprint(screen, f"Number of buttons: {buttons}")
-            text_print.indent()
+            lines.append((indentation, f"Number of buttons: {buttons}"))
+            indentation += 1
 
             for i in range(buttons):
                 button = joystick.get_button(i)
-                text_print.tprint(screen, f"Button {i:>2} value: {button}")
-            text_print.unindent()
+                lines.append((indentation, f"Button {i:>2} value: {button}"))
+            indentation -= 1
 
             hats = joystick.get_numhats()
-            text_print.tprint(screen, f"Number of hats: {hats}")
-            text_print.indent()
+            lines.append((indentation, f"Number of hats: {hats}"))
+            indentation += 1
 
             # Hat position. All or nothing for direction, not a float like
             # get_axis(). Position is a tuple of int values (x, y).
             for i in range(hats):
                 hat = joystick.get_hat(i)
-                text_print.tprint(screen, f"Hat {i} value: {str(hat)}")
-            text_print.unindent()
+                lines.append((indentation, f"Hat {i} value: {str(hat)}"))
+            indentation -= 2
 
-            text_print.unindent()
+        # draw the accumulated text
+        lines = [indent(text, indentation_level) for indentation_level, text in lines]
+        text = "\n".join(lines)
+        screen.blit(font.render(text, True, 'black', 'white', wraplength), (10, 10))
 
         # Go ahead and update the screen with what we've drawn.
         pygame.display.flip()

--- a/examples/joystick.py
+++ b/examples/joystick.py
@@ -65,61 +65,61 @@ def main():
 
         # Get count of joysticks.
         joystick_count = pygame.joystick.get_count()
-        lines.append((indentation, f"Number of joysticks: {joystick_count}"))
+        lines.append(indent("Number of joysticks: {joystick_count}", indentation))
         indentation += 1
 
         # For each joystick:
         for joystick in joysticks.values():
             jid = joystick.get_instance_id()
 
-            lines.append((indentation, f"Joystick {jid}"))
+            lines.append(indent("Joystick {jid}", indentation))
             indentation += 1
 
             # Get the name from the OS for the controller/joystick.
             name = joystick.get_name()
-            lines.append((indentation, f"Joystick name: {name}"))
+            lines.append(indent("Joystick name: {name}", indentation))
 
             guid = joystick.get_guid()
-            lines.append((indentation, f"GUID: {guid}"))
+            lines.append(indent("GUID: {guid}"))
 
             power_level = joystick.get_power_level()
-            lines.append((indentation, f"Joystick's power level: {power_level}"))
+            lines.append(indent("Joystick's power level: {power_level}", indentation))
 
             # Usually axis run in pairs, up/down for one, and left/right for
             # the other. Triggers count as axes.
             axes = joystick.get_numaxes()
-            lines.append((indentation, f"Number of axes: {axes}"))
+            lines.append(indent("Number of axes: {axes}", indentation))
             indentation += 1
 
             for i in range(axes):
                 axis = joystick.get_axis(i)
-                lines.append((indentation, f"Axis {i} value: {axis:>6.3f}"))
+                lines.append(indent("Axis {i} value: {axis:>6.3f}", indentation))
             indentation -= 1
 
             buttons = joystick.get_numbuttons()
-            lines.append((indentation, f"Number of buttons: {buttons}"))
+            lines.append(indent("Number of buttons: {buttons}", indentation))
             indentation += 1
 
             for i in range(buttons):
                 button = joystick.get_button(i)
-                lines.append((indentation, f"Button {i:>2} value: {button}"))
+                lines.append(indent("Button {i:>2} value: {button}", indentation))
             indentation -= 1
 
             hats = joystick.get_numhats()
-            lines.append((indentation, f"Number of hats: {hats}"))
+            lines.append(indent("Number of hats: {hats}", indentation))
             indentation += 1
 
             # Hat position. All or nothing for direction, not a float like
             # get_axis(). Position is a tuple of int values (x, y).
             for i in range(hats):
                 hat = joystick.get_hat(i)
-                lines.append((indentation, f"Hat {i} value: {str(hat)}"))
+                lines.append(indent("Hat {i} value: {str(hat)}", indentation))
             indentation -= 2
 
         # draw the accumulated text
-        lines = [indent(text, indentation_level) for indentation_level, text in lines]
-        text = "\n".join(lines)
-        screen.blit(font.render(text, True, "black", "white", wraplength), (10, 10))
+        screen.blit(
+            font.render("\n".join(lines), True, "black", "white", wraplength), (10, 10)
+        )
 
         # Go ahead and update the screen with what we've drawn.
         pygame.display.flip()

--- a/examples/music_drop_fade.py
+++ b/examples/music_drop_fade.py
@@ -19,7 +19,18 @@ import pygame
 import os, sys
 
 VOLUME_CHANGE_AMOUNT = 0.02  # how fast should up and down arrows change the volume?
+SCREEN_SIZE = (640, 480)
 
+MUSIC_DONE = pygame.event.custom_type()  # event to be set as mixer.music.set_endevent()
+main_dir = os.path.split(os.path.abspath(__file__))[0]
+data_dir = os.path.join(main_dir, "data")
+
+starting_pos = 0  # needed to fast forward and rewind
+volume = 0.75
+music_file_list = []
+music_file_types = ("mp3", "ogg", "mid", "mod", "it", "xm", "wav")
+music_can_seek = ("mp3", "ogg", "mod", "it", "xm")
+screen = None
 
 def add_file(filename):
     """
@@ -108,19 +119,6 @@ def play_next():
         starting_pos = -1
 
 
-def draw_text_line(text, y=0):
-    """
-    Draws a line of text onto the display surface
-    The text will be centered horizontally at the given y position
-    The text's height is added to y and returned to the caller
-    """
-    screen = pygame.display.get_surface()
-    surf = font.render(text, 1, (255, 255, 255))
-    y += surf.get_height()
-    x = (screen.get_width() - surf.get_width()) / 2
-    screen.blit(surf, (x, y))
-    return y
-
 
 def change_music_position(amount):
     """
@@ -140,20 +138,10 @@ def change_music_position(amount):
         print(f"jumped from {old_pos} to {starting_pos}")
 
 
-MUSIC_DONE = pygame.event.custom_type()  # event to be set as mixer.music.set_endevent()
-main_dir = os.path.split(os.path.abspath(__file__))[0]
-data_dir = os.path.join(main_dir, "data")
-
-starting_pos = 0  # needed to fast forward and rewind
-volume = 0.75
-music_file_list = []
-music_file_types = ("mp3", "ogg", "mid", "mod", "it", "xm", "wav")
-music_can_seek = ("mp3", "ogg", "mod", "it", "xm")
-
-
 def main():
     global font  # this will be used by the draw_text_line function
     global volume, starting_pos
+    global screen
     running = True
     paused = False
 
@@ -163,7 +151,7 @@ def main():
     change_volume = 0
 
     pygame.init()
-    pygame.display.set_mode((640, 480))
+    screen = pygame.display.set_mode(SCREEN_SIZE)
     font = pygame.font.SysFont("Arial", 24)
     clock = pygame.Clock()
 
@@ -177,14 +165,17 @@ def main():
     play_file("house_lo.ogg")  # play default music included with pygame
 
     # draw instructions on screen
-    y = draw_text_line("Drop music files or path names onto this window", 20)
-    y = draw_text_line("Copy file names into the clipboard", y)
-    y = draw_text_line("Or feed them from the command line", y)
-    y = draw_text_line("If it's music it will play!", y)
-    y = draw_text_line("SPACE to pause or UP/DOWN to change volume", y)
-    y = draw_text_line("LEFT and RIGHT will skip around the track", y)
-    draw_text_line("Other keys will start the next track", y)
+    text = """
+Drop music files or path names onto this window
+Copy file names into the clipboard
+Or feed them from the command line
+If it's music it will play!
 
+LEFT and RIGHT will skip around the track
+UP and DOWN will change volume
+ENTER or SPACE will pause/unpause the track
+Other keys will start the next track"""
+    screen.blit(font.render(text, True, 'white', 'black', SCREEN_SIZE[0] - 20), (10, 5))
     """
     This is the main loop
     It will respond to drag and drop, clipboard changes, and key presses

--- a/examples/music_drop_fade.py
+++ b/examples/music_drop_fade.py
@@ -32,6 +32,7 @@ music_file_types = ("mp3", "ogg", "mid", "mod", "it", "xm", "wav")
 music_can_seek = ("mp3", "ogg", "mod", "it", "xm")
 screen = None
 
+
 def add_file(filename):
     """
     This function will check if filename exists and is a music file
@@ -119,7 +120,6 @@ def play_next():
         starting_pos = -1
 
 
-
 def change_music_position(amount):
     """
     Changes current playback position by amount seconds.
@@ -175,7 +175,7 @@ LEFT and RIGHT will skip around the track
 UP and DOWN will change volume
 ENTER or SPACE will pause/unpause the track
 Other keys will start the next track"""
-    screen.blit(font.render(text, True, 'white', 'black', SCREEN_SIZE[0] - 20), (10, 5))
+    screen.blit(font.render(text, True, "white", "black", SCREEN_SIZE[0] - 20), (10, 5))
     """
     This is the main loop
     It will respond to drag and drop, clipboard changes, and key presses

--- a/examples/music_drop_fade.py
+++ b/examples/music_drop_fade.py
@@ -153,6 +153,7 @@ def main():
     pygame.init()
     screen = pygame.display.set_mode(SCREEN_SIZE)
     font = pygame.font.SysFont("Arial", 24)
+    font.align = pygame.FONT_CENTER
     clock = pygame.Clock()
 
     clipped = ""


### PR DESCRIPTION
This contains a commit for every example listed and not covered in issue #2206 except for playmus.  The default wrapping behaviour may not be desired for dropevent though:
![image](https://github.com/pygame-community/pygame-ce/assets/101531330/90ed9ce7-a772-4edd-9fdc-6b35e0f85015)
I tried not to change too much but the joystick example got the TextPrint class removed and the music fade example's constants and globals were put to the top (because I just could not wrap my head around the code else).  The font viewer is also left aligned now because multiline rendering does not center text.  I'm open to change this if necessary.