### PR TITLE
Possible optimization for blit functions

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2347,6 +2347,10 @@ surf_fblits(pgSurfaceObject *self, PyObject *const *args, Py_ssize_t nargs)
             dest_rect.w = src->w;
             dest_rect.h = src->h;
 
+            if (!SDL_HasIntersection(&dest_rect, &dest->clip_rect)) {
+                continue;
+            }
+
             /* Perform the blit */
             if (pgSurface_Blit(self, (pgSurfaceObject *)src_surf, &dest_rect,
                                NULL, blend_flags)) {

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1924,6 +1924,11 @@ surf_blit(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
     dest_rect.w = src_rect->w;
     dest_rect.h = src_rect->h;
 
+    if (!SDL_HasIntersection(&dest_rect, &dest->clip_rect)) {
+        dest_rect.w = dest_rect.h = 0;
+        return pgRect_New(&dest_rect);
+    }
+
     if (!blend_flags)
         blend_flags = 0;
 
@@ -2088,6 +2093,10 @@ surf_blits(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
         dest_rect.y = dy;
         dest_rect.w = src_rect->w;
         dest_rect.h = src_rect->h;
+
+        if (!SDL_HasIntersection(&dest_rect, &dest->clip_rect)) {
+            continue;
+        }
 
         if (special_flags) {
             if (!pg_IntFromObj(special_flags, &blend_flags)) {
@@ -2259,6 +2268,10 @@ surf_fblits(pgSurfaceObject *self, PyObject *const *args, Py_ssize_t nargs)
 
             dest_rect.w = src->w;
             dest_rect.h = src->h;
+
+            if (!SDL_HasIntersection(&dest_rect, &dest->clip_rect)) {
+                continue;
+            }
 
             /* Perform the blit */
             if (pgSurface_Blit(self, (pgSurfaceObject *)src_surf, &dest_rect,

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2112,6 +2112,13 @@ surf_blits(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
                 goto bliterror;
             }
             retrect = NULL; /* Clear to avoid double deref on errors */
+            Py_DECREF(srcobject);
+            Py_DECREF(argpos);
+            Py_XDECREF(argrect);
+            srcobject = NULL;
+            argpos = NULL;
+            argrect = NULL;
+            continue;
         }
 
         if (special_flags) {
@@ -2150,6 +2157,7 @@ surf_blits(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
             }
             retrect = NULL; /* Clear to avoid double deref on errors */
         }
+
         Py_DECREF(srcobject);
         Py_DECREF(argpos);
         Py_XDECREF(argrect);

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2095,7 +2095,23 @@ surf_blits(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
         dest_rect.h = src_rect->h;
 
         if (!SDL_HasIntersection(&dest_rect, &dest->clip_rect)) {
-            continue;
+            if (!doreturn)
+                continue;
+            dest_rect.w = dest_rect.h = 0;
+            retrect = pgRect_New(&dest_rect);
+            if (issequence) {
+                PyList_SET_ITEM(ret, curriter++, retrect);
+            }
+            else if (PyList_Append(ret, retrect) != -1) {
+                Py_DECREF(retrect);
+            }
+            else {
+                Py_DECREF(retrect);
+                retrect = NULL;
+                bliterrornum = BLITS_ERR_PY_EXCEPTION_RAISED;
+                goto bliterror;
+            }
+            retrect = NULL; /* Clear to avoid double deref on errors */
         }
 
         if (special_flags) {


### PR DESCRIPTION
Today I remembered of a comment made on discord, this one:
![image](https://github.com/pygame-community/pygame-ce/assets/103119829/94091081-185b-49f4-b8b3-064c1581ba69)
and thought that maybe there was something weird going on with blit rect clipping. Ran an ultra quick check and wanted to test something: adding a rect collision test between the destination rect and the surface clip_rect. While this seemed to work there might be better ways to do this, but i didn't have the time to check the actual blit function. This is also true for blits.

EDIT: i remade the test program to make it more compact and clearer, so i also had to change the results shown.
```Python
import pygame
from timeit import repeat
from statistics import mean


pygame.init()
WIDTH, HEIGHT = 400, 400
win = pygame.display.set_mode((WIDTH, HEIGHT))

surf = pygame.Surface((WIDTH, HEIGHT))
surf.fill((255, 0, 0))

lst_inside = [
    (surf, (350, 350)) for _ in range(1000)
]

lst_outside = [
    (surf, (1000, 1000)) for _ in range(1000)
]

G = globals()

def test(name: str, number=1000, rep=10) -> float:
    return mean(repeat(name, globals=G, number=number, repeat=rep))


print("fblits - outside", test("win.fblits(lst_outside)"))
print("blits - outside", test("win.blits(lst_outside)"))
print("blit - outside", test("win.blit(surf, (1000, 1000))"))
print()
print("fblits - inside", test("win.fblits(lst_inside)"))
print("blits - inside", test("win.blits(lst_inside)"))
print("blit - inside", test("win.blit(surf, (350, 350))"))
```

**WITH THE CHANGES**
```
fblits - outside 0.03345977000008134
blits - outside 0.10718321000003925
blit - outside 0.00023007999989204108

fblits - inside 0.6032612599999994
blits - inside 0.704143540000041
blit - inside 0.0008147099999405328
```
**MAIN**
```
fblits - outside 0.14072892000003775
blits - outside 0.208359400000154
blit - outside 0.00032422000003862195

fblits - inside 0.599861510000028
blits - inside 0.6935029799999939
blit - inside 0.0007882900000367954
```
So this change made not drawing shapes 4X faster and didn't slow down visible blits.