### PR TITLE
Try reverting PR #2088 to solve #2236

### DIFF
--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -76,7 +76,6 @@ mouse_get_pos(PyObject *self, PyObject *_null)
         if (sdlRenderer != NULL) {
             SDL_Rect vprect;
             float scalex, scaley;
-            int w, h;
 
             SDL_RenderGetScale(sdlRenderer, &scalex, &scaley);
             SDL_RenderGetViewport(sdlRenderer, &vprect);
@@ -84,19 +83,17 @@ mouse_get_pos(PyObject *self, PyObject *_null)
             x = (int)(x / scalex);
             y = (int)(y / scaley);
 
-            SDL_RenderGetLogicalSize(sdlRenderer, &w, &h);
-
             x -= vprect.x;
             y -= vprect.y;
 
             if (x < 0)
                 x = 0;
-            if (x >= w)
-                x = w - 1;
+            if (x >= vprect.w)
+                x = vprect.w - 1;
             if (y < 0)
                 y = 0;
-            if (y >= h)
-                y = h - 1;
+            if (y >= vprect.h)
+                y = vprect.h - 1;
         }
     }
 


### PR DESCRIPTION
This reverts commit 5924b0c6a8b9229edb1141904a2f314764a3bbee, reversing changes made to 16a17de867bb8957aac572f1dc808bb215c51640.

The problem is that sometimes SDL creates a renderer internally. So when we get a renderer, we can't assume that we created it (we can't assume we set the logical size in SCALED).

This could be fixed more legitimately adding a way to get the scaled renderer into the C api or something, but for the purposes of 2.3.0 I think we should just revert to the 2.2.1 status quo.