### PR TITLE
Fix segfault when rendering fonts

### DIFF
--- a/docs/reST/ref/font.rst
+++ b/docs/reST/ref/font.rst
@@ -57,6 +57,8 @@ solves no longer exists, it will likely be removed in the future.
 
    It is safe to call this function even if font is currently not initialized.
 
+   Previously created font objects will be invalid after the font module is quit.
+
    .. ## pygame.font.quit ##
 
 .. function:: get_init

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -61,6 +61,10 @@ PyFont_New(TTF_Font *);
 #define PyFont_Check(x) ((x)->ob_type == &PyFont_Type)
 
 static unsigned int current_ttf_generation = 0;
+
+#define PgFont_GenerationCheck(x) \
+    (((PyFontObject *)(x))->ttf_init_generation == current_ttf_generation)
+
 #if defined(BUILD_STATIC)
 // SDL_Init + TTF_Init()  are made in main before CPython process the module
 // inittab so the emscripten handler knows it will use SDL2 next cycle.
@@ -486,6 +490,10 @@ font_render(PyObject *self, PyObject *args, PyObject *kwds)
     const char *astring = "";
     int wraplength = 0;
 
+    if (!PgFont_GenerationCheck(self)) {
+        return RAISE(pgExc_SDLError, "Invalid font.");
+    }
+
     static char *kwlist[] = {"text",    "antialias",  "color",
                              "bgcolor", "wraplength", NULL};
 
@@ -610,6 +618,10 @@ font_size(PyObject *self, PyObject *text)
     int w, h;
     const char *string;
 
+    if (!PgFont_GenerationCheck(self)) {
+        return RAISE(pgExc_SDLError, "Invalid font.");
+    }
+
     if (PyUnicode_Check(text)) {
         PyObject *bytes = PyUnicode_AsEncodedString(text, "utf-8", "strict");
         int ecode;
@@ -663,6 +675,10 @@ font_metrics(PyObject *self, PyObject *textobj)
     Uint16 ch;
     PyObject *temp;
     int surrogate;
+
+    if (!PgFont_GenerationCheck(self)) {
+        return RAISE(pgExc_SDLError, "Invalid font.");
+    }
 
     if (PyUnicode_Check(textobj)) {
         obj = textobj;

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -491,7 +491,8 @@ font_render(PyObject *self, PyObject *args, PyObject *kwds)
     int wraplength = 0;
 
     if (!PgFont_GenerationCheck(self)) {
-        return RAISE(pgExc_SDLError, "Invalid font.");
+        return RAISE(pgExc_SDLError,
+                     "Invalid font (font module quit since font created)");
     }
 
     static char *kwlist[] = {"text",    "antialias",  "color",
@@ -619,7 +620,8 @@ font_size(PyObject *self, PyObject *text)
     const char *string;
 
     if (!PgFont_GenerationCheck(self)) {
-        return RAISE(pgExc_SDLError, "Invalid font.");
+        return RAISE(pgExc_SDLError,
+                     "Invalid font (font module quit since font created)");
     }
 
     if (PyUnicode_Check(text)) {
@@ -677,7 +679,8 @@ font_metrics(PyObject *self, PyObject *textobj)
     int surrogate;
 
     if (!PgFont_GenerationCheck(self)) {
-        return RAISE(pgExc_SDLError, "Invalid font.");
+        return RAISE(pgExc_SDLError,
+                     "Invalid font (font module quit since font created)");
     }
 
     if (PyUnicode_Check(textobj)) {


### PR DESCRIPTION
Fixes: #1506
**Test code:**
```py
import pygame

pygame.init()
font = pygame.font.Font(None, 40)

pygame.quit()
pygame.init()

font.render("hello", True, "white")
#font.size("hello")
#font.metrics("hello")
```
Now it will raise an error instead of segfault
```
pygame-ce 2.3.1.dev1 (SDL 2.26.4, Python 3.10.6)
Traceback (most recent call last):
  File "x:\python\pygame_test\segfault.py", line 10, in <module>
    font.render("hello", True, "white")
pygame.error: Invalid font.
```