### PR TITLE
Improved `blits()` docs

### DIFF
--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -133,22 +133,54 @@
    .. method:: blits
 
       | :sl:`draw many images onto another`
-      | :sg:`blits(blit_sequence=((source, dest), ...), doreturn=1) -> [Rect, ...] or None`
+      | :sg:`blits(blit_sequence=((source, dest), ...), doreturn=True) -> [Rect, ...] or None`
       | :sg:`blits(((source, dest, area), ...)) -> [Rect, ...]`
       | :sg:`blits(((source, dest, area, special_flags), ...)) -> [Rect, ...]`
 
-      Draws many surfaces onto this Surface. It takes a sequence as input,
-      with each of the elements corresponding to the ones of :meth:`blit()`.
-      It needs at minimum a sequence of (source, dest).
+      The ``blits`` method efficiently draws a sequence of surfaces onto this ``Surface``.
 
-      :param blit_sequence: a sequence of surfaces and arguments to blit them,
-         they correspond to the :meth:`blit()` arguments
-      :param doreturn: if ``True``, return a list of rects of the areas changed,
-         otherwise return ``None``
+      **Parameters**
 
-      :returns: a list of rects of the areas changed if ``doreturn`` is
-         ``True``, otherwise ``None``
-      :rtype: list or None
+              - ``blit_sequence``: The sequence of surfaces to blit.
+              - ``doreturn``: (optional) Modifies the return value of the method.
+
+          The ``blit_sequence`` parameter is a sequence that contains each surface to be drawn
+          along with its associated blit arguments. See the **Sequence Item Formats** section below
+          for the possible formats.
+
+          The ``doreturn`` parameter controls the return value. When set to ``True``, it returns
+          a list of rectangles representing the changed areas. When set to ``False``, returns
+          ``None``.
+
+      **Return**
+
+          A list of rectangles or ``None``.
+
+      **Sequence Item Formats**
+
+          ``(source, dest)``
+            - ``source``: Surface object to be drawn.
+            - ``dest``: Position where the source Surface should be blitted.
+
+          ``(source, dest, area)``
+            - ``area``: (optional) Specific area of the source Surface to be drawn.
+
+          ``(source, dest, area, special_flags)``
+            - ``special_flags``: (optional) Controls the blending mode for drawing colors.
+
+      **Notes**
+
+          .. note:: ``blits`` is an advanced method. It is recommended to read the documentation
+                    of :meth:`blit` first.
+
+          .. note:: To draw a ``Surface`` with a special flag, you must specify an area as well, e.g.,
+                    ``(source, dest, None, special_flags)``.
+
+          .. note:: Prefer using :meth:`blits` over :meth:`blit` when drawing a multiple images
+                    for better performance. Use :meth:`blit` if you need to draw a single image.
+
+          .. note:: For drawing a sequence of (source, dest) pairs with whole source Surface
+                    and a singular special_flag, use the :meth:`fblits()` method.
 
       .. versionaddedold:: 1.9.4
 

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -141,14 +141,14 @@
 
       **Parameters**
 
-      ``blit_sequence``
-            A sequence that contains each surface to be drawn along with its associated blit
-            arguments. See the **Sequence Item Formats** section below for the possible formats.
+          ``blit_sequence``
+                A sequence that contains each surface to be drawn along with its associated blit
+                arguments. See the **Sequence Item Formats** section below for the possible formats.
 
-      ``doreturn`` (optional)
-            The ``doreturn`` parameter controls the return value. When set to ``True``, it returns
-            a list of rectangles representing the changed areas. When set to ``False``, returns
-            ``None``.
+          ``doreturn`` (optional)
+                The ``doreturn`` parameter controls the return value. When set to ``True``, it returns
+                a list of rectangles representing the changed areas. When set to ``False``, returns
+                ``None``.
 
       **Return**
 
@@ -156,15 +156,15 @@
 
       **Sequence Item Formats**
 
-      ``(source, dest)``
-        - ``source``: Surface object to be drawn.
-        - ``dest``: Position where the source Surface should be blitted.
+          ``(source, dest)``
+            - ``source``: Surface object to be drawn.
+            - ``dest``: Position where the source Surface should be blitted.
 
-      ``(source, dest, area)``
-        - ``area``: (optional) Specific area of the source Surface to be drawn.
+          ``(source, dest, area)``
+            - ``area``: (optional) Specific area of the source Surface to be drawn.
 
-      ``(source, dest, area, special_flags)``
-        - ``special_flags``: (optional) Controls the blending mode for drawing colors.
+          ``(source, dest, area, special_flags)``
+            - ``special_flags``: (optional) Controls the blending mode for drawing colors.
 
       **Notes**
 

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -141,16 +141,14 @@
 
       **Parameters**
 
-              - ``blit_sequence``: The sequence of surfaces to blit.
-              - ``doreturn``: (optional) Modifies the return value of the method.
+      ``blit_sequence``
+            A sequence that contains each surface to be drawn along with its associated blit
+            arguments. See the **Sequence Item Formats** section below for the possible formats.
 
-          The ``blit_sequence`` parameter is a sequence that contains each surface to be drawn
-          along with its associated blit arguments. See the **Sequence Item Formats** section below
-          for the possible formats.
-
-          The ``doreturn`` parameter controls the return value. When set to ``True``, it returns
-          a list of rectangles representing the changed areas. When set to ``False``, returns
-          ``None``.
+      ``doreturn`` (optional)
+            The ``doreturn`` parameter controls the return value. When set to ``True``, it returns
+            a list of rectangles representing the changed areas. When set to ``False``, returns
+            ``None``.
 
       **Return**
 
@@ -158,29 +156,29 @@
 
       **Sequence Item Formats**
 
-          ``(source, dest)``
-            - ``source``: Surface object to be drawn.
-            - ``dest``: Position where the source Surface should be blitted.
+      ``(source, dest)``
+        - ``source``: Surface object to be drawn.
+        - ``dest``: Position where the source Surface should be blitted.
 
-          ``(source, dest, area)``
-            - ``area``: (optional) Specific area of the source Surface to be drawn.
+      ``(source, dest, area)``
+        - ``area``: (optional) Specific area of the source Surface to be drawn.
 
-          ``(source, dest, area, special_flags)``
-            - ``special_flags``: (optional) Controls the blending mode for drawing colors.
+      ``(source, dest, area, special_flags)``
+        - ``special_flags``: (optional) Controls the blending mode for drawing colors.
 
       **Notes**
 
-          .. note:: ``blits`` is an advanced method. It is recommended to read the documentation
-                    of :meth:`blit` first.
+          - ``blits`` is an advanced method. It is recommended to read the documentation
+            of :meth:`blit` first.
 
-          .. note:: To draw a ``Surface`` with a special flag, you must specify an area as well, e.g.,
-                    ``(source, dest, None, special_flags)``.
+          - To draw a ``Surface`` with a special flag, you must specify an area as well, e.g.,
+            ``(source, dest, None, special_flags)``.
 
-          .. note:: Prefer using :meth:`blits` over :meth:`blit` when drawing a multiple images
-                    for better performance. Use :meth:`blit` if you need to draw a single image.
+          - Prefer using :meth:`blits` over :meth:`blit` when drawing a multiple images
+            for better performance. Use :meth:`blit` if you need to draw a single image.
 
-          .. note:: For drawing a sequence of (source, dest) pairs with whole source Surface
-                    and a singular special_flag, use the :meth:`fblits()` method.
+          - For drawing a sequence of (source, dest) pairs with whole source Surface
+            and a singular special_flag, use the :meth:`fblits()` method.
 
       .. versionaddedold:: 1.9.4
 

--- a/src_c/doc/surface_doc.h
+++ b/src_c/doc/surface_doc.h
@@ -1,7 +1,7 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_SURFACE "Surface((width, height), flags=0, depth=0, masks=None) -> Surface\nSurface((width, height), flags=0, Surface) -> Surface\npygame object for representing images"
 #define DOC_SURFACE_BLIT "blit(source, dest, area=None, special_flags=0) -> Rect\ndraw one image onto another"
-#define DOC_SURFACE_BLITS "blits(blit_sequence=((source, dest), ...), doreturn=1) -> [Rect, ...] or None\nblits(((source, dest, area), ...)) -> [Rect, ...]\nblits(((source, dest, area, special_flags), ...)) -> [Rect, ...]\ndraw many images onto another"
+#define DOC_SURFACE_BLITS "blits(blit_sequence=((source, dest), ...), doreturn=True) -> [Rect, ...] or None\nblits(((source, dest, area), ...)) -> [Rect, ...]\nblits(((source, dest, area, special_flags), ...)) -> [Rect, ...]\ndraw many images onto another"
 #define DOC_SURFACE_FBLITS "fblits(blit_sequence=((source, dest), ...), special_flags=0) -> None\ndraw many surfaces onto the calling surface at their corresponding location and the same special_flags"
 #define DOC_SURFACE_CONVERT "convert(Surface=None) -> Surface\nconvert(depth, flags=0) -> Surface\nconvert(masks, flags=0) -> Surface\nchange the pixel format of an image"
 #define DOC_SURFACE_CONVERTALPHA "convert_alpha(Surface) -> Surface\nconvert_alpha() -> Surface\nchange the pixel format of an image including per pixel alphas"


### PR DESCRIPTION
Follows #2259. This one aims to improve the `Surface.blits()` method docs.

**Added:**
- A better and more natural explaination of what the function parameters are and what they do.
- A thorough explaination of what each item in the blit_sequence can be composed of and its resulting behaviour.
- A series of notes regarding suggestions about its use/when not to use blits over blit or fblits.

**Removed:**
- The compact parameters version, as they weren't used extensively in the surface module and forced having shorter descriptions.

Before:
![image](https://github.com/pygame-community/pygame-ce/assets/103119829/4f3b160b-662b-48a1-8dff-33394f99abde)

After:
![image](https://github.com/pygame-community/pygame-ce/assets/103119829/9cf1c637-a68e-4f08-b003-1d09348f0550)
