### PR TITLE
Fix SysFont None issue

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -488,6 +488,8 @@ def SysFont(name, size, bold=False, italic=False, constructor=None):
                     f"found. {match_text}"
                     "Using the default font instead."
                 )
+    else:
+        fontname = None
 
     set_bold = set_italic = False
     if bold and not gotbold:

--- a/test/sysfont_test.py
+++ b/test/sysfont_test.py
@@ -29,6 +29,8 @@ class SysfontModuleTest(unittest.TestCase):
         arial = pygame.font.SysFont("Arial", 40)
         self.assertTrue(isinstance(arial, pygame.font.Font))
 
+        pygame.font.SysFont(None, 40)
+
     @unittest.skipIf(
         ("Darwin" in platform.platform() or "Windows" in platform.platform()),
         "Not unix we skip.",


### PR DESCRIPTION
In Pygame CE 2.3.0, a bug was introduced in which an error is raised by Pygame when initialising a `SysFont` object with `None` as shown below.

```py
font = pygame.font.SysFont(None, 40)
```

This PR fixes the problem, and adds a test for it. Apologies, the error was almost certainly introduced in my PR #2147. It might be worth pushing this fix out in a minor version.