### PR TITLE
Add window hiddenimport

### DIFF
--- a/src_py/__pyinstaller/hook-pygame.py
+++ b/src_py/__pyinstaller/hook-pygame.py
@@ -14,6 +14,10 @@ from pygame import __file__ as pygame_main_file
 # Get pygame's folder
 pygame_folder = os.path.dirname(os.path.abspath(pygame_main_file))
 
+# pygame._window is currently where the Window class lives. It is imported in
+# cython into _sdl2, which PyInstaller can't see.
+hiddenimports = ["pygame._window"]
+
 # datas is the variable that pyinstaller looks for while processing hooks
 datas = []
 


### PR DESCRIPTION
In #2114, the Window class was moved to a hidden C module.

When distributing with PyInstaller, this C module is not picked up, so any program that uses Window fails at runtime only after building.

The solution to this is to add it as a hiddenimport to our pyinstaller hook.