### PR TITLE
Update pixelformat to modern format, fix typos

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1515,7 +1515,7 @@ pg_list_modes(PyObject *self, PyObject *args, PyObject *kwds)
         }
         /* use reasonable defaults (cf. SDL_video.c) */
         if (!mode.format)
-            mode.format = SDL_PIXELFORMAT_RGB888;
+            mode.format = PG_PIXELFORMAT_XRGB8888;
         if (!mode.w)
             mode.w = 640;
         if (!mode.h)

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -622,12 +622,12 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
             pos_x = pos_y = PyLong_AsLong(position);
             if (pos_x != SDL_WINDOWPOS_CENTERED &&
                 pos_x != SDL_WINDOWPOS_UNDEFINED) {
-                PyErr_SetString(PyExc_TypeError, "invalid positon argument");
+                PyErr_SetString(PyExc_TypeError, "invalid position argument");
                 return -1;
             }
         }
         else if (!pg_TwoIntsFromObj(position, &pos_x, &pos_y)) {
-            PyErr_SetString(PyExc_TypeError, "invalid positon argument");
+            PyErr_SetString(PyExc_TypeError, "invalid position argument");
             return -1;
         }
     }

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1108,7 +1108,7 @@ class TestSurfaceBlit(unittest.TestCase):
         width = len(combinations)
 
         # masks explicitly specified so direct pixel access of bytes below is
-        # gauranteed to be stable
+        # guaranteed to be stable
         surf1 = pygame.Surface((width, 1), depth=32, masks=(0xFF0000, 0xFF00, 0xFF, 0))
         surf2 = pygame.Surface(
             (width, 1),


### PR DESCRIPTION
RGB888 is out in SDL3, so we should replace with PG_PIXELFORMAT_XRGB888. XRGB8888 == RGB888 in SDL2, macro exists because XRGB8888 doesn't exist in SDL2 < 2.0.14

Typos originally by me and Yunline :)
Typos found with codespell