### PR TITLE
Try building 3.12 wheels

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -88,7 +88,7 @@ jobs:
             name: "x86_64 (CPython 3.10 and above)",
             macarch: x86_64,
             # pattern matches any 2 digit number
-            pyversions: "cp3[1-9][0-9]-*",
+            pyversions: "cp3{10,11,12}-*",
             cibw_platform: "macosx-10.11-x86_64"
           }
 
@@ -117,7 +117,7 @@ jobs:
             name: "arm64 (CPython 3.8 and above)",
             macarch: arm64,
             # pattern matches any number from 8 to 99
-            pyversions: "cp3{8,9,[1-9][0-9]}-*",
+            pyversions: "cp3{8,9,10,11,12}-*",
             cibw_platform: "macosx-11.0-arm64"
           }
 
@@ -176,7 +176,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@v2.13.1
+        uses: pypa/cibuildwheel@v2.14.0
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -88,7 +88,7 @@ jobs:
             name: "x86_64 (CPython 3.10 and above)",
             macarch: x86_64,
             # pattern matches any 2 digit number
-            pyversions: "cp3{10,11,12}-*",
+            pyversions: "cp3[1-9][0-9]-*",
             cibw_platform: "macosx-10.11-x86_64"
           }
 
@@ -117,7 +117,7 @@ jobs:
             name: "arm64 (CPython 3.8 and above)",
             macarch: arm64,
             # pattern matches any number from 8 to 99
-            pyversions: "cp3{8,9,10,11,12}-*",
+            pyversions: "cp3{8,9,[1-9][0-9]}-*",
             cibw_platform: "macosx-11.0-arm64"
           }
 
@@ -131,6 +131,8 @@ jobs:
       # Tell CIBW that the wheel should be for 10.11
       # Related issue: https://github.com/pypa/cibuildwheel/issues/952
       _PYTHON_HOST_PLATFORM: ${{ matrix.cibw_platform }}
+
+      CIBW_PRERELEASE_PYTHONS: True # for 3.12 testing
 
       CIBW_BUILD: ${{ matrix.pyversions }}
 

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -54,7 +54,7 @@ jobs:
       # also define environment variables needed for testing
       CIBW_ENVIRONMENT: PIP_CONFIG_FILE=buildconfig/pip_config.ini PORTMIDI_INC_PORTTIME=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=disk
 
-      CIBW_BUILD: "cp3{[7-9],10,11}-* pp3[7-9]-*"
+      CIBW_BUILD: "cp3{[7-9],10,11,12}-* pp3[7-9]-*"
       CIBW_ARCHS: ${{ matrix.arch }}
 
       # skip musllinux for now
@@ -118,7 +118,7 @@ jobs:
         CIBW_MANYLINUX_I686_IMAGE: ghcr.io/${{ github.repository }}_i686:${{ steps.meta.outputs.version }}
         CIBW_MANYLINUX_PYPY_I686_IMAGE: ghcr.io/${{ github.repository }}_i686:${{ steps.meta.outputs.version }}
 
-      uses: pypa/cibuildwheel@v2.13.1
+      uses: pypa/cibuildwheel@v2.14.0
 
     # We upload the generated files under github actions assets
     - name: Upload dist

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -54,6 +54,8 @@ jobs:
       # also define environment variables needed for testing
       CIBW_ENVIRONMENT: PIP_CONFIG_FILE=buildconfig/pip_config.ini PORTMIDI_INC_PORTTIME=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=disk
 
+      CIBW_PRERELEASE_PYTHONS: True # for 3.12 testing
+
       CIBW_BUILD: "cp3{[7-9],10,11,12}-* pp3[7-9]-*"
       CIBW_ARCHS: ${{ matrix.arch }}
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -172,7 +172,7 @@ jobs:
           set MSSdk=1
           python -m pip install setuptools wheel requests numpy Sphinx
           python setup.py docs
-          python -m pip --disable-pip-version-check install cibuildwheel==2.12.0
+          python -m pip --disable-pip-version-check install cibuildwheel==${{ contains(matrix.pyversions, 37) && '2.13.1' || '2.14.0' }}
           python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -44,6 +44,12 @@ jobs:
       matrix:
         include:
           - {
+            name: "CPython 3.12 (64 bit)",
+            winarch: AMD64,
+            msvc-dev-arch: x86_amd64,
+            pyversions: "cp312-*"
+          }
+          - {
             name: "CPython 3.11 (64 bit)",
             winarch: AMD64,
             msvc-dev-arch: x86_amd64,
@@ -72,6 +78,12 @@ jobs:
             winarch: AMD64,
             msvc-dev-arch: x86_amd64,
             pyversions: "cp37-*"
+          }
+          - {
+            name: "CPython 3.12 (32 bit)",
+            winarch: x86,
+            msvc-dev-arch: x86,
+            pyversions: "cp312-win32*"
           }
           - {
             name: "CPython 3.11 (32 bit)",

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -141,6 +141,8 @@ jobs:
       # also define environment variables needed for testing
       CIBW_ENVIRONMENT: PIP_CONFIG_FILE=buildconfig/pip_config.ini SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=disk
 
+      CIBW_PRERELEASE_PYTHONS: True # for 3.12 testing
+
       CIBW_BUILD: ${{ matrix.pyversions }}
       CIBW_ARCHS: ${{ matrix.winarch }}
 

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -268,8 +268,12 @@ pg_EncodeFilePath(PyObject *obj, PyObject *eclass)
 
     /* End code replacement section */
 
+    if (obj == NULL) {
+        PyErr_SetString(PyExc_SyntaxError, "Forwarded exception");
+    }
+
     PyObject *result =
-        pg_EncodeString(obj, encoding, UNICODE_DEF_FS_ERROR, eclass);
+        pg_EncodeString(obj, "utf-8", UNICODE_DEF_FS_ERROR, eclass);
     Py_DECREF(system_encoding_obj);
     if (result == NULL || result == Py_None) {
         return result;
@@ -843,9 +847,6 @@ pg_encode_file_path(PyObject *self, PyObject *args, PyObject *keywds)
         return NULL;
     }
 
-    if (obj == NULL) {
-        PyErr_SetString(PyExc_SyntaxError, "Forwarded exception");
-    }
     return pg_EncodeFilePath(obj, eclass);
 }
 

--- a/test/rwobject_test.py
+++ b/test/rwobject_test.py
@@ -115,7 +115,7 @@ class RWopsEncodeFilePathTest(unittest.TestCase):
 
         self.assertIsInstance(encoded_file_path, bytes)
 
-    def test_error_fowarding(self):
+    def test_error_forwarding(self):
         self.assertRaises(SyntaxError, encode_file_path)
 
     def test_path_with_null_bytes(self):


### PR DESCRIPTION
Issues:
Mac build complains about Py_FileSystemDefaultEncoding being deprecated. Doesn't look easy to fix. (handling in #2315)

Windows build just needs the pip install cibuildwheel updated, but that will make it cease to work on Python 3.7 I think, so it needs to be conditional.

Mac CI full of warnings like
`  ld: warning: dylib (/usr/local/lib/libSDL2.dylib) was built for newer macOS version (10.11) than being linked (10.9)`
Looks like we need to set mac deployment target before CIBW execution as well as before dependency generation (handling in #2314)