### PR TITLE
Replace Py_FileSystemDefaultEncoding

### DIFF
--- a/docs/reST/ref/pygame.rst
+++ b/docs/reST/ref/pygame.rst
@@ -177,6 +177,8 @@ object instead of the module, which can be used to test for availability.
    This function is used in encoding file paths. Keyword arguments are
    supported.
 
+   This function is not needed for normal pygame-ce usage.
+
    .. versionaddedold:: 1.9.2 (primarily for use in unit tests)
 
    .. ## pygame.encode_string ##
@@ -196,6 +198,8 @@ object instead of the module, which can be used to test for availability.
    This function is used to encode file paths in pygame. Encoding is to the
    codec as returned by ``sys.getfilesystemencoding()``. Keyword arguments are
    supported.
+
+   This function is not needed for normal pygame-ce usage.
 
    .. versionaddedold:: 1.9.2 (primarily for use in unit tests)
 

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -243,8 +243,39 @@ pg_EncodeString(PyObject *obj, const char *encoding, const char *errors,
 static PyObject *
 pg_EncodeFilePath(PyObject *obj, PyObject *eclass)
 {
-    PyObject *result = pg_EncodeString(obj, Py_FileSystemDefaultEncoding,
-                                       UNICODE_DEF_FS_ERROR, eclass);
+    /* All of this code is a replacement for Py_FileSystemDefaultEncoding,
+     * which is deprecated in Python 3.12
+     *
+     * But I'm not sure of the use of this function, so maybe it should be
+     * deprecated. */
+
+    PyObject *sys_module = PyImport_ImportModule("sys");
+    if (sys_module == NULL) {
+        return NULL;
+    }
+    PyObject *system_encoding_obj =
+        PyObject_CallMethod(sys_module, "getfilesystemencoding", NULL);
+    if (system_encoding_obj == NULL) {
+        Py_DECREF(sys_module);
+        return NULL;
+    }
+    Py_DECREF(sys_module);
+    const char *encoding = PyUnicode_AsUTF8(system_encoding_obj);
+    if (encoding == NULL) {
+        Py_DECREF(system_encoding_obj);
+        return NULL;
+    }
+
+    /* End code replacement section */
+
+    if (obj == NULL) {
+        PyErr_SetString(PyExc_SyntaxError, "Forwarded exception");
+    }
+
+    PyObject *result =
+        pg_EncodeString(obj, encoding, UNICODE_DEF_FS_ERROR, eclass);
+    Py_DECREF(system_encoding_obj);
+
     if (result == NULL || result == Py_None) {
         return result;
     }
@@ -817,9 +848,6 @@ pg_encode_file_path(PyObject *self, PyObject *args, PyObject *keywds)
         return NULL;
     }
 
-    if (obj == NULL) {
-        PyErr_SetString(PyExc_SyntaxError, "Forwarded exception");
-    }
     return pg_EncodeFilePath(obj, eclass);
 }
 


### PR DESCRIPTION
It's deprecated in 3.12. So deprecated they've just removed it from the docs without leaving a notice of deprecation there.

Anyways, the 3.12 whatsnew page links Py_FileSystemDefaultEncoding to PyConfig.filesystem_encoding (which I don't understand how could be used to get the encoding), but which also links to sys.getfilesystemencoding (python code)

So my approach was just to replace it with a C-API call to `sys.getfilesystemencoding`
Also had to relocate this SyntaxError setter to after the error flag would get reset by my new C API calls

I'm unsure if the function `pygame.encode_file_path` is even being used by anyone or whether it's useful, so maybe it should be deprecated and eventually removed. But the purpose of this PR is just to get wheels properly building in 3.12.