### PR TITLE
Corrected MacOS get_pref_path() documentation

### DIFF
--- a/docs/reST/ref/system.rst
+++ b/docs/reST/ref/system.rst
@@ -41,7 +41,7 @@ open just in case something obvious comes up.
         C:\\Users\\bob\\AppData\\Roaming\\My Company\\My Program Name\\
 
         On macOS, it would resemble
-        /Users/bob/Library/Application Support/My Program Name/
+        /Users/bob/Library/Application Support/My Company/My Program Name/
 
         And on Linux it would resemble
         /home/bob/.local/share/My Program Name/

--- a/docs/reST/ref/system.rst
+++ b/docs/reST/ref/system.rst
@@ -44,7 +44,7 @@ open just in case something obvious comes up.
         /Users/bob/Library/Application Support/My Company/My Program Name/
 
         And on Linux it would resemble
-        /home/bob/.local/share/My Program Name/
+        /home/bob/.local/share/My Company/My Program Name/
 
    .. note::
         Since the organization and app names can potentially be used as


### PR DESCRIPTION
The path generated by get_pref_path for MacOS should have included an extra folder using the "org" parameter.  (In the example, this has the value of "My Company").  I tested this call on my Mac, and the generated path includes the value of "org" as an additional folder.