### PR TITLE
Add `__repr__` for Window class

### DIFF
--- a/src_c/window.c
+++ b/src_c/window.c
@@ -710,15 +710,16 @@ window_repr(pgWindowObject *self)
         return PyUnicode_FromString("<Window(Destroyed)>");
     }
 
+    if (self->_is_borrowed) {
+        return PyUnicode_FromString("<Window(From Display)>");
+    }
+
     title = SDL_GetWindowTitle(self->_win);
     win_id = SDL_GetWindowID(self->_win);
     if (win_id == 0) {
         return RAISE(pgExc_SDLError, SDL_GetError());
     }
 
-    if (self->_is_borrowed) {
-        return PyUnicode_FromString("<Window(From Display)>");
-    }
     return PyUnicode_FromFormat("<Window(title='%s', id=%d)>", title, win_id);
 }
 

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -719,7 +719,7 @@ window_repr(pgWindowObject *self)
     if (self->_is_borrowed) {
         return PyUnicode_FromString("<Window(From Display)>");
     }
-    return PyUnicode_FromFormat("<Window(id=%d, title='%s')>", win_id, title);
+    return PyUnicode_FromFormat("<Window(title='%s', id=%d)>", title, win_id);
 }
 
 static PyMethodDef window_methods[] = {

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -705,14 +705,21 @@ PyObject *
 window_repr(pgWindowObject *self)
 {
     const char *title;
+    int win_id;
     if (!self->_win) {
         return PyUnicode_FromString("<Window(Destroyed)>");
     }
+
+    title = SDL_GetWindowTitle(self->_win);
+    win_id = SDL_GetWindowID(self->_win);
+    if (win_id == 0) {
+        return RAISE(pgExc_SDLError, SDL_GetError());
+    }
+
     if (self->_is_borrowed) {
         return PyUnicode_FromString("<Window(From Display)>");
     }
-    title = SDL_GetWindowTitle(self->_win);
-    return PyUnicode_FromFormat("<Window(title='%s')>", title);
+    return PyUnicode_FromFormat("<Window(id=%d, title='%s')>", win_id, title);
 }
 
 static PyMethodDef window_methods[] = {

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -701,6 +701,20 @@ window_from_display_module(PyTypeObject *cls, PyObject *_null)
     return (PyObject *)self;
 }
 
+PyObject *
+window_repr(pgWindowObject *self)
+{
+    const char *title;
+    if (!self->_win) {
+        return PyUnicode_FromString("<Window(Destroyed)>");
+    }
+    if (self->_is_borrowed) {
+        return PyUnicode_FromString("<Window(From Display)>");
+    }
+    title = SDL_GetWindowTitle(self->_win);
+    return PyUnicode_FromFormat("<Window(title='%s')>", title);
+}
+
 static PyMethodDef window_methods[] = {
     {"destroy", (PyCFunction)window_destroy, METH_NOARGS,
      DOC_SDL2_VIDEO_WINDOW_DESTROY},
@@ -763,7 +777,8 @@ static PyTypeObject pgWindow_Type = {
     .tp_methods = window_methods,
     .tp_init = (initproc)window_init,
     .tp_new = PyType_GenericNew,
-    .tp_getset = _window_getset};
+    .tp_getset = _window_getset,
+    .tp_repr = (reprfunc)window_repr};
 
 static PyMethodDef _window_methods[] = {
     {"get_grabbed_window", (PyCFunction)get_grabbed_window, METH_NOARGS,


### PR DESCRIPTION
```py
import pygame
from pygame._sdl2 import video

pygame.init()
pygame.display.set_mode((640,480))

win1 = video.Window.from_display_module()
win2 = video.Window("hello window")
win3 = video.Window()
win4 = video.Window()

win4.destroy()

print(win1)
print(win2)
print(win3)
print(win4)
```

```
<Window(From Display)>
<Window(id=2, title='hello window')>
<Window(id=3, title='pygame window')>
<Window(Destroyed)>
```