### PR TITLE
Rename PyClockObject to pgClockObject, remove rendered field, small cleanups

### DIFF
--- a/src_c/time.c
+++ b/src_c/time.c
@@ -501,7 +501,6 @@ typedef struct {
     PyObject_HEAD Uint64 last_tick, fps_count, fps_tick;
     float fps;
     Uint64 timepassed, rawpassed;
-    PyObject *rendered;
 } PyClockObject;
 
 // to be called by the other tick functions.
@@ -559,7 +558,6 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
             _clock->fps_count / ((nowtime - _clock->fps_tick) / 1000.0f);
         _clock->fps_count = 0;
         _clock->fps_tick = nowtime;
-        Py_XDECREF(_clock->rendered);
     }
     return PyLong_FromUnsignedLongLong(_clock->timepassed);
 }
@@ -611,8 +609,6 @@ static struct PyMethodDef clock_methods[] = {
 static void
 clock_dealloc(PyObject *self)
 {
-    PyClockObject *_clock = (PyClockObject *)self;
-    Py_XDECREF(_clock->rendered);
     Py_TYPE(self)->tp_free(self);
 }
 
@@ -655,7 +651,6 @@ clock_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     self->last_tick = PG_GetTicks();
     self->fps = 0.0f;
     self->fps_count = 0;
-    self->rendered = NULL;
 
     return (PyObject *)self;
 }


### PR DESCRIPTION
As far as I could tell, nothing uses the rendered field, so no reason to keep it around

EDIT: I found the [commit](https://github.com/pygame/pygame/commit/dddaa9d11c61cdb3717f77b425f61c78efd7cd62#diff-6dd08642f71a022c76a495718c4942ce70262949b2b3ceb7644ee03bd8c37b7a) that added it. It had no use for it back then either. And there was no use added as far as I could tell.

Also changed the name from `PyClockObject` to `pgClockObject` to be more consistent with all the other struct's names.

Removed the `PyClockObject *_clock = (PyClockObject *)self;` lines by making `self`s be already clock objects and casting the functions in the methods table