### PR TITLE
Re-add CircleCI for aarch64 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,19 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine.
 # See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
+parameters:
+  GHA_Actor:
+    type: string
+    default: ""
+  GHA_Action:
+    type: string
+    default: ""
+  GHA_Event:
+    type: string
+    default: ""
+  GHA_Meta:
+    type: string
+    default: ""
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
@@ -8,16 +21,20 @@ jobs:
   linux-arm-wheels:
     working_directory: ~/linux-wheels
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
+      docker_layer_caching: true
+
     resource_class: arm.medium
 
     environment:
       # these environment variables will be passed to the docker container
       - CIBW_ENVIRONMENT: PIP_CONFIG_FILE=buildconfig/pip_config.ini PORTMIDI_INC_PORTTIME=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=disk
+      - CIBW_PRERELEASE_PYTHONS: True # for 3.12 testing
+      - CIBW_BUILD: "cp3{[7-9],10,11,12}-* pp3{[8-9],10}-*"
       - CIBW_ARCHS: aarch64
       - CIBW_SKIP: '*-musllinux_*'
-      - CIBW_MANYLINUX_AARCH64_IMAGE: pygame/manylinux2014_base_aarch64
-      - CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: pygame/manylinux2014_base_aarch64
+      - CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014_base_aarch64
+      - CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: manylinux2014_base_aarch64
       - CIBW_BEFORE_BUILD: pip install Sphinx && python setup.py docs
       - CIBW_TEST_COMMAND: python -m pygame.tests -v --exclude opengl,music,timing --time_out 300
       - CIBW_BUILD_VERBOSITY: 2
@@ -25,9 +42,14 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Build the aarch64 base image (and cache it)
+          working_directory: buildconfig/manylinux-build/docker_base
+          command: docker build -t manylinux2014_base_aarch64 -f Dockerfile-aarch64 .
+
+      - run:
           name: Build the Linux wheels.
           command: |
-            pip3 install --user cibuildwheel==2.12.0
+            pip3 install --user cibuildwheel==2.14.1
             PATH="$HOME/.local/bin:$PATH" cibuildwheel --output-dir wheelhouse
 
       - store_artifacts:

--- a/.github/workflows/release-gh-draft.yml
+++ b/.github/workflows/release-gh-draft.yml
@@ -5,6 +5,18 @@ on:
     branches: 'release/**'
 
 jobs:
+  manylinux-aarch64:
+    runs-on: ubuntu-latest
+    outputs:
+      pipeline_id: ${{ steps.circleci.outputs.id }}
+
+    steps:
+      - name: Trigger CircleCI builds on release
+        id: circleci
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
+
   manylinux:
     uses: ./.github/workflows/build-manylinux.yml
 
@@ -18,14 +30,22 @@ jobs:
     uses: ./.github/workflows/build-ubuntu-sdist.yml
 
   draft-release:
-    needs: [manylinux, macos, windows, sdist]
+    needs: [manylinux-aarch64, manylinux, macos, windows, sdist]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.3
 
       - name: Download all artifacts
         uses: actions/download-artifact@v3
-      
+
+      - name: Download manylinux-aarch64 artifacts from CircleCI
+        continue-on-error: true # incase things don't work here, can manually handle it
+        run: >
+          python3 buildconfig/ci/circleci/pull_circleci_artifacts.py
+          ${{ secrets.CCI_TOKEN }}
+          ${{ needs.manylinux-aarch64.outputs.pipeline_id }}
+          pygame-wheels-manylinux
+
       # Strips 'release/' from the ref_name, this helps us access the version
       # name as 'steps.ver.outputs.VER'
       - name: Get version

--- a/buildconfig/ci/circleci/pull_circleci_artifacts.py
+++ b/buildconfig/ci/circleci/pull_circleci_artifacts.py
@@ -1,0 +1,87 @@
+import http.client
+import json
+import sys
+import time
+from pathlib import Path
+from urllib import request
+
+_, token, pipeline_id, save_dir = sys.argv
+
+headers = {"Circle-Token": token}
+save_dir = Path(save_dir)
+
+print(
+    f"Starting for {pipeline_id = } (and {save_dir = }), now establishing connection..."
+)
+
+cci_api = http.client.HTTPSConnection("circleci.com")
+
+
+def paginate_get_items_and_next(url, next_page=""):
+    url_query = f"{url}?page-token={next_page}" if next_page else url
+    cci_api.request("GET", f"/api/v2/{url_query}", headers=headers)
+    response = cci_api.getresponse()
+    if response.status != 200:
+        raise RuntimeError(
+            f"Request to '{url}' not successful: {response.status} ({response.reason})"
+        )
+
+    response_dict = json.loads(response.read())
+    if "message" in response_dict:
+        raise RuntimeError(
+            f"Request to '{url}' failed with message - {response_dict['message']}"
+        )
+
+    return response_dict["items"], response_dict["next_page_token"]
+
+
+def paginate_get_single_item(url):
+    items, _ = paginate_get_items_and_next(url)
+    if len(items) != 1:
+        raise RuntimeError(f"Expected one item, got {len(items)}")
+
+    return items[0]
+
+
+def paginate_get_all_items(url):
+    prev_page_tag = ""
+    while True:
+        items, prev_page_tag = paginate_get_items_and_next(url, prev_page_tag)
+        if not items:
+            break
+
+        yield from items
+        if not prev_page_tag:
+            break
+
+cnt = 1
+while True:
+    print(f"\nAttempt {cnt}")
+    workflow = paginate_get_single_item(f"/pipeline/{pipeline_id}/workflow")
+    if workflow["status"] != "running":
+        if workflow["status"] != "success":
+            raise RuntimeError(f"The workflow has status '{workflow['status']}'")
+
+        # successfully finished workflow at this point
+        job = paginate_get_single_item(f"/workflow/{workflow['id']}/job")
+
+        # shouldn't really happen, but test anyways
+        if job["status"] != "success":
+            raise RuntimeError(f"The job has status '{workflow['status']}'")
+
+        print("Handling artifacts...")
+        for i, artifact in enumerate(
+            paginate_get_all_items(
+                f"/project/{job['project_slug']}/{job['job_number']}/artifacts"
+            ),
+            start=1,
+        ):
+            path = Path(artifact["path"])
+            save_path = save_dir / path.name
+            print(f"{i}) Downloading {path.name} ({path}) and saving it in {save_path}")
+            request.urlretrieve(artifact["url"], save_path)
+
+        break
+
+    cnt += 1
+    time.sleep(30)

--- a/buildconfig/ci/circleci/pull_circleci_artifacts.py
+++ b/buildconfig/ci/circleci/pull_circleci_artifacts.py
@@ -1,3 +1,28 @@
+"""
+A script to automate downloading CircleCI artifacts.
+
+Usage: python3 pull_circleci_artifacts.py <TOKEN> <PIPELINE_ID> <SAVE_DIR>
+    TOKEN: 
+        CircleCI "personal access token" of a github (preferably machine) user.
+        This is secret!
+
+    PIPELINE_ID:
+        A unique string id that represents the CircleCI pipeline, whose artifacts this
+        script pulls.
+        This pipeline must have exactly one workflow and that workflow must have exactly
+        one job. This script waits for the pipeline to finish, and pulls artifacts from
+        this job. If the pipeline isn't successful on finish, this script exits with an
+        error.
+
+    SAVE_DIR:
+        The downloaded artifacts are saved to this directory
+
+CircleCI API docs: https://circleci.com/docs/api/v2/index.html (useful for understanding
+this code)
+"""
+
+# yup, all these are stdlib modules incase you are wondering
+import concurrent.futures
 import http.client
 import json
 import sys
@@ -18,6 +43,12 @@ cci_api = http.client.HTTPSConnection("circleci.com")
 
 
 def paginate_get_items_and_next(url, next_page=""):
+    """
+    Helper to get "items" and "next_page_token" from CircleCI API, used to handle
+    pagination.
+    """
+
+    # page-token is used for pagination. Initially, it is unspecified.
     url_query = f"{url}?page-token={next_page}" if next_page else url
     cci_api.request("GET", f"/api/v2/{url_query}", headers=headers)
     response = cci_api.getresponse()
@@ -36,6 +67,9 @@ def paginate_get_items_and_next(url, next_page=""):
 
 
 def paginate_get_single_item(url):
+    """
+    Helper to get exactly one item from CircleCI paginated APIs
+    """
     items, _ = paginate_get_items_and_next(url)
     if len(items) != 1:
         raise RuntimeError(f"Expected one item, got {len(items)}")
@@ -44,15 +78,33 @@ def paginate_get_single_item(url):
 
 
 def paginate_get_all_items(url):
+    """
+    Helper to get all "items" from CircleCI paginated APIs
+    """
     prev_page_tag = ""
     while True:
         items, prev_page_tag = paginate_get_items_and_next(url, prev_page_tag)
         if not items:
+            # all artifacts are probably downloaded at this point
             break
 
         yield from items
         if not prev_page_tag:
+            # done with pagination, exit
             break
+
+
+def download_artifact(artifact):
+    """
+    Helper to download an artifact given an "artifact dict". This can be concurrently
+    called in multiple threads to speed up downloads.
+    """
+    path = Path(artifact["path"])
+    save_path = save_dir / path.name
+    print(f"Downloading {path.name}")
+    request.urlretrieve(artifact["url"], save_path)
+    print(f"Done with saving {path.name}")
+
 
 cnt = 1
 while True:
@@ -60,6 +112,7 @@ while True:
     workflow = paginate_get_single_item(f"/pipeline/{pipeline_id}/workflow")
     if workflow["status"] != "running":
         if workflow["status"] != "success":
+            # workflow failed
             raise RuntimeError(f"The workflow has status '{workflow['status']}'")
 
         # successfully finished workflow at this point
@@ -69,19 +122,17 @@ while True:
         if job["status"] != "success":
             raise RuntimeError(f"The job has status '{workflow['status']}'")
 
-        print("Handling artifacts...")
-        for i, artifact in enumerate(
-            paginate_get_all_items(
-                f"/project/{job['project_slug']}/{job['job_number']}/artifacts"
-            ),
-            start=1,
-        ):
-            path = Path(artifact["path"])
-            save_path = save_dir / path.name
-            print(f"{i}) Downloading {path.name} ({path}) and saving it in {save_path}")
-            request.urlretrieve(artifact["url"], save_path)
+        print(f"Downloading artifacts (they will all be saved in {str(save_dir)})")
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            pool.map(
+                download_artifact,
+                paginate_get_all_items(
+                    f"/project/{job['project_slug']}/{job['job_number']}/artifacts"
+                ),
+            )
 
         break
 
     cnt += 1
+    print("Job is still running (now sleeping for 30s before retrying)")
     time.sleep(30)


### PR DESCRIPTION
Mostly using the old config, but with a few updates. We now make base images directly on CircleCI itself, and use CircleCI DLC (docker layer caching) to speeden it up for subsequent builds

TODO (either in this PR or a future one)
- [x] Integration with the github actions release machinery somehow (can only test it while doing a dev release)