### PR TITLE
Use OIDC to publish PyPI releases

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
       - uses: actions/checkout@v3.5.3
 
@@ -21,5 +25,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
https://docs.pypi.org/trusted-publishers/using-a-publisher/

TL;DR - moving away from `secrets.PYPI_TOKEN` (which I now removed) to a more secure way to do our automated releases.

After this change, there would be a small addition to our release process that also increases security. The action that does the PyPI release would wait for an approval from a steering council member.