### PR TITLE
Don't use SDL_ name for our compat layer

### DIFF
--- a/src_c/pgcompat_rect.c
+++ b/src_c/pgcompat_rect.c
@@ -36,8 +36,8 @@ ComputeOutCodeF(const SDL_FRect *rect, float x, float y)
 }
 
 SDL_bool
-SDL_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
-                          float *Y2)
+PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
+                         float *Y2)
 {
     float x = 0;
     float y = 0;

--- a/src_c/pgcompat_rect.h
+++ b/src_c/pgcompat_rect.h
@@ -20,8 +20,10 @@ typedef struct SDL_FPoint {
 #if !(SDL_VERSION_ATLEAST(2, 0, 22))
 
 SDL_bool
-SDL_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
-                          float *Y2);
+PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
+                         float *Y2);
+#else
+#define PG_IntersectFRectAndLine SDL_IntersectFRectAndLine
 #endif /* !(SDL_VERSION_ATLEAST(2, 0, 22)) */
 
 #define pg_PyFloat_FromFloat(x) (PyFloat_FromDouble((double)x))

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -253,7 +253,7 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
 #define RectImport_twoPrimitivesFromObj pg_TwoFloatsFromObj
 #define RectImport_PrimitiveFromObj pg_FloatFromObj
 #define RectImport_RectObject pgFRectObject
-#define RectImport_IntersectRectAndLine SDL_IntersectFRectAndLine
+#define RectImport_IntersectRectAndLine PG_IntersectFRectAndLine
 #define RectImport_TypeObject pgFRect_Type
 #define RectImport_PyBuildValueFormat "f"
 #define RectImport_ObjectName "pygame.rect.FRect"


### PR DESCRIPTION
This actually bit me when I tried to compile pygame-ce on a mac running 2.0.21, which has the symbol SDL_IntersectFRectAndLine. The compilation failed because of the duplicate symbol.