### PR TITLE
Fixed `Sound.__init__` raising `TypeError` when it should be `FileNotFoundError`

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1844,6 +1844,9 @@ sound_init(PyObject *self, PyObject *arg, PyObject *kwarg)
         rw = pgRWops_FromObject(file, NULL);
 
         if (rw == NULL) {
+            if (PyErr_ExceptionMatches(PyExc_FileNotFoundError)) {
+                return -1;
+            }
             if (obj) {
                 /* use 'buffer' as fallback for single arg */
                 PyErr_Clear();

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1852,7 +1852,6 @@ sound_init(PyObject *self, PyObject *arg, PyObject *kwarg)
             }
             return -1;
         }
-
         Py_BEGIN_ALLOW_THREADS;
         chunk = Mix_LoadWAV_RW(rw, 1);
         Py_END_ALLOW_THREADS;

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1841,10 +1841,14 @@ sound_init(PyObject *self, PyObject *arg, PyObject *kwarg)
     }
 
     if (file != NULL) {
+        PyObject *path = PyOS_FSPath(file);
+        int file_is_bytes = PyBytes_Check(file);
+
         rw = pgRWops_FromObject(file, NULL);
 
         if (rw == NULL) {
-            if (PyErr_ExceptionMatches(PyExc_FileNotFoundError)) {
+            if (path && !file_is_bytes) {
+                Py_DECREF(path);
                 return -1;
             }
             if (obj) {
@@ -1854,6 +1858,8 @@ sound_init(PyObject *self, PyObject *arg, PyObject *kwarg)
             }
             return -1;
         }
+        Py_XDECREF(path);
+
         Py_BEGIN_ALLOW_THREADS;
         chunk = Mix_LoadWAV_RW(rw, 1);
         Py_END_ALLOW_THREADS;

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1796,7 +1796,8 @@ sound_init(PyObject *self, PyObject *arg, PyObject *kwarg)
         }
         obj = PyTuple_GET_ITEM(arg, 0);
 
-        if (PyUnicode_Check(obj)) {
+        if (PyUnicode_Check(obj) ||
+            PyObject_HasAttrString(obj, "__fspath__")) {
             file = obj;
             obj = NULL;
         }
@@ -1841,16 +1842,9 @@ sound_init(PyObject *self, PyObject *arg, PyObject *kwarg)
     }
 
     if (file != NULL) {
-        PyObject *path = PyOS_FSPath(file);
-        int file_is_bytes = PyBytes_Check(file);
-
         rw = pgRWops_FromObject(file, NULL);
 
         if (rw == NULL) {
-            if (path && !file_is_bytes) {
-                Py_DECREF(path);
-                return -1;
-            }
             if (obj) {
                 /* use 'buffer' as fallback for single arg */
                 PyErr_Clear();
@@ -1858,7 +1852,6 @@ sound_init(PyObject *self, PyObject *arg, PyObject *kwarg)
             }
             return -1;
         }
-        Py_XDECREF(path);
 
         Py_BEGIN_ALLOW_THREADS;
         chunk = Mix_LoadWAV_RW(rw, 1);

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -1019,6 +1019,10 @@ class SoundTypeTest(unittest.TestCase):
         self.assertIsInstance(sound1, mixer.Sound)
         self.assertIsInstance(sound2, mixer.Sound)
 
+        self.assertRaises(
+            FileNotFoundError, mixer.Sound, pathlib.Path("/aWH8ryIyWt5BL7xf327e")
+        )  # this path should not exist on any system really
+
     def todo_test_sound__from_buffer(self):
         """Ensure Sound() creation with a buffer works."""
         self.fail()


### PR DESCRIPTION
Test code
```py
import pathlib

import pygame


pygame.mixer.init()
pygame.mixer.Sound(pathlib.Path("nope"))
```