### PR TITLE
Deprecate passing out of range sequence lengths to colorspace setters

### DIFF
--- a/src_c/color.c
+++ b/src_c/color.c
@@ -1144,6 +1144,16 @@ _color_set_hsva(pgColorObject *color, PyObject *value, void *closure)
         return -1;
     }
 
+    if (PySequence_Size(value) > 4) {
+        if (PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "Passing sequences of size larger than 4 is deprecated, doing "
+                "this will error in a future version",
+                1) == -1) {
+            return -1;
+        }
+    }
+
     /* H */
     item = PySequence_GetItem(value, 0);
     if (!item || !_get_double(item, &(hsva[0])) || hsva[0] < 0 ||
@@ -1309,6 +1319,16 @@ _color_set_hsla(pgColorObject *color, PyObject *value, void *closure)
         return -1;
     }
 
+    if (PySequence_Size(value) > 4) {
+        if (PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "Passing sequences of size larger than 4 is deprecated, doing "
+                "this will error in a future version",
+                1) == -1) {
+            return -1;
+        }
+    }
+
     /* H */
     item = PySequence_GetItem(value, 0);
     if (!item || !_get_double(item, &(hsla[0])) || hsla[0] < 0 ||
@@ -1469,6 +1489,21 @@ _color_set_i1i2i3(pgColorObject *color, PyObject *value, void *closure)
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("i1i2i3", value);
 
+    if (!PySequence_Check(value) || PySequence_Size(value) < 3) {
+        PyErr_SetString(PyExc_ValueError, "invalid I1I2I3 value");
+        return -1;
+    }
+
+    if (PySequence_Size(value) > 3) {
+        if (PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "Passing sequences of size larger than 3 is deprecated, doing "
+                "this will error in a future version",
+                1) == -1) {
+            return -1;
+        }
+    }
+
     /* I1 */
     item = PySequence_GetItem(value, 0);
     if (!item || !_get_double(item, &(i1i2i3[0])) || i1i2i3[0] < 0 ||
@@ -1535,6 +1570,21 @@ _color_set_cmy(pgColorObject *color, PyObject *value, void *closure)
     double cmy[3] = {0, 0, 0};
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("cmy", value);
+
+    if (!PySequence_Check(value) || PySequence_Size(value) < 3) {
+        PyErr_SetString(PyExc_ValueError, "invalid CMY value");
+        return -1;
+    }
+
+    if (PySequence_Size(value) > 3) {
+        if (PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "Passing sequences of size larger than 3 is deprecated, doing "
+                "this will error in a future version",
+                1) == -1) {
+            return -1;
+        }
+    }
 
     /* I1 */
     item = PySequence_GetItem(value, 0);

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -782,6 +782,14 @@ class ColorTypeTest(unittest.TestCase):
         self.assertEqual(expected_cmy, cmy)
         self.assertEqual(expected_cmy, cmy_tuple)
 
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(
+                expected_cmy, pygame.Color.from_cmy(0.5, 0.5, 0.5, "lel", "foo")
+            )
+
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(expected_cmy, pygame.Color.from_cmy((0.5, 0.5, 0.5, 0.5)))
+
     def test_from_hsva(self):
         hsva = pygame.Color.from_hsva(0, 100, 100, 100)
         hsva_tuple = pygame.Color.from_hsva((0, 100, 100, 100))
@@ -790,6 +798,16 @@ class ColorTypeTest(unittest.TestCase):
 
         self.assertEqual(expected_hsva, hsva)
         self.assertEqual(expected_hsva, hsva_tuple)
+
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(
+                expected_hsva, pygame.Color.from_hsva(0, 100, 100, 100, "lel", "foo")
+            )
+
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(
+                expected_hsva, pygame.Color.from_hsva((0, 100, 100, 100, "lel"))
+            )
 
     def test_from_hsla(self):
         hsla = pygame.Color.from_hsla(0, 100, 100, 100)
@@ -800,6 +818,16 @@ class ColorTypeTest(unittest.TestCase):
         self.assertEqual(expected_hsla, hsla)
         self.assertEqual(expected_hsla, hsla_tuple)
 
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(
+                expected_hsla, pygame.Color.from_hsla(0, 100, 100, 100, "lel")
+            )
+
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(
+                expected_hsla, pygame.Color.from_hsla((0, 100, 100, 100, "lel", "foo"))
+            )
+
     def test_from_i1i2i3(self):
         i1i2i3 = pygame.Color.from_i1i2i3(0, 0, 0)
         i1i2i3_tuple = pygame.Color.from_i1i2i3((0, 0, 0))
@@ -808,6 +836,14 @@ class ColorTypeTest(unittest.TestCase):
 
         self.assertEqual(expected_i1i2i3, i1i2i3)
         self.assertEqual(expected_i1i2i3, i1i2i3_tuple)
+
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(
+                expected_i1i2i3, pygame.Color.from_i1i2i3(0, 0, 0, "lel", "foo")
+            )
+
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(expected_i1i2i3, pygame.Color.from_i1i2i3((0, 0, 0, 0)))
 
     def test_normalize(self):
         c = pygame.Color(204, 38, 194, 55)
@@ -988,6 +1024,12 @@ class ColorTypeTest(unittest.TestCase):
 
     def test_i1i2i3__sanity_testing_converted_should_equate_bar_rounding(self):
         self.colorspaces_converted_should_equate_bar_rounding("i1i2i3")
+
+    def test_colorspaces_deprecated_large_sequence(self):
+        c = pygame.Color("black")
+        for space in ("hsla", "hsva", "i1i2i3", "cmy"):
+            with self.assertWarns(DeprecationWarning):
+                setattr(c, space, (0, 0, 0, 0, "hehe 5th ignored member"))
 
     ################################################################################
 


### PR DESCRIPTION
First step for #2386