### PR TITLE
ignore lint warning in locals.py (to make the linter pass)

### DIFF
--- a/src_py/locals.py
+++ b/src_py/locals.py
@@ -23,7 +23,7 @@
 the local namespace for your module"""
 
 import pygame
-from pygame.constants import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from pygame.constants import *  # pylint: disable=wildcard-import,unused-wildcard-import; lgtm[py/polluting-import]
 from pygame.rect import Rect
 from pygame.color import Color
 


### PR DESCRIPTION
this is needed to avoid a non 0 return value of `python -m setup lint`, at least on window using
py 3.10
black                         23.7.0
clang                         16.0.1.1
clang-format                  16.0.4
pylint                        2.17.5
