### PR TITLE
Fix missing colon in color C API

### DIFF
--- a/docs/reST/c_api/color.rst
+++ b/docs/reST/c_api/color.rst
@@ -36,7 +36,7 @@ Header file: src_c/include/pygame.h
    Argument *length* must be between ``1`` and ``4`` inclusive.
    On failure, raise a Python exception and return ``NULL``.
 
-.. c:function int pg_RGBAFromColorObj(PyObject *color, Uint8 rgba[])
+.. c:function:: int pg_RGBAFromColorObj(PyObject *color, Uint8 rgba[])
 
    Set the four element array *rgba* to the color represented by object *color*.
    Return ``1`` on success, ``0`` otherwise.


### PR DESCRIPTION
Before:
![image](https://github.com/pygame-community/pygame-ce/assets/31395137/e80ca53b-5a7b-431a-a3de-8625cbaa385a)
After:
![image](https://github.com/pygame-community/pygame-ce/assets/31395137/b4d446c6-f1f0-4822-8aab-4983a4fc9ce5)
