### PR TITLE
`pg_IntFromObj` rework

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -542,14 +542,33 @@ pg_TwoIntsFromObj(PyObject *obj, int *val1, int *val2)
 static int
 pg_FloatFromObj(PyObject *obj, float *val)
 {
-    float f = (float)PyFloat_AsDouble(obj);
+    double tmp_val;
+    PyObject *tmp_obj;
+    SDL_bool do_decref = SDL_FALSE;
 
-    if (f == -1 && PyErr_Occurred()) {
-        PyErr_Clear();
-        return 0;
+    if (PyFloat_Check(obj)) {
+        tmp_obj = obj;
+    }
+    else if (PyNumber_Check(obj)) {
+        tmp_obj = PyNumber_Float(obj);
+        if (!tmp_obj)
+            return 0;
+
+        do_decref = SDL_TRUE;
+    }
+    else {
+        return 0;  // Not a number type
     }
 
-    *val = f;
+    tmp_val = PyFloat_AsDouble(tmp_obj);
+
+    if (do_decref)
+        Py_DECREF(tmp_obj);
+
+    if (tmp_val == -1 && PyErr_Occurred()) {
+        return 0;
+    }
+    *val = (float)tmp_val;
     return 1;
 }
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -683,7 +683,10 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (!pg_IntFromObj(radiusobj, &radius)) {
-        PyErr_SetString(PyExc_TypeError, "radius argument must be a number");
+        if (!PyErr_Occurred()) {
+            PyErr_SetString(PyExc_TypeError,
+                            "radius argument must be a number");
+        }
         return 0;
     }
 

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -5686,10 +5686,10 @@ class DrawCircleMixin:
 
         # way way outside the screen
         test_centers = [
-            (-1e30, height / 2),
-            (1e30, height / 2),
-            (width / 2, -1e30),
-            (width / 2, 1e30),
+            (-(1 << 30), height / 2),
+            (1 << 30, height / 2),
+            (width / 2, -(1 << 30)),
+            (width / 2, 1 << 30),
         ]
         for center in test_centers:
             surf.fill("black")


### PR DESCRIPTION
`pg_IntFromObj` is used for converting python objects into c int.
Currently, when encountering an error, this API clears the error indicator and returns 0 representing error occured. Some error like `OverflowError` will be cleared and may be replaced with a different error like `TypeError`, which may make debug harder. 
When handling with a float that way larger than `INT_MAX`, this function just cast the number to int without any error returned. This may make the behavior of code unpredictable.

So I changed the API. The new function first converts the input object into python int object. Then convert the python int object into c int. If any error occurs , the function returns 0 with the error indicator kept. If the type of input object is not able to be converted as a python int object, the function will return 0 with no error set. 
This is compatible with the old API and (hopefully) is able to pass all the tests.
Here is an example of this function: 
```c
if (!pg_IntFromObj(radiusobj, &radius)) {
    if (!PyErr_Occurred()) {
        PyErr_SetString(PyExc_TypeError,
                        "radius argument must be a number");
    }
    return 0;
}
```

In this PR, I fixed #2404 in draw.c. I think there are still some bugs like that (especially in rect_impl.h). I'll fix those in other PRs in the same way if this PR is merged.