### PR TITLE
wasm: in 32bits mode (mvp) lseek64 is not present

### DIFF
--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -36,6 +36,9 @@
 #elif defined(__APPLE__)
 /* Mac does not implement lseek64 */
 #define PG_LSEEK lseek
+#elif defined(__EMSCRIPTEN__)
+/* emsdk mvp 1.0 does not implement lseek64  */
+#define PG_LSEEK lseek
 #else
 #define PG_LSEEK lseek64
 #endif


### PR DESCRIPTION
fix compilation on recent emsdk 3.1.45