### PR TITLE
Use `BUILD_STATIC` instead of `PYGAMEAPI_DISPLAY_INTERNAL` in window.c

### DIFF
--- a/src_c/window.c
+++ b/src_c/window.c
@@ -6,8 +6,9 @@
 
 #include "doc/sdl2_video_doc.h"
 
-#ifndef BUILD_STATIC  // to pass the static check
-// Copied from display.c
+// prevent that code block copied from display.c from being linked twice
+#ifndef BUILD_STATIC
+
 #if !defined(__APPLE__)
 static char *icon_defaultname = "pygame_icon.bmp";
 static int icon_colorkey = 0;

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -6,7 +6,7 @@
 
 #include "doc/sdl2_video_doc.h"
 
-#ifndef PYGAMEAPI_DISPLAY_INTERNAL  // to pass the static check
+#ifndef BUILD_STATIC  // to pass the static check
 // Copied from display.c
 #if !defined(__APPLE__)
 static char *icon_defaultname = "pygame_icon.bmp";
@@ -93,7 +93,7 @@ display_resource_end:
     return result;
 }
 
-#endif  // PYGAMEAPI_DISPLAY_INTERNAL
+#endif  // BUILD_STATIC
 
 static PyTypeObject pgWindow_Type;
 


### PR DESCRIPTION
Fixes [this](https://github.com/pygame-community/pygame-ce/commit/f1d5abdc2569301fc80e5a8d096dadfb9d8ef068#r125055908).

> if you need to protect a block from being statically linked a second time, just enclose it with #ifndef BUILD_STATIC
>
>i fear PYGAMEAPI_DISPLAY_INTERNAL is unrelated to static build

Thank you for your suggestion @pmp-p.