### PR TITLE
Prevent segfault due to division by zero in music.get_pos

### DIFF
--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -219,12 +219,6 @@ MP3 in most cases.
 
    Returns -1 if ``get_pos`` failed due to music not playing.
 
-   :returns: milliseconds (or -1 if failed)
-   :rtype: int
-
-   .. versionchanged:: 2.3.2 Returns -1 if getting pos failed due to nothing having
-                        been played yet
-
    .. ## pygame.mixer.music.get_pos ##
 
 .. function:: queue

--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -217,6 +217,14 @@ MP3 in most cases.
    The returned time only represents how long the music has been playing; it
    does not take into account any starting position offsets.
 
+   Returns -1 if ``get_pos`` failed due to music not playing.
+
+   :returns: milliseconds (or -1 if failed)
+   :rtype: int
+
+   .. versionchanged:: 2.3.2 Returns -1 if getting pos failed due to nothing having
+                        been played yet
+
    .. ## pygame.mixer.music.get_pos ##
 
 .. function:: queue

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -252,14 +252,11 @@ music_get_pos(PyObject *self, PyObject *_null)
 
     MIXER_INIT_CHECK();
 
-    if (music_pos_time < 0)
-        return PyLong_FromLong(-1);
-
     Uint16 intermediate_step = (music_format & 0xff) >> 3;
     long denominator = music_channels * music_frequency * intermediate_step;
-    if (denominator == 0) {
-        return RAISE(PyExc_ZeroDivisionError,
-                     "Division by zero in music.get_pos");
+    if (music_pos_time < 0 || denominator == 0)
+    {
+        return PyLong_FromLong(-1);
     }
 
     ticks = (long)(1000 * music_pos / denominator);

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -255,9 +255,14 @@ music_get_pos(PyObject *self, PyObject *_null)
     if (music_pos_time < 0)
         return PyLong_FromLong(-1);
 
-    ticks = (long)(1000 * music_pos /
-                   (music_channels * music_frequency *
-                    ((music_format & 0xff) >> 3)));
+    Uint16 intermediate_step = (music_format & 0xff) >> 3;
+    long denominator = music_channels * music_frequency * intermediate_step;
+    if (denominator == 0) {
+        return RAISE(PyExc_ZeroDivisionError,
+                     "Division by zero in music.get_pos");
+    }
+
+    ticks = (long)(1000 * music_pos / denominator);
     if (!Mix_PausedMusic())
         ticks += PG_GetTicks() - music_pos_time;
 

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -254,8 +254,7 @@ music_get_pos(PyObject *self, PyObject *_null)
 
     Uint16 intermediate_step = (music_format & 0xff) >> 3;
     long denominator = music_channels * music_frequency * intermediate_step;
-    if (music_pos_time < 0 || denominator == 0)
-    {
+    if (music_pos_time < 0 || denominator == 0) {
         return PyLong_FromLong(-1);
     }
 


### PR DESCRIPTION
@pmp-p reported an issue in discord where this code can crash due to a division by zero:
```py
import pygame
pygame.init()
pygame.mixer.init()
pygame.mixer.music.get_pos()
```
I tried to write a regression test for this fix, but I couldn't reliably reproduce it in a test environment. Because the variables involved are static to the `music.c` file, I believe this is only possible before any music has ever been loaded, and because other tests run before the created test, those static variables retain their last value, even if `pygame.mixer.quit()` or `pygame.quit()` has been called and mixer has been reinitialized

@bilhox reported that they didn't get the floating point exception on windows 11 (pmp-p and I are both using linux), but I suspect that is windows doing windows things and not actually showing the parachute info.

For reference, here is the parachute dump I get:
```
pygame-ce 2.4.0.dev1 (SDL 2.28.2, Python 3.11.3)
Fatal Python error: pygame_parachute: (pygame parachute) Floating Point Exception
Python runtime state: initialized

Current thread 0x00007f55234a3740 (most recent call first):
  File "/home/andrew/Projects/pygame-ce/test.py", line 4 in <module>

Extension modules: pygame.base, pygame.constants, pygame.rect, pygame.rwobject, pygame.surflock, pygame.bufferproxy, pygame.math, pygame.surface, pygame.display, pygame.draw, pygame.joystick, pygame.event, pygame.imageext, pygame.image, pygame.key, pygame.mouse, pygame.time, pygame.mask, pygame.pixelcopy, pygame.transform, pygame.font, pygame.mixer_music, pygame.mixer, pygame.scrap, pygame.system, pygame._freetype (total: 26)
zsh: IOT instruction (core dumped)  /home/andrew/Projects/pygame-ce/venv/bin/python 
```
And the gdb result on receipt of the exception
```
Thread 1 "python" received signal SIGFPE, Arithmetic exception.
0x00007ffff626da71 in music_get_pos (self=<optimized out>, _null=<optimized out>) at src_c/music.c:258
258         ticks = (long)(1000 * music_pos /
```