### PR TITLE
Improved `Surface.fill` error message for invalid blend flags

### DIFF
--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -908,7 +908,7 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
         }
 
         default: {
-            result = -1;
+            result = SDL_SetError("invalid blend flag for this operation");
             break;
         }
     }

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -301,6 +301,17 @@ class SurfaceTypeTest(unittest.TestCase):
         )
         self.assertTrue(blit_surf.get_flags() & pygame.RLEACCEL)
 
+    def test_fill_raise_exceptions(self):
+        surf = pygame.Surface((5, 5))
+        invalid_rect_style_obj = 0
+        self.assertRaises(ValueError, surf.fill, "black", rect=invalid_rect_style_obj)
+        self.assertRaises(
+            pygame.error, surf.fill, "black", special_flags=pygame.BLEND_PREMULTIPLIED
+        )
+        self.assertRaises(
+            pygame.error, surf.fill, "black", special_flags=pygame.BLEND_ALPHA_SDL2
+        )
+
     def test_mustlock_rle(self):
         """Test RLEACCEL flag with mustlock()"""
         surf = pygame.Surface((100, 100))


### PR DESCRIPTION
Test code:
```py
import pygame

image = pygame.Surface((5, 5))
try:
    image.fill((255, 0, 0), special_flags=pygame.BLEND_PREMULTIPLIED)
except pygame.error as e:
    print(f"{e = }")
else:
    print("no error")

image = pygame.Surface((5, 5), pygame.SRCALPHA)
try:
    image.fill((255, 0, 0), special_flags=pygame.BLEND_PREMULTIPLIED)
except pygame.error as e:
    print(f"{e = }")
else:
    print("no error")
```

Currently it either simply raises a `pygame.error` without any error message or I have managed to get `Surface doesn't have a colorkey` in this case:
```py
import pygame

pygame.display.set_mode(flags=pygame.HIDDEN)
image = pygame.image.load("scenery.jpg").convert()
try:
    image.fill((255, 0, 0), special_flags=pygame.BLEND_PREMULTIPLIED)
except pygame.error as e:
    print(f"{e = }")
else:
    print("no error")
```