### PR TITLE
Skipping mixer test because it randomly fails on Linux

### DIFF
--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -143,6 +143,10 @@ class MixerModuleTest(unittest.TestCase):
         self.assertRaises(pygame.error, mixer.get_num_channels)
 
     # TODO: FIXME: pypy (on linux) fails here sometimes.
+    @unittest.skipIf(
+        sys.maxsize <= 2**32,
+        "randomly fails on comparing bytes",
+    )
     @unittest.skipIf(IS_PYPY, "random errors here with pypy")
     def test_sound_args(self):
         def get_bytes(snd):


### PR DESCRIPTION
This test, especially recently, tends to fail randomly on Linux, skipping it for now until a solution is found.
![image](https://github.com/pygame-community/pygame-ce/assets/83066658/3ee2cb6f-4123-4859-815f-37d743cf521d)
