### PR TITLE
Use format instead of masks (5)

### DIFF
--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -400,14 +400,11 @@ _PGFT_Render_NewSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
                         const FontRenderMode *mode, PGFT_String *text,
                         FontColor *fgcolor, FontColor *bgcolor, SDL_Rect *r)
 {
-    FT_UInt32 rmask = 0;
-    FT_UInt32 gmask = 0;
-    FT_UInt32 bmask = 0;
-    FT_UInt32 amask = 0;
     int locked = 0;
     SDL_Surface *surface = 0;
     int bits_per_pixel =
         (bgcolor || mode->render_flags & FT_RFLAG_ANTIALIAS) ? 32 : 8;
+    Uint32 pixelformat;
 
     FontSurface font_surf;
     Layout *font_text;
@@ -435,21 +432,13 @@ _PGFT_Render_NewSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
         offset.y = -font_text->min_y;
     }
 
-    if (bits_per_pixel == 32) {
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-        rmask = 0xff000000;
-        gmask = 0x00ff0000;
-        bmask = 0x0000ff00;
-        amask = 0x000000ff;
-#else
-        rmask = 0x000000ff;
-        gmask = 0x0000ff00;
-        bmask = 0x00ff0000;
-        amask = 0xff000000;
-#endif
+    if (bits_per_pixel == 8) {
+        pixelformat = SDL_PIXELFORMAT_INDEX8;
     }
-    surface = SDL_CreateRGBSurface(0, width, height, bits_per_pixel, rmask,
-                                   gmask, bmask, amask);
+    else {
+        pixelformat = SDL_PIXELFORMAT_RGBA32;
+    }
+    surface = SDL_CreateRGBSurfaceWithFormat(0, width, height, 0, pixelformat);
     if (!surface) {
         PyErr_SetString(pgExc_SDLError, SDL_GetError());
         return 0;


### PR DESCRIPTION
Easier to port to SDL3.

Continuing from #2439 