### PR TITLE
Corrects sprite documentation error

### DIFF
--- a/docs/reST/ref/sprite.rst
+++ b/docs/reST/ref/sprite.rst
@@ -19,7 +19,7 @@ of objects in the game. There is also a base Group class that simply stores
 sprites. A game could create new types of Group classes that operate on
 specially customized Sprite instances they contain.
 
-The basic Sprite class can draw the Sprites it contains to a Surface. The
+The basic Group class can draw the Sprites it contains to a Surface. The
 ``Group.draw()`` method requires that each Sprite have a ``Sprite.image``
 attribute and a ``Sprite.rect``. The ``Group.clear()`` method requires these
 same attributes, and can be used to erase all the Sprites with background.


### PR DESCRIPTION
[https://pyga.me/docs/ref/sprite.html](https://pyga.me/docs/ref/sprite.html)

I believe this paragraph is discussing Groups, but erroneously refers to a Sprite class drawing multiple Sprites it contains.

![image](https://github.com/pygame-community/pygame-ce/assets/90118809/5d1061cd-6a8b-4655-9e9c-b1bfa4e9c60e)

Corrects this by changing the word Sprite to Group.

