### PR TITLE
Optimize vector parsing in math.c

### DIFF
--- a/src_c/math.c
+++ b/src_c/math.c
@@ -465,8 +465,8 @@ pgVectorCompatible_Check(PyObject *obj, Py_ssize_t dim)
 // Returns 1 if obj is vector compatible to a vector of size "dim," and
 // copies vector coordinates into "coords" array of size >= dim
 // managed by caller. Returns 0 if obj is not compatible or an error
-// occurred. If 0 is returned, the error flag will not normally set. Callers
-// should set error themselves. This function is a combo of
+// occurred. If 0 is returned, the error flag will not normally be set.
+// Callers should set error themselves. This function is a combo of
 // pgVectorCompatible_Check and PySequence_AsVectorCoords
 static int
 pg_VectorCoordsFromObj(PyObject *obj, Py_ssize_t dim, double *const coords)
@@ -498,7 +498,7 @@ pg_VectorCoordsFromObj(PyObject *obj, Py_ssize_t dim, double *const coords)
     }
 
     for (i = 0; i < dim; ++i) {
-        tmp = PySequence_GetItem(obj, i);
+        tmp = PySequence_ITEM(obj, i);
         if (tmp != NULL) {
             coords[i] = PyFloat_AsDouble(tmp);
         }

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -502,7 +502,7 @@ pg_VectorCoordsFromObj(PyObject *obj, Py_ssize_t dim, double *const coords)
         if (tmp != NULL) {
             coords[i] = PyFloat_AsDouble(tmp);
         }
-        Py_DECREF(tmp);
+        Py_XDECREF(tmp);
         if (PyErr_Occurred()) {
             PyErr_Clear();
             return 0;


### PR DESCRIPTION
Strategy-- The vector compatible check and sequence_vectorcoords functions duplicated some checks, so a unified function could optimize the overall runtime.

Conclusions: I had hoped to optimize vector_generic_math, but the results are mixed as you can see below. The runs are too variable for me to confidently say it's a speedup or slowdown in that area. However, this is definitely a speedup for Vector methods that take in and process vectors, especially when called with sequences instead of other vectors. ~~**Vector methods are now 7% faster on average when taking vector arguments, 18% faster when taking sequence arguments.**~~ **Vector methods are now 5.5% faster on average when taking vector arguments, 20% faster when taking sequence arguments.**

There are more instances of pgVectorCompatible_Check +  PySequence_AsVectorCoords coupled in the code, but in harder to test areas, like in the elementwise proxy, so I'm leaving those be for now.

Benchmarking results (several runs before/after averaged):
```
vec2_1.move_towards(vec2_2, 4): 0.8714175000000001 (3.349% faster)
vec2_1.move_towards(vec2like, 4): 1.06382 (12.487% faster)
vec2_1.move_towards_ip(vec2_2, 4): 0.7681425000000001 (3.353% faster)
vec2_1.move_towards_ip(vec2like, 4): 0.89942 (17.049% faster)
vec3_1.move_towards(vec3_2, 4): 0.9133575 (0.082% faster)
vec3_1.move_towards(vec3like, 4): 1.0817775 (16.579% faster)
vec3_1.move_towards_ip(vec3_2, 4): 0.7777825 (4.29% faster)
vec3_1.move_towards_ip(vec3like, 4): 0.9343374999999999 (20.735% faster)
vec2_1.cross(vec2_2): 0.4231025 (9.083% faster)
vec2_1.cross(vec2like): 0.6134875 (21.03% faster)
vec3_1.cross(vec3_2): 0.488765 (6.727% faster)
vec3_1.cross(vec3like): 0.7261725 (23.767% faster)
vec2_1.angle_to(vec2_2): 0.5835575 (8.587% faster)
vec2_1.angle_to(vec2like): 0.7513475 (22.943% faster)
vec3_1.angle_to(vec3_2): 0.5254425 (14.304% faster)
vec3_1.angle_to(vec3like): 0.7385475 (23.836% faster)
vec3_1.rotate(34, vec3_2): 0.9605474999999999 (1.951% faster)
vec3_1.rotate_ip(34, vec3_2): 0.85734 (3.164% faster)
vec2_1 + vec2_2: 0.27509249999999996 (3.111% faster)
vec2_1 + vec2like: 0.477885 (25.886% faster)
vec2_1 * vec2_2: 0.2107525 (2.365% faster)
vec2_1 * vec2like: 0.4136725 (26.987% faster)
vec2_1 * 2.3: 0.356165 (-9.052% faster)
vec3_1 + vec3_2: 0.3149825 (2.445% faster)
vec3_1 + vec3like: 0.52228 (30.443% faster)
vec3_1 * vec3_2: 0.245065 (8.35% faster)
vec3_1 * vec3like: 0.4576 (31.846% faster)
vec3_1 * 2.3: 0.37668 (-7.955% faster)

Average change = 11.705 %
```

<details>
<summary>Benchmarking script</summary>

```py
import timeit

import pygame

vec2_1 = pygame.Vector2(36,6.4)
vec2_2 = pygame.Vector2(4,5)
vec2like = (50, 60)

vec3_1 = pygame.Vector3(36,6.4,-99)
vec3_2 = pygame.Vector3(4,5,56)
vec3like = (50, 60, 20.4)

def bench(statement, globals=globals(), number=5000000):
    return round(timeit.timeit(statement, globals=globals, number=number), 5)

# Put previous output results here to automatically generate comparison
prevresults = []

thisresults = []

thischanges = []

def printbench(statement):
    v2 = bench(statement)
    thisresults.append(v2)

    if prevresults:
        v1 = prevresults[len(thisresults)-1]
        change = -round((v2 - v1) / abs(v1) * 100, 3)
        thischanges.append(change)
        print(f"{statement}: {v2} ({change}% faster)")
    else:
        print(f"{statement}: {v2}")

printbench("vec2_1.move_towards(vec2_2, 4)")
printbench("vec2_1.move_towards(vec2like, 4)")
printbench("vec2_1.move_towards_ip(vec2_2, 4)")
printbench("vec2_1.move_towards_ip(vec2like, 4)")

printbench("vec3_1.move_towards(vec3_2, 4)")
printbench("vec3_1.move_towards(vec3like, 4)")
printbench("vec3_1.move_towards_ip(vec3_2, 4)")
printbench("vec3_1.move_towards_ip(vec3like, 4)")

printbench("vec2_1.cross(vec2_2)")
printbench("vec2_1.cross(vec2like)")

printbench("vec3_1.cross(vec3_2)")
printbench("vec3_1.cross(vec3like)")

printbench("vec2_1.angle_to(vec2_2)")
printbench("vec2_1.angle_to(vec2like)")

printbench("vec3_1.angle_to(vec3_2)")
printbench("vec3_1.angle_to(vec3like)")

printbench("vec3_1.rotate(34, vec3_2)")
printbench("vec3_1.rotate_ip(34, vec3_2)")

printbench("vec2_1 + vec2_2")
printbench("vec2_1 + vec2like")
printbench("vec2_1 * vec2_2")
printbench("vec2_1 * vec2like")
printbench("vec2_1 * 2.3")

printbench("vec3_1 + vec3_2")
printbench("vec3_1 + vec3like")
printbench("vec3_1 * vec3_2")
printbench("vec3_1 * vec3like")
printbench("vec3_1 * 2.3")

if thischanges:
    print()
    print("Average change =", round(sum(thischanges)/len(thischanges), 3), "%")
    print()

print(thisresults)
```
</details>