### PR TITLE
Fix linter failing due to new clang-format version

### DIFF
--- a/src_c/freetype/ft_wrap.h
+++ b/src_c/freetype/ft_wrap.h
@@ -43,10 +43,10 @@
 #define FX16_ROUND_TO_INT(x) (((x) + 32768L) >> 16)
 #define INT_TO_FX6(i) ((FT_Fixed)((i) << 6))
 #define INT_TO_FX16(i) ((FT_Fixed)((i) << 16))
-#define FX16_TO_DBL(x) ((x)*1.52587890625e-5 /* 2.0^-16 */)
-#define DBL_TO_FX16(d) ((FT_Fixed)((d)*65536.0))
-#define FX6_TO_DBL(x) ((x)*1.5625e-2 /* 2.0^-6 */)
-#define DBL_TO_FX6(d) ((FT_Fixed)((d)*64.0))
+#define FX16_TO_DBL(x) ((x) * 1.52587890625e-5 /* 2.0^-16 */)
+#define DBL_TO_FX16(d) ((FT_Fixed)((d) * 65536.0))
+#define FX6_TO_DBL(x) ((x) * 1.5625e-2 /* 2.0^-6 */)
+#define DBL_TO_FX6(d) ((FT_Fixed)((d) * 64.0))
 
 /* Internal configuration variables */
 #define PGFT_DEFAULT_CACHE_SIZE 64

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -93,8 +93,8 @@ static PyTypeObject pgVectorIter_Type;
 #define _vector_subtype_new(x) \
     ((pgVector *)(Py_TYPE(x)->tp_new(Py_TYPE(x), NULL, NULL)))
 
-#define DEG2RAD(angle) ((angle)*M_PI / 180.)
-#define RAD2DEG(angle) ((angle)*180. / M_PI)
+#define DEG2RAD(angle) ((angle) * M_PI / 180.)
+#define RAD2DEG(angle) ((angle) * 180. / M_PI)
 
 typedef struct {
     PyObject_HEAD double coords[VECTOR_MAX_SIZE]; /* Coordinates */

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -57,13 +57,13 @@ const PG_sample_format_t PG_SAMPLE_LITTLE_ENDIAN = 0;
 const PG_sample_format_t PG_SAMPLE_BIG_ENDIAN = 0x20000u;
 #endif
 const PG_sample_format_t PG_SAMPLE_CHAR_SIGN = (char)0xff > 0 ? 0 : 0x10000u;
-#define PG_SAMPLE_SIZE(sf) ((sf)&0x0ffffu)
-#define PG_IS_SAMPLE_SIGNED(sf) ((sf)&PG_SAMPLE_SIGNED != 0)
-#define PG_IS_SAMPLE_NATIVE_ENDIAN(sf) ((sf)&PG_SAMPLE_NATIVE_ENDIAN != 0)
+#define PG_SAMPLE_SIZE(sf) ((sf) & 0x0ffffu)
+#define PG_IS_SAMPLE_SIGNED(sf) ((sf) & PG_SAMPLE_SIGNED != 0)
+#define PG_IS_SAMPLE_NATIVE_ENDIAN(sf) ((sf) & PG_SAMPLE_NATIVE_ENDIAN != 0)
 #define PG_IS_SAMPLE_LITTLE_ENDIAN(sf) \
-    ((sf)&PG_SAMPLE_LITTLE_ENDIAN == PG_SAMPLE_LITTLE_ENDIAN)
+    ((sf) & PG_SAMPLE_LITTLE_ENDIAN == PG_SAMPLE_LITTLE_ENDIAN)
 #define PG_IS_SAMPLE_BIG_ENDIAN(sf) \
-    ((sf)&PG_SAMPLE_BIG_ENDIAN == PG_SAMPLE_BIG_ENDIAN)
+    ((sf) & PG_SAMPLE_BIG_ENDIAN == PG_SAMPLE_BIG_ENDIAN)
 
 /* Since they are documented, the default init values are defined here
    rather than taken from SDL_mixer. It also means that the default

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1955,79 +1955,86 @@ clamp_4
 
 */
 
-#define SURF_GET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format, p_pix)     \
-    switch (p_format->BytesPerPixel) {                                        \
-        case 1:                                                               \
-            p_color = (Uint32) *                                              \
-                      ((Uint8 *)(p_pixels) + (p_y)*p_surf->pitch + (p_x));    \
-            break;                                                            \
-        case 2:                                                               \
-            p_color = (Uint32) *                                              \
-                      ((Uint16 *)((p_pixels) + (p_y)*p_surf->pitch) + (p_x)); \
-            break;                                                            \
-        case 3:                                                               \
-            p_pix = ((Uint8 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)*3);    \
-            p_color = (SDL_BYTEORDER == SDL_LIL_ENDIAN)                       \
-                          ? (p_pix[0]) + (p_pix[1] << 8) + (p_pix[2] << 16)   \
-                          : (p_pix[2]) + (p_pix[1] << 8) + (p_pix[0] << 16);  \
-            break;                                                            \
-        default: /* case 4: */                                                \
-            p_color = *((Uint32 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x));  \
-            break;                                                            \
+#define SURF_GET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format, p_pix)    \
+    switch (p_format->BytesPerPixel) {                                       \
+        case 1:                                                              \
+            p_color = (Uint32) *                                             \
+                      ((Uint8 *)(p_pixels) + (p_y) * p_surf->pitch + (p_x)); \
+            break;                                                           \
+        case 2:                                                              \
+            p_color =                                                        \
+                (Uint32) *                                                   \
+                ((Uint16 *)((p_pixels) + (p_y) * p_surf->pitch) + (p_x));    \
+            break;                                                           \
+        case 3:                                                              \
+            p_pix =                                                          \
+                ((Uint8 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x) * 3);   \
+            p_color = (SDL_BYTEORDER == SDL_LIL_ENDIAN)                      \
+                          ? (p_pix[0]) + (p_pix[1] << 8) + (p_pix[2] << 16)  \
+                          : (p_pix[2]) + (p_pix[1] << 8) + (p_pix[0] << 16); \
+            break;                                                           \
+        default: /* case 4: */                                               \
+            p_color =                                                        \
+                *((Uint32 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x));     \
+            break;                                                           \
     }
 
 #if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
 
-#define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,            \
-                    p_byte_buf)                                               \
-    switch (p_format->BytesPerPixel) {                                        \
-        case 1:                                                               \
-            *((Uint8 *)p_pixels + (p_y)*p_surf->pitch + (p_x)) =              \
-                (Uint8)p_color;                                               \
-            break;                                                            \
-        case 2:                                                               \
-            *((Uint16 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)) =           \
-                (Uint16)p_color;                                              \
-            break;                                                            \
-        case 3:                                                               \
-            p_byte_buf = (Uint8 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)*3; \
-            *(p_byte_buf + (p_format->Rshift >> 3)) =                         \
-                (Uint8)(p_color >> p_format->Rshift);                         \
-            *(p_byte_buf + (p_format->Gshift >> 3)) =                         \
-                (Uint8)(p_color >> p_format->Gshift);                         \
-            *(p_byte_buf + (p_format->Bshift >> 3)) =                         \
-                (Uint8)(p_color >> p_format->Bshift);                         \
-            break;                                                            \
-        default:                                                              \
-            *((Uint32 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)) = p_color;  \
-            break;                                                            \
+#define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,       \
+                    p_byte_buf)                                          \
+    switch (p_format->BytesPerPixel) {                                   \
+        case 1:                                                          \
+            *((Uint8 *)p_pixels + (p_y) * p_surf->pitch + (p_x)) =       \
+                (Uint8)p_color;                                          \
+            break;                                                       \
+        case 2:                                                          \
+            *((Uint16 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
+                (Uint16)p_color;                                         \
+            break;                                                       \
+        case 3:                                                          \
+            p_byte_buf =                                                 \
+                (Uint8 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x) * 3; \
+            *(p_byte_buf + (p_format->Rshift >> 3)) =                    \
+                (Uint8)(p_color >> p_format->Rshift);                    \
+            *(p_byte_buf + (p_format->Gshift >> 3)) =                    \
+                (Uint8)(p_color >> p_format->Gshift);                    \
+            *(p_byte_buf + (p_format->Bshift >> 3)) =                    \
+                (Uint8)(p_color >> p_format->Bshift);                    \
+            break;                                                       \
+        default:                                                         \
+            *((Uint32 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
+                p_color;                                                 \
+            break;                                                       \
     }
 
 #else
 
-#define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,            \
-                    p_byte_buf)                                               \
-    switch (p_format->BytesPerPixel) {                                        \
-        case 1:                                                               \
-            *((Uint8 *)p_pixels + (p_y)*p_surf->pitch + (p_x)) =              \
-                (Uint8)p_color;                                               \
-            break;                                                            \
-        case 2:                                                               \
-            *((Uint16 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)) =           \
-                (Uint16)p_color;                                              \
-            break;                                                            \
-        case 3:                                                               \
-            p_byte_buf = (Uint8 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)*3; \
-            *(p_byte_buf + 2 - (p_format->Rshift >> 3)) =                     \
-                (Uint8)(p_color >> p_format->Rshift);                         \
-            *(p_byte_buf + 2 - (p_format->Gshift >> 3)) =                     \
-                (Uint8)(p_color >> p_format->Gshift);                         \
-            *(p_byte_buf + 2 - (p_format->Bshift >> 3)) =                     \
-                (Uint8)(p_color >> p_format->Bshift);                         \
-            break;                                                            \
-        default:                                                              \
-            *((Uint32 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)) = p_color;  \
-            break;                                                            \
+#define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,       \
+                    p_byte_buf)                                          \
+    switch (p_format->BytesPerPixel) {                                   \
+        case 1:                                                          \
+            *((Uint8 *)p_pixels + (p_y) * p_surf->pitch + (p_x)) =       \
+                (Uint8)p_color;                                          \
+            break;                                                       \
+        case 2:                                                          \
+            *((Uint16 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
+                (Uint16)p_color;                                         \
+            break;                                                       \
+        case 3:                                                          \
+            p_byte_buf =                                                 \
+                (Uint8 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x) * 3; \
+            *(p_byte_buf + 2 - (p_format->Rshift >> 3)) =                \
+                (Uint8)(p_color >> p_format->Rshift);                    \
+            *(p_byte_buf + 2 - (p_format->Gshift >> 3)) =                \
+                (Uint8)(p_color >> p_format->Gshift);                    \
+            *(p_byte_buf + 2 - (p_format->Bshift >> 3)) =                \
+                (Uint8)(p_color >> p_format->Bshift);                    \
+            break;                                                       \
+        default:                                                         \
+            *((Uint32 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
+                p_color;                                                 \
+            break;                                                       \
     }
 
 #endif


### PR DESCRIPTION
So `clang-format` got updated and now the linter is failing because it wants to format some stuff, well, this PR formats that stuff.