### PR TITLE
Fix uint64 underflow in `tick_busy_loop`

### DIFF
--- a/src_c/time.c
+++ b/src_c/time.c
@@ -27,7 +27,7 @@
 #include "doc/time_doc.h"
 
 #define WORST_CLOCK_ACCURACY 12
-#define MAX_UINT_64 18446744073709551615
+#define MAX_UINT_64 18446744073709551615ULL
 
 /* Enum containing some error codes used by timer related functions */
 typedef enum {

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -27,6 +27,7 @@
 #include "doc/time_doc.h"
 
 #define WORST_CLOCK_ACCURACY 12
+#define MAX_UINT_64 18446744073709551615
 
 /* Enum containing some error codes used by timer related functions */
 typedef enum {
@@ -330,7 +331,7 @@ accurate_delay(Sint64 ticks)
     }
     do {
         delay = ticks - (PG_GetTicks() - funcstart);
-    } while (delay > 0);
+    } while (delay > 0 && delay < (MAX_UINT_64 >> 1));
 
     return PG_GetTicks() - funcstart;
 }

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -27,7 +27,6 @@
 #include "doc/time_doc.h"
 
 #define WORST_CLOCK_ACCURACY 12
-#define MAX_UINT_64 18446744073709551615ULL
 
 /* Enum containing some error codes used by timer related functions */
 typedef enum {
@@ -331,7 +330,7 @@ accurate_delay(Sint64 ticks)
     }
     do {
         delay = ticks - (PG_GetTicks() - funcstart);
-    } while (delay > 0 && delay < (MAX_UINT_64 >> 1));
+    } while (delay > 0 && delay < (SDL_MAX_UINT64 >> 1));
 
     return PG_GetTicks() - funcstart;
 }

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -308,6 +308,10 @@ static Uint64
 accurate_delay(Sint64 ticks)
 {
     Uint64 funcstart, delay;
+    // Maximum delay, of the order of hundreds of millions of years. This
+    // should prevent Uint64 underflow issues with a CPU lag spike during the
+    // loop
+    Uint64 maximum_delay = (SDL_MAX_UINT64 >> 1);
 
     if (ticks <= 0)
         return 0;
@@ -330,7 +334,7 @@ accurate_delay(Sint64 ticks)
     }
     do {
         delay = ticks - (PG_GetTicks() - funcstart);
-    } while (delay > 0 && delay < (SDL_MAX_UINT64 >> 1));
+    } while (delay > 0 && delay < maximum_delay);
 
     return PG_GetTicks() - funcstart;
 }


### PR DESCRIPTION
It was reported on discord that using `tick_busy_loop` could cause a crash in a specific scenario.

Reproducer
```python
import pygame


WIDTH, HEIGHT = 640, 360
FPS = 60

pygame.init()
screen = pygame.display.set_mode((WIDTH, HEIGHT))
clock = pygame.Clock()

running = True
while running:
    dt = clock.tick_busy_loop(FPS) / 1000
    screen.fill("black")
    
    events = pygame.event.get()
    for event in events:
        if event.type == pygame.QUIT:
            running = False

    pygame.display.flip()
```
It's an odd one though, I didn't see it on my own machine. After some troubleshooting with @Matiiss and the reporter, I believe it is due to an int underflow when there is a lag spike in cpu processing, causing `delay` to become insanely large (thus blocking the `while` loop from ever finishing).

I don't think a regression test is possible with our current framework