### PR TITLE
Make mpg123, fluidsynth and sndfile not link directly to lower-level audio playback libs

### DIFF
--- a/buildconfig/manylinux-build/docker_base/fluidsynth/build-fluidsynth.sh
+++ b/buildconfig/manylinux-build/docker_base/fluidsynth/build-fluidsynth.sh
@@ -14,12 +14,17 @@ cd $FSYNTH
 mkdir build
 cd build
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    export FLUIDSYNTH_EXTRA_PLAT_FLAGS="-Denable-alsa=NO -Denable-systemd=NO"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
     # We don't need fluidsynth framework on mac builds
-    export FLUIDSYNTH_EXTRA_MAC_FLAGS="-Denable-framework=NO"
+    export FLUIDSYNTH_EXTRA_PLAT_FLAGS="-Denable-framework=NO"
 fi
 
-cmake .. $PG_BASE_CMAKE_FLAGS -Denable-readline=OFF $FLUIDSYNTH_EXTRA_MAC_FLAGS
+cmake .. $PG_BASE_CMAKE_FLAGS -Denable-readline=OFF $FLUIDSYNTH_EXTRA_PLAT_FLAGS \
+    -Denable-pulseaudio=NO \
+    -Denable-pipewire=NO
+
 make
 make install
 

--- a/buildconfig/manylinux-build/docker_base/mpg123/build-mpg123.sh
+++ b/buildconfig/manylinux-build/docker_base/mpg123/build-mpg123.sh
@@ -12,7 +12,8 @@ bzip2 -d ${MPG123}.tar.bz2
 tar xf ${MPG123}.tar
 cd $MPG123
 
-./configure $ARCHS_CONFIG_FLAG --enable-int-quality --disable-debug
+./configure $ARCHS_CONFIG_FLAG --enable-int-quality --disable-debug \
+    --disable-components --enable-libmpg123 --enable-libsyn123
 make
 make install
 

--- a/buildconfig/manylinux-build/docker_base/sndfile/build-sndfile.sh
+++ b/buildconfig/manylinux-build/docker_base/sndfile/build-sndfile.sh
@@ -13,7 +13,8 @@ tar xf ${SNDFILE}
 cd $SNDNAME
 # autoreconf -fvi
 
-./configure $ARCHS_CONFIG_FLAG --disable-mpeg
+# alsa is only needed for examples here
+./configure $ARCHS_CONFIG_FLAG --disable-mpeg --disable-alsa
 make
 make install
 


### PR DESCRIPTION
Depends on #2470 (it should be merged before this)

EDITED description to what this PR does now (taking starbucks suggestions):

Previously, `mpg123`, `fluidsynth` and `sndfile` would link directly to lower-level libraries `alsa`, `pulseaudio` and others and all these would get included in the wheels. But these links aren't required for audio playback

As a side effect of these changes, our manylinux wheels should get a bit lighter (maybe 1-2 mb)

To test this PR, we need to make sure that fluidsynth-based music and mp3 music still work as before on linux (which I can test) and mac (for which I need a volunteers help)