### PR TITLE
Add SSE2 intrinsics smoothscale backend

### DIFF
--- a/src_c/simd_transform.h
+++ b/src_c/simd_transform.h
@@ -9,6 +9,21 @@
 
 // SSE2 functions
 #if defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)
+
+// smoothscale filters
+void
+filter_shrink_X_SSE2(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
+                     int dstpitch, int srcwidth, int dstwidth);
+void
+filter_shrink_Y_SSE2(Uint8 *srcpix, Uint8 *dstpix, int width, int srcpitch,
+                     int dstpitch, int srcheight, int dstheight);
+void
+filter_expand_X_SSE2(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
+                     int dstpitch, int srcwidth, int dstwidth);
+void
+filter_expand_Y_SSE2(Uint8 *srcpix, Uint8 *dstpix, int width, int srcpitch,
+                     int dstpitch, int srcheight, int dstheight);
+
 #endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
 
 // AVX2 functions

--- a/src_c/simd_transform_sse2.c
+++ b/src_c/simd_transform_sse2.c
@@ -37,69 +37,101 @@ pg_neon_at_runtime_but_uncompiled()
 
 #if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
 
-void
-filter_shrink_X_SSE2_multi(Uint8 *srcpix, Uint8 *dstpix, int height,
-                           int srcpitch, int dstpitch, int srcwidth,
-                           int dstwidth)
-{
-    // FIXME TODO: assumes height is multiple of 2
+// For some reason this is not defined on some non Windows compilers
+#define _pg_loadu_si32(p) _mm_cvtsi32_si128(*(unsigned int const *)(p))
+#define _pg_loadu_si64(p) _mm_loadl_epi64((__m128i const *)(p))
+#define _pg_storeu_si32(p, a) (void)(*(int *)(p) = _mm_cvtsi128_si32((a)))
+#define _pg_storeu_si64(p, a) (_mm_storel_epi64((__m128i *)(p), (a)))
 
+void
+filter_shrink_X_SSE2(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
+                     int dstpitch, int srcwidth, int dstwidth)
+{
+    // This filter run through multiple pixels in a row at once, since it
+    // accumulates then writes -- the pixels in a row are not independent.
+    // However, this accumulate/write cycle is the same for each row, so
+    // multiple rows can be run at once, saving about 37% X-shrink runtime
+    // in my testing.
+
+    // These need to skip remaining bytes in a row, plus the entire next
+    // row, with the alternating row strategy. The redundancy in the equations
+    // makes them more clear, so I left it.
     int srcdiff = srcpitch - (srcwidth * 4) + srcpitch;
     int dstdiff = dstpitch - (dstwidth * 4) + dstpitch;
-    int x, y;
-
-    __m128i src, src2, dst, dst2, accumulate, mm_xcounter, mm_xfrac;
-
     Uint8 *srcpix2 = srcpix + srcpitch;
     Uint8 *dstpix2 = dstpix + dstpitch;
 
-    int xspace = 0x04000 * srcwidth / dstwidth; /* must be > 1 */
+    int x, y;
+    __m128i src, src2, dst, accumulate, mm_xcounter, mm_xfrac;
 
+    int xspace = 0x04000 * srcwidth / dstwidth; /* must be > 1 */
     __m128i xrecip = _mm_set1_epi16((Uint16)(0x40000000 / xspace));
 
     for (y = 0; y < height; y += 2) {
         accumulate = _mm_setzero_si128();
         int xcounter = xspace;
+
+        // Prevent overwrite over final row of pixels when the surface height
+        // is odd (as in not even)
+        if (y == height - 1) {
+            srcpix2 = srcpix;
+            dstpix2 = dstpix;
+        }
+
         for (x = 0; x < srcwidth; x++) {
             if (xcounter > 0x04000) {
-                src = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix),
+                // Load a pixel from two separate lines at once
+                // Unpack RGBA into 16 bit lanes
+                src = _mm_unpacklo_epi8(_pg_loadu_si32(srcpix),
                                         _mm_setzero_si128());
-
-                src2 = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix2),
+                src2 = _mm_unpacklo_epi8(_pg_loadu_si32(srcpix2),
                                          _mm_setzero_si128());
-                src2 = _mm_slli_si128(src2, 8);  // replace with
-                src = _mm_add_epi16(src, src2);  // _mm_unpacklo_epi64?
 
+                // Combine the two expanded pixels
+                src = _mm_unpacklo_epi64(src, src2);
+
+                // Accumulate[127:64] tracks the srcpix2 pixel line,
+                // [63:0] tracks the srcpix pixel line
                 accumulate = _mm_add_epi16(accumulate, src);
                 srcpix += 4;
                 srcpix2 += 4;
                 xcounter -= 0x04000;
             }
+            /* write out a destination pixel */
             else {
                 int xfrac = 0x04000 - xcounter;
-                /* write out a destination pixel */
 
+                // Broadcast variables into intrinsics
                 mm_xcounter = _mm_set1_epi16(xcounter);
                 mm_xfrac = _mm_set1_epi16(xfrac);
 
-                src = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix),
+                // Load a pixel from two separate lines at once
+                // Unpack RGBA into 16 bit lanes
+                src = _mm_unpacklo_epi8(_pg_loadu_si32(srcpix),
                                         _mm_setzero_si128());
-
-                src2 = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix2),
+                src2 = _mm_unpacklo_epi8(_pg_loadu_si32(srcpix2),
                                          _mm_setzero_si128());
-                src2 = _mm_slli_si128(src2, 8);  // replace with
-                src = _mm_add_epi16(src, src2);  // _mm_unpacklo_epi64?
 
+                // Combine the two expanded pixels
+                src = _mm_unpacklo_epi64(src, src2);
+
+                // The operation! Translated from old filter_shrink_X_SSE
+                // assembly. I don't understand the equivalence between
+                // these operations and the C version of these operations,
+                // but it works.
                 src = _mm_slli_epi16(src, 2);
                 dst = _mm_mulhi_epu16(src, mm_xcounter);
                 dst = _mm_add_epi16(dst, accumulate);
                 accumulate = _mm_mulhi_epu16(src, mm_xfrac);
 
                 dst = _mm_mulhi_epu16(dst, xrecip);
-                dst = _mm_packus_epi16(dst, _mm_setzero_si128());
-                _mm_storeu_si32(dstpix, dst);
 
-                _mm_storeu_si32(dstpix2, _mm_srli_si128(dst, 4));
+                // Pack and store results. Once packed, both pixel results are
+                // in 64 bits. First 32 is stored at dstpix, next 32 is stored
+                // at dstpix2.
+                dst = _mm_packus_epi16(dst, _mm_setzero_si128());
+                _pg_storeu_si32(dstpix, dst);
+                _pg_storeu_si32(dstpix2, _mm_srli_si128(dst, 4));
 
                 dstpix += 4;
                 dstpix2 += 4;
@@ -116,127 +148,115 @@ filter_shrink_X_SSE2_multi(Uint8 *srcpix, Uint8 *dstpix, int height,
 }
 
 void
-filter_shrink_X_SSE2(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
-                     int dstpitch, int srcwidth, int dstwidth)
-{
-    int srcdiff = srcpitch - (srcwidth * 4);
-    int dstdiff = dstpitch - (dstwidth * 4);
-    int x, y;
-    __m128i src, dst, accumulate, mm_xcounter, mm_xfrac;
-
-    int xspace = 0x04000 * srcwidth / dstwidth; /* must be > 1 */
-    __m128i xrecip = _mm_set1_epi16(0x40000000 / xspace);
-
-    for (y = 0; y < height; y++) {
-        accumulate = _mm_setzero_si128();
-        int xcounter = xspace;
-        for (x = 0; x < srcwidth; x++) {
-            if (xcounter > 0x04000) {
-                src = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix),
-                                        _mm_setzero_si128());
-
-                accumulate = _mm_add_epi16(accumulate, src);
-                srcpix += 4;
-                xcounter -= 0x04000;
-            }
-            else {
-                int xfrac = 0x04000 - xcounter;
-                /* write out a destination pixel */
-
-                mm_xcounter = _mm_set1_epi16(xcounter);
-                mm_xfrac = _mm_set1_epi16(xfrac);
-
-                src = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix),
-                                        _mm_setzero_si128());
-
-                src = _mm_slli_epi16(src, 2);
-                dst = _mm_mulhi_epu16(src, mm_xcounter);
-                dst = _mm_add_epi16(dst, accumulate);
-                accumulate = _mm_mulhi_epu16(src, mm_xfrac);
-
-                dst = _mm_mulhi_epu16(dst, xrecip);
-                dst = _mm_packus_epi16(dst, _mm_setzero_si128());
-                _mm_storeu_si32(dstpix, dst);
-
-                dstpix += 4;
-                srcpix += 4;
-
-                xcounter = xspace - xfrac;
-            }
-        }
-        srcpix += srcdiff;
-        dstpix += dstdiff;
-    }
-}
-
-void
 filter_shrink_Y_SSE2(Uint8 *srcpix, Uint8 *dstpix, int width, int srcpitch,
                      int dstpitch, int srcheight, int dstheight)
 {
+    // This filter also iterates over Y and then over X, but unlike
+    // filter_shrink_X_SSE2 it can be parallelized in the X direction because
+    // each pixel in a row is independent from the algorithm's perspective.
+    // Going from SSE2 single pixel to SSE2 double pixel in this saved about
+    // 25% Y-shrink runtime in my testing.
+
     int srcdiff = srcpitch - (width * 4);
     int dstdiff = dstpitch - (width * 4);
     int x, y;
     __m128i src, dst, mm_acc, mm_yfrac, mm_ycounter;
+
+    int during_2_width = width / 2;
+    int post_2_width = width % 2;
 
     int yspace = 0x04000 * srcheight / dstheight; /* must be > 1 */
     __m128i yrecip = _mm_set1_epi16(0x40000000 / yspace);
     int ycounter = yspace;
 
     Uint16 *templine;
-    // TODO replace malloc+memset with calloc?
-    /* allocate and clear a memory area for storing the accumulator line */
-    templine = (Uint16 *)malloc(dstpitch * 2);
-    if (templine == NULL)
+    /* allocate a clear memory area for storing the accumulator line */
+    // Future: when we support SDL 2.0.10 and up, we can use SDL_SIMDAlloc
+    // here so accumulate load/stores can be aligned, for a small perf
+    // improvement.
+    templine = (Uint16 *)calloc(dstpitch, 2);
+    if (templine == NULL) {
         return;
-    memset(templine, 0, dstpitch * 2);
+    }
 
     for (y = 0; y < srcheight; y++) {
         Uint16 *accumulate = templine;
         if (ycounter > 0x04000) {
-            // TODO could iterate multipixel at a time
-            for (x = 0; x < width; x++) {
-                src = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix),
+            // Loads up the whole pixel row in 16 bit lanes and adds to
+            // existing data in accumulate/templine.
+            for (x = 0; x < during_2_width; x++) {
+                src = _mm_unpacklo_epi8(_pg_loadu_si64(srcpix),
                                         _mm_setzero_si128());
-                _mm_storeu_si64(
+                _mm_storeu_si128(
+                    (__m128i *)accumulate,
+                    _mm_add_epi16(_mm_loadu_si128((const __m128i *)accumulate),
+                                  src));
+                accumulate += 8;  // 8 Uint16s, so 16 bytes
+                srcpix += 8;      // 8 Uint8s, so 8 bytes (2 pixels)
+            }
+            if (post_2_width) {  // either 0 or 1, no need for second for loop
+                src = _mm_unpacklo_epi8(_pg_loadu_si32(srcpix),
+                                        _mm_setzero_si128());
+                _pg_storeu_si64(
                     accumulate,
-                    _mm_add_epi16(_mm_loadu_si64(accumulate), src));
+                    _mm_add_epi16(_pg_loadu_si64(accumulate), src));
                 accumulate += 4;  // 4 Uint16s, so 8 bytes
-                srcpix += 4;
+                srcpix += 4;      // 4 bytes (1 pixel)
             }
             ycounter -= 0x04000;
         }
         else {
+            // Calculates and tracks variables in C then broadcasts them
+            // to intrinsics when needed for calculations.
             int yfrac = 0x04000 - ycounter;
+            mm_yfrac = _mm_set1_epi16(yfrac);
+            mm_ycounter = _mm_set1_epi16(ycounter);
+
             /* write out a destination line */
-            // TODO could iterate multipixel at a time
-            for (x = 0; x < width; x++) {
-                src = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix),
+            for (x = 0; x < during_2_width; x++) {
+                src = _mm_unpacklo_epi8(_pg_loadu_si64(srcpix),
                                         _mm_setzero_si128());
-                srcpix += 4;
-
-                mm_acc = _mm_loadu_si64(accumulate);
-
-                mm_yfrac = _mm_set1_epi16(yfrac);
-                mm_ycounter = _mm_set1_epi16(ycounter);
+                srcpix += 8;  // 8 bytes
+                mm_acc = _mm_loadu_si128((const __m128i *)accumulate);
 
                 src = _mm_slli_epi16(src, 2);
                 dst = _mm_mulhi_epu16(src, mm_yfrac);
                 src = _mm_mulhi_epu16(src, mm_ycounter);
 
-                _mm_storeu_si64(accumulate, dst);
-                accumulate += 4;  // 4 Uint16s, so 8 bytes
+                _mm_storeu_si128((__m128i *)accumulate, dst);
+                accumulate += 8;  // 4 Uint16s, so 8 bytes
 
                 dst = _mm_add_epi16(src, mm_acc);
                 dst = _mm_mulhi_epu16(dst, yrecip);
                 dst = _mm_packus_epi16(dst, _mm_setzero_si128());
-                _mm_storeu_si32(dstpix, dst);
+                _pg_storeu_si64(dstpix, dst);
+                dstpix += 8;  // 8 bytes
+            }
+            if (post_2_width) {  // either 0 or 1, no need for second for loop
+                src = _mm_unpacklo_epi8(_pg_loadu_si32(srcpix),
+                                        _mm_setzero_si128());
+                srcpix += 4;
+                mm_acc = _pg_loadu_si64(accumulate);
+
+                src = _mm_slli_epi16(src, 2);
+                dst = _mm_mulhi_epu16(src, mm_yfrac);
+                src = _mm_mulhi_epu16(src, mm_ycounter);
+
+                _pg_storeu_si64(accumulate, dst);
+                // accumulate doesn't need to be incremented here because
+                // it is reassigned at the top of the loop.
+
+                dst = _mm_add_epi16(src, mm_acc);
+                dst = _mm_mulhi_epu16(dst, yrecip);
+                dst = _mm_packus_epi16(dst, _mm_setzero_si128());
+                _pg_storeu_si32(dstpix, dst);
                 dstpix += 4;
             }
             dstpix += dstdiff;
             ycounter = yspace - yfrac;
         }
         srcpix += srcdiff;
-    } /* for (int y = 0; y < srcheight; y++) */
+    }
 
     /* free the temporary memory */
     free(templine);
@@ -251,6 +271,7 @@ filter_expand_X_SSE2(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
     int x, y;
     const int factorwidth = 8;
 
+    // Inherited this from the ONLYC variant, maybe can be removed/
 #ifdef _MSC_VER
     /* Make MSVC static analyzer happy by assuring dstwidth >= 2 to suppress
      * a false analyzer report */
@@ -261,6 +282,8 @@ filter_expand_X_SSE2(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
     xidx0 = malloc(dstwidth * 4);
     if (xidx0 == 0)
         return;
+    // This algorithm uses two multipliers, xm0 and xm1. Each multiplier
+    // gets 32 bits of space, so this gives 64 bits per dstwidth.
     xmult_combined = (int *)malloc(dstwidth * factorwidth);
     if (xmult_combined == 0) {
         free(xidx0);
@@ -281,7 +304,7 @@ filter_expand_X_SSE2(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
         xmult_combined[x * 2 + 1] = xm1 | (xm1 << 16);
     }
 
-    __m128i src, mmxid, mult0, mult1, multcombined, dst;
+    __m128i src, multcombined, dst;
 
     /* Do the scaling in raster order so we don't trash the cache */
     for (y = 0; y < height; y++) {
@@ -291,20 +314,21 @@ filter_expand_X_SSE2(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
                 srcrow0 + xidx0[x] * 4;  // *8 now because of factorwidth?
 
             src =
-                _mm_unpacklo_epi8(_mm_loadu_si64(src_p), _mm_setzero_si128());
+                _mm_unpacklo_epi8(_pg_loadu_si64(src_p), _mm_setzero_si128());
 
             // uses combined multipliers against 2 src pixels
-            // xm0 against src[0-3] (1 px), and xm1 against xrc[4-7] (1 px)
+            // xm0 against src[0-3] (1 px), and xm1 against src[4-7] (1 px)
             multcombined = _mm_shuffle_epi32(
-                _mm_loadu_si64(xmult_combined + x * 2), 0b01010000);
-
+                _pg_loadu_si64(xmult_combined + x * 2), 0b01010000);
             src = _mm_mullo_epi16(src, multcombined);
 
-            dst = _mm_bsrli_si128(src, 8);
-            dst = _mm_add_epi16(src, dst);
-            dst = _mm_srli_epi16(dst, 8);
-            dst = _mm_packus_epi16(dst, _mm_setzero_si128());
-            _mm_storeu_si32(dstpix, dst);
+            // shift over pixel 2 results and add with pixel 1 results
+            dst = _mm_add_epi16(src, _mm_bsrli_si128(src, 8));
+
+            // pack results and store destination pixel.
+            dst =
+                _mm_packus_epi16(_mm_srli_epi16(dst, 8), _mm_setzero_si128());
+            _pg_storeu_si32(dstpix, dst);
 
             dstpix += 4;
         }
@@ -320,9 +344,18 @@ void
 filter_expand_Y_SSE2(Uint8 *srcpix, Uint8 *dstpix, int width, int srcpitch,
                      int dstpitch, int srcheight, int dstheight)
 {
-    int x, y;
+    // This filter parallelizes math operations using SSE2, but it also runs
+    // through each row 2 pixels at a time. The 2x pixels at a time strategy
+    // was a 23% performance improvment for Y-expand over 1x at a time.
 
+    int x, y;
     __m128i src0, src1, dst, ymult0_mm, ymult1_mm;
+
+    // For some reason the C implementation does not have this, is that ok?
+    int dstdiff = dstpitch - (width * 4);
+
+    int during_2_width = width / 2;
+    int post_2_width = width % 2;
 
     for (y = 0; y < dstheight; y++) {
         int yidx0 = y * (srcheight - 1) / dstheight;
@@ -334,25 +367,49 @@ filter_expand_Y_SSE2(Uint8 *srcpix, Uint8 *dstpix, int width, int srcpitch,
         ymult0_mm = _mm_set1_epi16(ymult0);
         ymult1_mm = _mm_set1_epi16(ymult1);
 
-        for (x = 0; x < width; x++) {
-            src0 = _mm_unpacklo_epi8(_mm_loadu_si32(srcrow0),
+        for (x = 0; x < during_2_width; x++) {
+            // Load from srcrow0 and srcrow1 two pixels each, swizzled out
+            // into 16 bit lanes.
+            src0 = _mm_unpacklo_epi8(_pg_loadu_si64(srcrow0),
                                      _mm_setzero_si128());
-            src1 = _mm_unpacklo_epi8(_mm_loadu_si32(srcrow1),
+            src1 = _mm_unpacklo_epi8(_pg_loadu_si64(srcrow1),
                                      _mm_setzero_si128());
 
             src0 = _mm_mullo_epi16(src0, ymult0_mm);
             src1 = _mm_mullo_epi16(src1, ymult1_mm);
-
             dst = _mm_add_epi16(src0, src1);
             dst = _mm_srli_epi16(dst, 8);
-            dst = _mm_packus_epi16(dst, _mm_setzero_si128());
-            _mm_storeu_si32(dstpix, dst);
 
-            srcrow0 += 4;
+            // Pack down and store 2 destination pixels.
+            dst = _mm_packus_epi16(dst, _mm_setzero_si128());
+            _pg_storeu_si64(dstpix, dst);
+
+            srcrow0 += 8;  // 8 bytes (2 pixels)
+            srcrow1 += 8;
+            dstpix += 8;
+        }
+        if (post_2_width) {
+            // Load from srcrow0 and srcrow1 one pixel each, swizzled out
+            // into 16 bit lanes.
+            src0 = _mm_unpacklo_epi8(_pg_loadu_si32(srcrow0),
+                                     _mm_setzero_si128());
+            src1 = _mm_unpacklo_epi8(_pg_loadu_si32(srcrow1),
+                                     _mm_setzero_si128());
+
+            src0 = _mm_mullo_epi16(src0, ymult0_mm);
+            src1 = _mm_mullo_epi16(src1, ymult1_mm);
+            dst = _mm_add_epi16(src0, src1);
+            dst = _mm_srli_epi16(dst, 8);
+
+            // Pack down and store 1 destination pixel.
+            dst = _mm_packus_epi16(dst, _mm_setzero_si128());
+            _pg_storeu_si32(dstpix, dst);
+
+            srcrow0 += 4;  // 4 bytes (1 pixel)
             srcrow1 += 4;
             dstpix += 4;
         }
-        Uint8 *dstrow = dstpix + y * dstpitch;
+        dstpix += dstdiff;
     }
 }
 

--- a/src_c/simd_transform_sse2.c
+++ b/src_c/simd_transform_sse2.c
@@ -34,3 +34,326 @@ pg_neon_at_runtime_but_uncompiled()
     }
     return 0;
 }
+
+#if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
+
+void
+filter_shrink_X_SSE2_multi(Uint8 *srcpix, Uint8 *dstpix, int height,
+                           int srcpitch, int dstpitch, int srcwidth,
+                           int dstwidth)
+{
+    // FIXME TODO: assumes height is multiple of 2
+
+    int srcdiff = srcpitch - (srcwidth * 4) + srcpitch;
+    int dstdiff = dstpitch - (dstwidth * 4) + dstpitch;
+    int x, y;
+
+    __m128i src, src2, dst, dst2, accumulate, mm_xcounter, mm_xfrac;
+
+    Uint8 *srcpix2 = srcpix + srcpitch;
+    Uint8 *dstpix2 = dstpix + dstpitch;
+
+    int xspace = 0x04000 * srcwidth / dstwidth; /* must be > 1 */
+
+    __m128i xrecip = _mm_set1_epi16((Uint16)(0x40000000 / xspace));
+
+    for (y = 0; y < height; y += 2) {
+        accumulate = _mm_setzero_si128();
+        int xcounter = xspace;
+        for (x = 0; x < srcwidth; x++) {
+            if (xcounter > 0x04000) {
+                src = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix),
+                                        _mm_setzero_si128());
+
+                src2 = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix2),
+                                         _mm_setzero_si128());
+                src2 = _mm_slli_si128(src2, 8);  // replace with
+                src = _mm_add_epi16(src, src2);  // _mm_unpacklo_epi64?
+
+                accumulate = _mm_add_epi16(accumulate, src);
+                srcpix += 4;
+                srcpix2 += 4;
+                xcounter -= 0x04000;
+            }
+            else {
+                int xfrac = 0x04000 - xcounter;
+                /* write out a destination pixel */
+
+                mm_xcounter = _mm_set1_epi16(xcounter);
+                mm_xfrac = _mm_set1_epi16(xfrac);
+
+                src = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix),
+                                        _mm_setzero_si128());
+
+                src2 = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix2),
+                                         _mm_setzero_si128());
+                src2 = _mm_slli_si128(src2, 8);  // replace with
+                src = _mm_add_epi16(src, src2);  // _mm_unpacklo_epi64?
+
+                src = _mm_slli_epi16(src, 2);
+                dst = _mm_mulhi_epu16(src, mm_xcounter);
+                dst = _mm_add_epi16(dst, accumulate);
+                accumulate = _mm_mulhi_epu16(src, mm_xfrac);
+
+                dst = _mm_mulhi_epu16(dst, xrecip);
+                dst = _mm_packus_epi16(dst, _mm_setzero_si128());
+                _mm_storeu_si32(dstpix, dst);
+
+                _mm_storeu_si32(dstpix2, _mm_srli_si128(dst, 4));
+
+                dstpix += 4;
+                dstpix2 += 4;
+                srcpix += 4;
+                srcpix2 += 4;
+                xcounter = xspace - xfrac;
+            }
+        }
+        srcpix += srcdiff;
+        srcpix2 += srcdiff;
+        dstpix += dstdiff;
+        dstpix2 += dstdiff;
+    }
+}
+
+void
+filter_shrink_X_SSE2(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
+                     int dstpitch, int srcwidth, int dstwidth)
+{
+    int srcdiff = srcpitch - (srcwidth * 4);
+    int dstdiff = dstpitch - (dstwidth * 4);
+    int x, y;
+    __m128i src, dst, accumulate, mm_xcounter, mm_xfrac;
+
+    int xspace = 0x04000 * srcwidth / dstwidth; /* must be > 1 */
+    __m128i xrecip = _mm_set1_epi16(0x40000000 / xspace);
+
+    for (y = 0; y < height; y++) {
+        accumulate = _mm_setzero_si128();
+        int xcounter = xspace;
+        for (x = 0; x < srcwidth; x++) {
+            if (xcounter > 0x04000) {
+                src = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix),
+                                        _mm_setzero_si128());
+
+                accumulate = _mm_add_epi16(accumulate, src);
+                srcpix += 4;
+                xcounter -= 0x04000;
+            }
+            else {
+                int xfrac = 0x04000 - xcounter;
+                /* write out a destination pixel */
+
+                mm_xcounter = _mm_set1_epi16(xcounter);
+                mm_xfrac = _mm_set1_epi16(xfrac);
+
+                src = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix),
+                                        _mm_setzero_si128());
+
+                src = _mm_slli_epi16(src, 2);
+                dst = _mm_mulhi_epu16(src, mm_xcounter);
+                dst = _mm_add_epi16(dst, accumulate);
+                accumulate = _mm_mulhi_epu16(src, mm_xfrac);
+
+                dst = _mm_mulhi_epu16(dst, xrecip);
+                dst = _mm_packus_epi16(dst, _mm_setzero_si128());
+                _mm_storeu_si32(dstpix, dst);
+
+                dstpix += 4;
+                srcpix += 4;
+
+                xcounter = xspace - xfrac;
+            }
+        }
+        srcpix += srcdiff;
+        dstpix += dstdiff;
+    }
+}
+
+void
+filter_shrink_Y_SSE2(Uint8 *srcpix, Uint8 *dstpix, int width, int srcpitch,
+                     int dstpitch, int srcheight, int dstheight)
+{
+    int srcdiff = srcpitch - (width * 4);
+    int dstdiff = dstpitch - (width * 4);
+    int x, y;
+    __m128i src, dst, mm_acc, mm_yfrac, mm_ycounter;
+
+    int yspace = 0x04000 * srcheight / dstheight; /* must be > 1 */
+    __m128i yrecip = _mm_set1_epi16(0x40000000 / yspace);
+    int ycounter = yspace;
+
+    Uint16 *templine;
+    // TODO replace malloc+memset with calloc?
+    /* allocate and clear a memory area for storing the accumulator line */
+    templine = (Uint16 *)malloc(dstpitch * 2);
+    if (templine == NULL)
+        return;
+    memset(templine, 0, dstpitch * 2);
+
+    for (y = 0; y < srcheight; y++) {
+        Uint16 *accumulate = templine;
+        if (ycounter > 0x04000) {
+            // TODO could iterate multipixel at a time
+            for (x = 0; x < width; x++) {
+                src = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix),
+                                        _mm_setzero_si128());
+                _mm_storeu_si64(
+                    accumulate,
+                    _mm_add_epi16(_mm_loadu_si64(accumulate), src));
+                accumulate += 4;  // 4 Uint16s, so 8 bytes
+                srcpix += 4;
+            }
+            ycounter -= 0x04000;
+        }
+        else {
+            int yfrac = 0x04000 - ycounter;
+            /* write out a destination line */
+            // TODO could iterate multipixel at a time
+            for (x = 0; x < width; x++) {
+                src = _mm_unpacklo_epi8(_mm_loadu_si32(srcpix),
+                                        _mm_setzero_si128());
+                srcpix += 4;
+
+                mm_acc = _mm_loadu_si64(accumulate);
+
+                mm_yfrac = _mm_set1_epi16(yfrac);
+                mm_ycounter = _mm_set1_epi16(ycounter);
+
+                src = _mm_slli_epi16(src, 2);
+                dst = _mm_mulhi_epu16(src, mm_yfrac);
+                src = _mm_mulhi_epu16(src, mm_ycounter);
+
+                _mm_storeu_si64(accumulate, dst);
+                accumulate += 4;  // 4 Uint16s, so 8 bytes
+
+                dst = _mm_add_epi16(src, mm_acc);
+                dst = _mm_mulhi_epu16(dst, yrecip);
+                dst = _mm_packus_epi16(dst, _mm_setzero_si128());
+                _mm_storeu_si32(dstpix, dst);
+                dstpix += 4;
+            }
+            dstpix += dstdiff;
+            ycounter = yspace - yfrac;
+        }
+        srcpix += srcdiff;
+    } /* for (int y = 0; y < srcheight; y++) */
+
+    /* free the temporary memory */
+    free(templine);
+}
+
+void
+filter_expand_X_SSE2(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
+                     int dstpitch, int srcwidth, int dstwidth)
+{
+    int dstdiff = dstpitch - (dstwidth * 4);
+    int *xidx0, *xmult_combined;
+    int x, y;
+    const int factorwidth = 8;
+
+#ifdef _MSC_VER
+    /* Make MSVC static analyzer happy by assuring dstwidth >= 2 to suppress
+     * a false analyzer report */
+    __analysis_assume(dstwidth >= 2);
+#endif
+
+    /* Allocate memory for factors */
+    xidx0 = malloc(dstwidth * 4);
+    if (xidx0 == 0)
+        return;
+    xmult_combined = (int *)malloc(dstwidth * factorwidth);
+    if (xmult_combined == 0) {
+        free(xidx0);
+        return;
+    }
+
+    /* Create multiplier factors and starting indices and put them in arrays */
+    for (x = 0; x < dstwidth; x++) {
+        // Could it be worth it to reduce the fixed point there to fit
+        // inside 16 bits (0xFF), and then pack xidx0 in with mult factors?
+        int xm1 = 0x100 * ((x * (srcwidth - 1)) % dstwidth) / dstwidth;
+        int xm0 = 0x100 - xm1;
+        xidx0[x] = x * (srcwidth - 1) / dstwidth;
+
+        // packs xm0 and xm1 scaling factors into a combined array, for easy
+        // loading
+        xmult_combined[x * 2] = xm0 | (xm0 << 16);
+        xmult_combined[x * 2 + 1] = xm1 | (xm1 << 16);
+    }
+
+    __m128i src, mmxid, mult0, mult1, multcombined, dst;
+
+    /* Do the scaling in raster order so we don't trash the cache */
+    for (y = 0; y < height; y++) {
+        Uint8 *srcrow0 = srcpix + y * srcpitch;
+        for (x = 0; x < dstwidth; x++) {
+            Uint8 *src_p =
+                srcrow0 + xidx0[x] * 4;  // *8 now because of factorwidth?
+
+            src =
+                _mm_unpacklo_epi8(_mm_loadu_si64(src_p), _mm_setzero_si128());
+
+            // uses combined multipliers against 2 src pixels
+            // xm0 against src[0-3] (1 px), and xm1 against xrc[4-7] (1 px)
+            multcombined = _mm_shuffle_epi32(
+                _mm_loadu_si64(xmult_combined + x * 2), 0b01010000);
+
+            src = _mm_mullo_epi16(src, multcombined);
+
+            dst = _mm_bsrli_si128(src, 8);
+            dst = _mm_add_epi16(src, dst);
+            dst = _mm_srli_epi16(dst, 8);
+            dst = _mm_packus_epi16(dst, _mm_setzero_si128());
+            _mm_storeu_si32(dstpix, dst);
+
+            dstpix += 4;
+        }
+        dstpix += dstdiff;
+    }
+
+    /* free memory */
+    free(xidx0);
+    free(xmult_combined);
+}
+
+void
+filter_expand_Y_SSE2(Uint8 *srcpix, Uint8 *dstpix, int width, int srcpitch,
+                     int dstpitch, int srcheight, int dstheight)
+{
+    int x, y;
+
+    __m128i src0, src1, dst, ymult0_mm, ymult1_mm;
+
+    for (y = 0; y < dstheight; y++) {
+        int yidx0 = y * (srcheight - 1) / dstheight;
+        Uint8 *srcrow0 = srcpix + yidx0 * srcpitch;
+        Uint8 *srcrow1 = srcrow0 + srcpitch;
+        int ymult1 = 0x0100 * ((y * (srcheight - 1)) % dstheight) / dstheight;
+        int ymult0 = 0x0100 - ymult1;
+
+        ymult0_mm = _mm_set1_epi16(ymult0);
+        ymult1_mm = _mm_set1_epi16(ymult1);
+
+        for (x = 0; x < width; x++) {
+            src0 = _mm_unpacklo_epi8(_mm_loadu_si32(srcrow0),
+                                     _mm_setzero_si128());
+            src1 = _mm_unpacklo_epi8(_mm_loadu_si32(srcrow1),
+                                     _mm_setzero_si128());
+
+            src0 = _mm_mullo_epi16(src0, ymult0_mm);
+            src1 = _mm_mullo_epi16(src1, ymult1_mm);
+
+            dst = _mm_add_epi16(src0, src1);
+            dst = _mm_srli_epi16(dst, 8);
+            dst = _mm_packus_epi16(dst, _mm_setzero_si128());
+            _mm_storeu_si32(dstpix, dst);
+
+            srcrow0 += 4;
+            srcrow1 += 4;
+            dstpix += 4;
+        }
+        Uint8 *dstrow = dstpix + y * dstpitch;
+    }
+}
+
+#endif /* __SSE2__ || PG_ENABLE_ARM_NEON*/

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1610,7 +1610,8 @@ surf_set_smoothscale_backend(PyObject *self, PyObject *args, PyObject *kwargs)
 #else  /* Not an x86 processor */
     if (strcmp(type, "GENERIC") != 0) {
         if (strcmp(st->filter_type, "MMX") == 0 ||
-            strcmp(st->filter_type, "SSE") == 0) {
+            strcmp(st->filter_type, "SSE") == 0 ||
+            strcmp(st->filter_type, "SSE2") == 0) {
             return PyErr_Format(PyExc_ValueError,
                                 "%s not supported on this machine", type);
         }

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1221,7 +1221,14 @@ smoothscale_init(struct _module_state *st)
     }
 
 #ifdef SCALE_MMX_SUPPORT
-    if (SDL_HasSSE()) {
+    if (SDL_HasSSE2()) {
+        st->filter_type = "SSE2";
+        st->filter_shrink_X = filter_shrink_X_SSE2;
+        st->filter_shrink_Y = filter_shrink_Y_SSE2;
+        st->filter_expand_X = filter_expand_X_SSE2;
+        st->filter_expand_Y = filter_expand_Y_SSE2;
+    }
+    else if (SDL_HasSSE()) {
         st->filter_type = "SSE";
         st->filter_shrink_X = filter_shrink_X_SSE;
         st->filter_shrink_Y = filter_shrink_Y_SSE;
@@ -1584,6 +1591,17 @@ surf_set_smoothscale_backend(PyObject *self, PyObject *args, PyObject *kwargs)
         st->filter_shrink_Y = filter_shrink_Y_SSE;
         st->filter_expand_X = filter_expand_X_SSE;
         st->filter_expand_Y = filter_expand_Y_SSE;
+    }
+    else if (strcmp(type, "SSE2") == 0) {
+        if (!SDL_HasSSE2()) {
+            return RAISE(PyExc_ValueError,
+                         "SSE2 not supported on this machine");
+        }
+        st->filter_type = "SSE2";
+        st->filter_shrink_X = filter_shrink_X_SSE2;
+        st->filter_shrink_Y = filter_shrink_Y_SSE2;
+        st->filter_expand_X = filter_expand_X_SSE2;
+        st->filter_expand_Y = filter_expand_Y_SSE2;
     }
     else {
         return PyErr_Format(PyExc_ValueError, "Unknown backend type %s", type);

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1160,7 +1160,7 @@ class TransformModuleTest(unittest.TestCase):
 
     def test_get_smoothscale_backend(self):
         filter_type = pygame.transform.get_smoothscale_backend()
-        self.assertTrue(filter_type in ["GENERIC", "MMX", "SSE"])
+        self.assertTrue(filter_type in ["GENERIC", "MMX", "SSE", "SSE2"])
         # It would be nice to test if a non-generic type corresponds to an x86
         # processor. But there is no simple test for this. platform.machine()
         # returns process version specific information, like 'i686'.
@@ -1192,8 +1192,9 @@ class TransformModuleTest(unittest.TestCase):
             pygame.transform.set_smoothscale_backend(1)
 
         self.assertRaises(TypeError, change)
+
         # Unsupported type, if possible.
-        if original_type != "SSE":
+        if original_type == "GENERIC":
 
             def change():
                 pygame.transform.set_smoothscale_backend("SSE")


### PR DESCRIPTION
Tackles the bulk of what I wanted in #1767 

This was more difficult than I thought, this was quite difficult. I read through the existing smoothscale assembly (written assembly, not intrinsics) and the C implementations and combined what I saw into an SSE2 intrinsic version of the same algorithm.

I then had lots of ideas for optimizations on top of that, so for three of the filters it processes more pixels at a time than the existing SSE/MMX implementations.

This PR "just" implements the SSE2 backend, there are several follow on steps that would be quite nice:
- Get it compiling and up at runtime on NEON, so ARM folks can get fast smoothscale
- Remove legacy MMX/SSE backends eventually (we've been linking the compiled code for this in, at least on Windows, this is a part of the pygame codebase we don't know how to compile). Wanting to remove this uncompileable, unportable and ancient bit of our codebase was my chief motivation for opening this PR.
- AVX2 backend? Now that we've got it in intrinsics, it's much easier to scale up the parallelism with other intrinsics.
- Fix so if a malloc fails in the filters it will accurately report an error

Performance relative to SSE backend:
```
X-shrinking: 25% faster
Y-shrinking: 28% faster
X-expanding: neglible
Y-expanding: 25% faster
```

These are pixel perfect accurate relative to the SSE backend. Verified by saving out to pngs and checking the file hashes.