### PR TITLE
Strip the leading SDL_ from the pixel format name

### DIFF
--- a/buildconfig/stubs/pygame/display.pyi
+++ b/buildconfig/stubs/pygame/display.pyi
@@ -29,6 +29,7 @@ class _VidInfo:
     blit_sw_A: int
     current_h: int
     current_w: int
+    pixel_format: str
 
 def init() -> None: ...
 def quit() -> None: ...

--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -311,12 +311,12 @@ required).
    mode to verify specific display options were satisfied. The VidInfo object
    has several attributes:
 
-   ::
+   .. code-block:: text
 
      hw:         1 if the display is hardware accelerated
      wm:         1 if windowed display modes can be used
-     video_mem:  The megabytes of video memory on the display. This is 0 if
-                 unknown
+     video_mem:  The megabytes of video memory on the display.
+                 This is 0 if unknown
      bitsize:    Number of bits used to store each pixel
      bytesize:   Number of bytes used to store each pixel
      masks:      Four values used to pack RGBA values into pixels
@@ -324,13 +324,20 @@ required).
      losses:     Four values used to pack RGBA values into pixels
      blit_hw:    1 if hardware Surface blitting is accelerated
      blit_hw_CC: 1 if hardware Surface colorkey blitting is accelerated
-     blit_hw_A:  1 if hardware Surface pixel alpha blitting is accelerated
+     blit_hw_A:  1 if hardware Surface pixel alpha blitting is
+                 accelerated
      blit_sw:    1 if software Surface blitting is accelerated
-     blit_sw_CC: 1 if software Surface colorkey blitting is accelerated
-     blit_sw_A:  1 if software Surface pixel alpha blitting is accelerated
-     current_h, current_w:  Height and width of the current video mode, or
-                 of the desktop mode if called before the display.set_mode
-                 is called. They are -1 on error.
+     blit_sw_CC: 1 if software Surface colorkey blitting is
+                 accelerated
+     blit_sw_A:  1 if software Surface pixel alpha blitting is
+                 accelerated
+     current_h, current_w:  Height and width of the current video
+                 mode, or of the desktop mode if called before
+                 the display.set_mode is called. They are -1 on error.
+     pixel_format: The pixel format of the display Surface as a string.
+                 E.g PIXELFORMAT_RGB888.
+
+   .. versionchanged:: 2.4.0 ``pixel_format`` attribute added.
 
    .. ## pygame.display.Info ##
 

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -366,6 +366,8 @@ pg_vidinfo_str(PyObject *self)
         info->vfmt->Bshift, info->vfmt->Ashift, info->vfmt->Rloss,
         info->vfmt->Gloss, info->vfmt->Bloss, info->vfmt->Aloss, current_w,
         current_h, trimmed_format_name);
+
+        free(trimmed_format_name);
 }
 
 static PyTypeObject pgVidInfo_Type = {

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -324,6 +324,14 @@ pg_vidinfo_getattr(PyObject *self, char *name)
         return PyLong_FromLong(current_h);
     else if (!strcmp(name, "current_w"))
         return PyLong_FromLong(current_w);
+    else if (!strcmp(name, "pixel_format")) {
+        const char *pixel_format_name =
+            SDL_GetPixelFormatName(info->vfmt->format);
+        if (!strncmp(pixel_format_name, "SDL_", 4)) {
+            pixel_format_name += 4;
+        }
+        return PyUnicode_FromString(pixel_format_name);
+    }
 
     return RAISE(PyExc_AttributeError, "does not exist in vidinfo");
 }

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -334,6 +334,7 @@ pg_vidinfo_str(PyObject *self)
     int current_w = -1;
     int current_h = -1;
     pg_VideoInfo *info = &((pgVidInfoObject *)self)->info;
+    PyObject *return_string = NULL;
     const char *pixel_format_name = SDL_GetPixelFormatName(info->vfmt->format);
     char *trimmed_format_name = malloc(sizeof(char) * (strlen(pixel_format_name) - 4));
     strcpy(trimmed_format_name, pixel_format_name+=4);
@@ -347,7 +348,7 @@ pg_vidinfo_str(PyObject *self)
         current_h = info->current_h;
     }
 
-    return PyUnicode_FromFormat(
+    return_string = PyUnicode_FromFormat(
         "<VideoInfo(hw = %u, wm = %u,video_mem = %u\n"
         "         blit_hw = %u, blit_hw_CC = %u, blit_hw_A = %u,\n"
         "         blit_sw = %u, blit_sw_CC = %u, blit_sw_A = %u,\n"
@@ -366,6 +367,10 @@ pg_vidinfo_str(PyObject *self)
         info->vfmt->Bshift, info->vfmt->Ashift, info->vfmt->Rloss,
         info->vfmt->Gloss, info->vfmt->Bloss, info->vfmt->Aloss, current_w,
         current_h, trimmed_format_name);
+
+    free(trimmed_format_name);
+
+    return return_string;
 
 }
 

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -334,7 +334,6 @@ pg_vidinfo_str(PyObject *self)
     int current_w = -1;
     int current_h = -1;
     pg_VideoInfo *info = &((pgVidInfoObject *)self)->info;
-    PyObject *return_string = NULL;
     const char *pixel_format_name = SDL_GetPixelFormatName(info->vfmt->format);
     if (!strncmp(pixel_format_name, "SDL_", 4)) {
         pixel_format_name += 4;

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -336,8 +336,9 @@ pg_vidinfo_str(PyObject *self)
     pg_VideoInfo *info = &((pgVidInfoObject *)self)->info;
     PyObject *return_string = NULL;
     const char *pixel_format_name = SDL_GetPixelFormatName(info->vfmt->format);
-    char *trimmed_format_name = malloc(sizeof(char) * (strlen(pixel_format_name) - 4));
-    strcpy(trimmed_format_name, pixel_format_name+=4);
+    if (!strncmp(pixel_format_name, "SDL_", 4)) {
+        pixel_format_name += 4;
+    }
 
     SDL_version versioninfo;
     SDL_VERSION(&versioninfo);
@@ -348,7 +349,7 @@ pg_vidinfo_str(PyObject *self)
         current_h = info->current_h;
     }
 
-    return_string = PyUnicode_FromFormat(
+    return PyUnicode_FromFormat(
         "<VideoInfo(hw = %u, wm = %u,video_mem = %u\n"
         "         blit_hw = %u, blit_hw_CC = %u, blit_hw_A = %u,\n"
         "         blit_sw = %u, blit_sw_CC = %u, blit_sw_A = %u,\n"
@@ -366,12 +367,7 @@ pg_vidinfo_str(PyObject *self)
         info->vfmt->Amask, info->vfmt->Rshift, info->vfmt->Gshift,
         info->vfmt->Bshift, info->vfmt->Ashift, info->vfmt->Rloss,
         info->vfmt->Gloss, info->vfmt->Bloss, info->vfmt->Aloss, current_w,
-        current_h, trimmed_format_name);
-
-    free(trimmed_format_name);
-
-    return return_string;
-
+        current_h, pixel_format_name);
 }
 
 static PyTypeObject pgVidInfo_Type = {

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -367,7 +367,6 @@ pg_vidinfo_str(PyObject *self)
         info->vfmt->Gloss, info->vfmt->Bloss, info->vfmt->Aloss, current_w,
         current_h, trimmed_format_name);
 
-        free(trimmed_format_name);
 }
 
 static PyTypeObject pgVidInfo_Type = {

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -335,6 +335,8 @@ pg_vidinfo_str(PyObject *self)
     int current_h = -1;
     pg_VideoInfo *info = &((pgVidInfoObject *)self)->info;
     const char *pixel_format_name = SDL_GetPixelFormatName(info->vfmt->format);
+    char *trimmed_format_name = malloc(sizeof(char) * (strlen(pixel_format_name) - 4));
+    strcpy(trimmed_format_name, pixel_format_name+=4);
 
     SDL_version versioninfo;
     SDL_VERSION(&versioninfo);
@@ -363,7 +365,7 @@ pg_vidinfo_str(PyObject *self)
         info->vfmt->Amask, info->vfmt->Rshift, info->vfmt->Gshift,
         info->vfmt->Bshift, info->vfmt->Ashift, info->vfmt->Rloss,
         info->vfmt->Gloss, info->vfmt->Bloss, info->vfmt->Aloss, current_w,
-        current_h, pixel_format_name);
+        current_h, trimmed_format_name);
 }
 
 static PyTypeObject pgVidInfo_Type = {


### PR DESCRIPTION
Fixes issue #1741.

I'm not sure this is the best way to strip 4 characters from a C string, so please let me know.