### PR TITLE
Add PG_CreateSurface(From) for SDL2/3 compat

### DIFF
--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -109,9 +109,7 @@ surf_colorspace(PyObject *self, PyObject *arg)
     surf = pgSurface_AsSurface(surfobj);
 
     if (!surfobj2) {
-        newsurf = SDL_CreateRGBSurfaceWithFormat(0, surf->w, surf->h,
-                                                 surf->format->BitsPerPixel,
-                                                 surf->format->format);
+        newsurf = PG_CreateSurface(surf->w, surf->h, surf->format->format);
         if (!newsurf) {
             return NULL;
         }
@@ -376,11 +374,11 @@ camera_get_image(pgCameraObject *self, PyObject *arg)
 
     if (!surfobj) {
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
-        surf = SDL_CreateRGBSurfaceWithFormat(0, self->width, self->height, 24,
-                                              SDL_PIXELFORMAT_RGB24);
+        surf =
+            PG_CreateSurface(self->width, self->height, SDL_PIXELFORMAT_RGB24);
 #else
-        surf = SDL_CreateRGBSurfaceWithFormat(0, self->width, self->height, 24,
-                                              SDL_PIXELFORMAT_BGR24);
+        surf =
+            PG_CreateSurface(self->width, self->height, SDL_PIXELFORMAT_BGR24);
 #endif
     }
     else {
@@ -427,8 +425,7 @@ camera_get_image(pgCameraObject *self, PyObject *arg)
         return NULL;
 
     if (!surfobj) {
-        surf = SDL_CreateRGBSurfaceWithFormat(0, width, height, 32,
-                                              PG_PIXELFORMAT_XRGB8888);
+        surf = PG_CreateSurface(width, height, PG_PIXELFORMAT_XRGB8888);
     }
     else {
         surf = pgSurface_AsSurface(surfobj);

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -63,6 +63,9 @@
 
 #define PG_JOYBALLMOTION 0
 
+#define PG_CreateSurface SDL_CreateSurface
+#define PG_CreateSurfaceFrom SDL_CreateSurfaceFrom
+
 #else /* ~SDL_VERSION_ATLEAST(3, 0, 0)*/
 
 #define PG_INIT_NOPARACHUTE SDL_INIT_NOPARACHUTE
@@ -80,6 +83,11 @@
 #define PG_MULTIGESTURE SDL_MULTIGESTURE
 
 #define PG_JOYBALLMOTION SDL_JOYBALLMOTION
+
+#define PG_CreateSurface(width, height, format) \
+    SDL_CreateRGBSurfaceWithFormat(0, width, height, 0, format)
+#define PG_CreateSurfaceFrom(pixels, width, height, pitch, format) \
+    SDL_CreateRGBSurfaceWithFormatFrom(pixels, width, height, 0, pitch, format)
 
 #endif
 

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -701,8 +701,8 @@ pg_ResizeEventWatch(void *userdata, SDL_Event *event)
                 int h = event->window.data2;
                 pgSurfaceObject *display_surface =
                     pg_GetDefaultWindowSurface();
-                SDL_Surface *surf = SDL_CreateRGBSurfaceWithFormat(
-                    0, w, h, 32, PG_PIXELFORMAT_XRGB8888);
+                SDL_Surface *surf =
+                    PG_CreateSurface(w, h, PG_PIXELFORMAT_XRGB8888);
 
                 SDL_FreeSurface(display_surface->surf);
                 display_surface->surf = surf;
@@ -1169,8 +1169,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
 
                 So we make a fake surface.
                 */
-                surf = SDL_CreateRGBSurfaceWithFormat(0, w, h, 32,
-                                                      PG_PIXELFORMAT_XRGB8888);
+                surf = PG_CreateSurface(w, h, PG_PIXELFORMAT_XRGB8888);
                 newownedsurf = surf;
             }
             else {
@@ -1271,8 +1270,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                         pg_renderer, SDL_PIXELFORMAT_ARGB8888,
                         SDL_TEXTUREACCESS_STREAMING, w, h);
                 }
-                surf = SDL_CreateRGBSurfaceWithFormat(0, w, h, 32,
-                                                      PG_PIXELFORMAT_XRGB8888);
+                surf = PG_CreateSurface(w, h, PG_PIXELFORMAT_XRGB8888);
                 newownedsurf = surf;
             }
             else {

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -519,8 +519,7 @@ font_render(PyObject *self, PyObject *args, PyObject *kwds)
 
     if (strlen(astring) == 0) { /* special 0 string case */
         int height = TTF_FontHeight(font);
-        surf = SDL_CreateRGBSurfaceWithFormat(0, 0, height, 32,
-                                              PG_PIXELFORMAT_XRGB8888);
+        surf = PG_CreateSurface(0, height, PG_PIXELFORMAT_XRGB8888);
     }
     else { /* normal case */
         if (antialias && bg_rgba_obj == Py_None) {

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -438,7 +438,7 @@ _PGFT_Render_NewSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
     else {
         pixelformat = SDL_PIXELFORMAT_RGBA32;
     }
-    surface = SDL_CreateRGBSurfaceWithFormat(0, width, height, 0, pixelformat);
+    surface = PG_CreateSurface(width, height, pixelformat);
     if (!surface) {
         PyErr_SetString(pgExc_SDLError, SDL_GetError());
         return 0;

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1070,8 +1070,7 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
 
-        surf =
-            SDL_CreateRGBSurfaceWithFormat(0, w, h, 8, SDL_PIXELFORMAT_INDEX8);
+        surf = PG_CreateSurface(w, h, SDL_PIXELFORMAT_INDEX8);
         if (!surf)
             return RAISE(pgExc_SDLError, SDL_GetError());
         SDL_LockSurface(surf);
@@ -1096,11 +1095,9 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
                 "Bytes length does not equal format and resolution size");
 
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-        surf =
-            SDL_CreateRGBSurfaceWithFormat(0, w, h, 24, SDL_PIXELFORMAT_BGR24);
+        surf = PG_CreateSurface(w, h, SDL_PIXELFORMAT_BGR24);
 #else
-        surf =
-            SDL_CreateRGBSurfaceWithFormat(0, w, h, 24, SDL_PIXELFORMAT_RGB24);
+        surf = PG_CreateSurface(w, h, SDL_PIXELFORMAT_RGB24);
 #endif
         if (!surf)
             return RAISE(pgExc_SDLError, SDL_GetError());
@@ -1141,8 +1138,8 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
-        surf = SDL_CreateRGBSurfaceWithFormat(
-            0, w, h, 32,
+        surf = PG_CreateSurface(
+            w, h,
             (alphamult ? SDL_PIXELFORMAT_RGBA32 : PG_PIXELFORMAT_RGBX32));
         if (!surf)
             return RAISE(pgExc_SDLError, SDL_GetError());
@@ -1169,8 +1166,7 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
-        surf = SDL_CreateRGBSurfaceWithFormat(0, w, h, 32,
-                                              SDL_PIXELFORMAT_BGRA32);
+        surf = PG_CreateSurface(w, h, SDL_PIXELFORMAT_BGRA32);
         if (!surf)
             return RAISE(pgExc_SDLError, SDL_GetError());
         SDL_LockSurface(surf);
@@ -1196,8 +1192,7 @@ image_frombytes(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Bytes length does not equal format and resolution size");
-        surf = SDL_CreateRGBSurfaceWithFormat(0, w, h, 32,
-                                              SDL_PIXELFORMAT_ARGB32);
+        surf = PG_CreateSurface(w, h, SDL_PIXELFORMAT_ARGB32);
         if (!surf)
             return RAISE(pgExc_SDLError, SDL_GetError());
         SDL_LockSurface(surf);
@@ -1310,8 +1305,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
 
-        surf = SDL_CreateRGBSurfaceWithFormatFrom(data, w, h, 8, pitch,
-                                                  SDL_PIXELFORMAT_INDEX8);
+        surf = PG_CreateSurfaceFrom(data, w, h, pitch, SDL_PIXELFORMAT_INDEX8);
     }
     else if (!strcmp(format, "RGB")) {
         if (pitch == -1) {
@@ -1327,8 +1321,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
-        surf = SDL_CreateRGBSurfaceWithFormatFrom(data, w, h, 24, pitch,
-                                                  SDL_PIXELFORMAT_RGB24);
+        surf = PG_CreateSurfaceFrom(data, w, h, pitch, SDL_PIXELFORMAT_RGB24);
     }
     else if (!strcmp(format, "BGR")) {
         if (pitch == -1) {
@@ -1344,8 +1337,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
-        surf = SDL_CreateRGBSurfaceWithFormatFrom(data, w, h, 24, pitch,
-                                                  SDL_PIXELFORMAT_BGR24);
+        surf = PG_CreateSurfaceFrom(data, w, h, pitch, SDL_PIXELFORMAT_BGR24);
     }
     else if (!strcmp(format, "BGRA")) {
         if (pitch == -1) {
@@ -1361,8 +1353,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
-        surf = SDL_CreateRGBSurfaceWithFormatFrom(data, w, h, 32, pitch,
-                                                  SDL_PIXELFORMAT_BGRA32);
+        surf = PG_CreateSurfaceFrom(data, w, h, pitch, SDL_PIXELFORMAT_BGRA32);
     }
     else if (!strcmp(format, "RGBA") || !strcmp(format, "RGBX")) {
         if (pitch == -1) {
@@ -1379,8 +1370,8 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
-        surf = SDL_CreateRGBSurfaceWithFormatFrom(
-            data, w, h, 32, pitch,
+        surf = PG_CreateSurfaceFrom(
+            data, w, h, pitch,
             (alphamult ? SDL_PIXELFORMAT_RGBA32 : PG_PIXELFORMAT_RGBX32));
     }
     else if (!strcmp(format, "ARGB")) {
@@ -1397,8 +1388,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
-        surf = SDL_CreateRGBSurfaceWithFormatFrom(data, w, h, 32, pitch,
-                                                  SDL_PIXELFORMAT_ARGB32);
+        surf = PG_CreateSurfaceFrom(data, w, h, pitch, SDL_PIXELFORMAT_ARGB32);
     }
     else
         return RAISE(PyExc_ValueError, "Unrecognized type of format");

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -128,9 +128,7 @@ _make_surface(pgPixelArrayObject *array, PyObject *args)
 
     /* Create the second surface. */
 
-    temp_surf = SDL_CreateRGBSurfaceWithFormat(0, (int)dim0, (int)dim1,
-                                               surf->format->BitsPerPixel,
-                                               surf->format->format);
+    temp_surf = PG_CreateSurface((int)dim0, (int)dim1, surf->format->format);
     if (!temp_surf) {
         return RAISE(pgExc_SDLError, SDL_GetError());
     }

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -1165,7 +1165,7 @@ make_surface(PyObject *self, PyObject *arg)
     sizex = (int)view_p->shape[0];
     sizey = (int)view_p->shape[1];
 
-    surf = SDL_CreateRGBSurfaceWithFormat(0, sizex, sizey, 0, pixelformat);
+    surf = PG_CreateSurface(sizex, sizey, pixelformat);
     if (!surf) {
         pgBuffer_Release(&pg_view);
         return RAISE(pgExc_SDLError, SDL_GetError());

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -533,8 +533,7 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
         /*
          * New source surface is 32bit with a defined RGBA ordering
          */
-        rz_src = SDL_CreateRGBSurfaceWithFormat(0, src->w, src->h, 32,
-                                                SDL_PIXELFORMAT_ABGR8888);
+        rz_src = PG_CreateSurface(src->w, src->h, SDL_PIXELFORMAT_ABGR8888);
         SDL_BlitSurface(src, NULL, rz_src, NULL);
         src_converted = 1;
     }
@@ -583,8 +582,7 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
         /*
          * Target surface is 32bit with source RGBA/ABGR ordering
          */
-        rz_dst = SDL_CreateRGBSurfaceWithFormat(0, dstwidth, dstheight, 32,
-                                                rz_src->format->format);
+        rz_dst = PG_CreateSurface(dstwidth, dstheight, rz_src->format->format);
 
         /*
          * Lock source surface
@@ -630,8 +628,7 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
         /*
          * Target surface is 32bit with source RGBA/ABGR ordering
          */
-        rz_dst = SDL_CreateRGBSurfaceWithFormat(0, dstwidth, dstheight, 32,
-                                                rz_src->format->format);
+        rz_dst = PG_CreateSurface(dstwidth, dstheight, rz_src->format->format);
 
         /*
          * Lock source surface

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1367,8 +1367,7 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
         sdlrect.h = 0;
         sdlrect.w = 0;
 
-        surface =
-            SDL_CreateRGBSurfaceWithFormat(0, 1, 1, 32, surf->format->format);
+        surface = PG_CreateSurface(1, 1, surf->format->format);
 
         SDL_LowerBlit(surf, &sdlrect, surface, &sdlrect);
         SDL_FreeSurface(surface);
@@ -2675,9 +2674,8 @@ surf_subsurface(PyObject *self, PyObject *args)
     pixeloffset = rect->x * format->BytesPerPixel + rect->y * surf->pitch;
     startpixel = ((char *)surf->pixels) + pixeloffset;
 
-    sub = SDL_CreateRGBSurfaceWithFormatFrom(startpixel, rect->w, rect->h,
-                                             format->BitsPerPixel, surf->pitch,
-                                             format->format);
+    sub = PG_CreateSurfaceFrom(startpixel, rect->w, rect->h, surf->pitch,
+                               format->format);
 
     pgSurface_Unlock((pgSurfaceObject *)self);
 

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -129,8 +129,7 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
         return (SDL_Surface *)(RAISE(
             PyExc_ValueError, "unsupported Surface bit depth for transform"));
 
-    newsurf = SDL_CreateRGBSurfaceWithFormat(
-        0, width, height, surf->format->BitsPerPixel, surf->format->format);
+    newsurf = PG_CreateSurface(width, height, surf->format->format);
     if (!newsurf)
         return (SDL_Surface *)(RAISE(pgExc_SDLError, SDL_GetError()));
 
@@ -445,10 +444,9 @@ scale_to(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int width,
          * rejects the input.
          * For example, RGBA and RGBX surfaces are compatible in this way. */
         if (retsurf->format->Amask != src->format->Amask) {
-            modsurf = SDL_CreateRGBSurfaceWithFormatFrom(
-                retsurf->pixels, retsurf->w, retsurf->h,
-                retsurf->format->BitsPerPixel, retsurf->pitch,
-                src->format->format);
+            modsurf =
+                PG_CreateSurfaceFrom(retsurf->pixels, retsurf->w, retsurf->h,
+                                     retsurf->pitch, src->format->format);
         }
     }
 
@@ -885,8 +883,7 @@ surf_rotozoom(PyObject *self, PyObject *args, PyObject *kwargs)
     }
     else {
         Py_BEGIN_ALLOW_THREADS;
-        surf32 = SDL_CreateRGBSurfaceWithFormat(0, surf->w, surf->h, 32,
-                                                SDL_PIXELFORMAT_ABGR8888);
+        surf32 = PG_CreateSurface(surf->w, surf->h, SDL_PIXELFORMAT_ABGR8888);
         SDL_BlitSurface(surf, NULL, surf32, NULL);
         Py_END_ALLOW_THREADS;
     }


### PR DESCRIPTION
This was the end goal of my previous PRs switching out SDL_CreateRGBSurface for SDL_CreateRGBSurfaceWithFormat. This allows us to write our create surface calls in "SDL3 form" on both on SDL2 and SDL3, because of the macro.

You might be wondering about the depth argument always being 0. This is okay. In SDL2's SDL_CreateRGBSurfaceWithFormat, the depth argument is ignored. (https://github.com/libsdl-org/SDL/blob/f9dc49c21c99cd6eb63d80d60b6e706a51234b46/src/video/SDL_surface.c#L72-L78). This makes sense, as the depth info is in the pixelformat.

I like this patch as well because it actually simplifies the calling code (at least makes it shorter), as you can see with the line count reduction in this PR.

There are still a small few SDL_CreateRGBSurface calls in the wilds of the codebase, they'll get handled eventually.