### PR TITLE
WASM: add required PyObject *_null parameter to remaining functions marked with METH_NOARGS in math.c and color.c

### DIFF
--- a/src_c/color.c
+++ b/src_c/color.c
@@ -93,7 +93,7 @@ _color_set_length(pgColorObject *, PyObject *);
 static PyObject *
 _color_lerp(pgColorObject *, PyObject *, PyObject *);
 static PyObject *
-_color_grayscale(pgColorObject *);
+_color_grayscale(pgColorObject *, PyObject *);
 static PyObject *
 _premul_alpha(pgColorObject *, PyObject *);
 static PyObject *
@@ -760,7 +760,7 @@ _color_correct_gamma(pgColorObject *color, PyObject *args)
  * color.grayscale()
  */
 static PyObject *
-_color_grayscale(pgColorObject *self)
+_color_grayscale(pgColorObject *self, PyObject *_null)
 {
     // RGBA to GRAY formula used by OpenCV
     Uint8 grayscale_pixel =

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -325,7 +325,7 @@ vectoriter_dealloc(vectoriter *it);
 static PyObject *
 vectoriter_next(vectoriter *it);
 static PyObject *
-vectoriter_len(vectoriter *it);
+vectoriter_len(vectoriter *it, PyObject *_null);
 static PyObject *
 vector_iter(PyObject *vec);
 
@@ -3514,7 +3514,7 @@ vectoriter_next(vectoriter *it)
 }
 
 static PyObject *
-vectoriter_len(vectoriter *it)
+vectoriter_len(vectoriter *it, PyObject *_null)
 {
     Py_ssize_t len = 0;
     if (it && it->vec) {


### PR DESCRIPTION
I didn't notice them, otherwise I would have added those in the display.c pull request on the same topic.

References:
https://docs.python.org/3/c-api/structures.html#c.METH_NOARGS
https://blog.pyodide.org/posts/function-pointer-cast-handling/