### PR TITLE
Deprecate set_mode depth argument

### DIFF
--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -134,10 +134,9 @@ required).
    are set to ``0``, the Surface will have the same width or height as the
    screen resolution.
 
-   It is usually best to not pass the depth argument. It will default to the
-   best and fastest color depth for the system. If your game requires a
-   specific color format you can control the depth with this argument. Pygame
-   will emulate an unavailable color depth which can be slow.
+   Since pygame 2, the depth argument is ignored, in favour of the best
+   and fastest one. It also raises a deprecation warning since pygame-ce
+   2.4.0 if the passed in depth is not 0 or the one pygame selects.
 
    When requesting fullscreen display modes, sometimes an exact match for the
    requested size cannot be made. In these situations pygame will select
@@ -212,6 +211,8 @@ required).
    .. versionchanged:: 2.2.0 explicit request for "adaptive vsync"
 
    .. versionchanged:: 2.2.0 ``vsync=1`` does not require ``SCALED`` or ``OPENGL``
+
+   .. deprecated:: 2.4.0 The depth argument is ignored, and will be set to the optimal value
 
 
    Basic example:

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -999,7 +999,6 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                 SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 0);
         }
 
-#pragma PG_WARN(Not setting bpp ?)
 #pragma PG_WARN(Add mode stuff.)
         {
             int w_1 = w, h_1 = h;
@@ -1358,6 +1357,14 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                              "on top of wayland, instead of wayland directly",
                              1) != 0)
                 return NULL;
+        }
+    }
+
+    if (depth != 0 && surface->surf->format->BitsPerPixel != depth) {
+        if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "The depth argument is deprecated, and is ignored",
+                         1)) {
+            return NULL;
         }
     }
 

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -150,22 +150,27 @@ class DisplayModuleTest(unittest.TestCase):
         # display.init() already called in setUp()
         self.assertTrue(display.get_init())
 
-    # This test can be uncommented when issues #991 and #993 are resolved.
-    @unittest.skipIf(True, "SDL2 issues")
     def test_get_surface(self):
         """Ensures get_surface gets the current display surface."""
         lengths = (1, 5, 100)
+        correct_depth = pygame.display.Info().bitsize
 
         for expected_size in ((w, h) for w in lengths for h in lengths):
-            for expected_depth in (8, 16, 24, 32):
-                expected_surface = display.set_mode(expected_size, 0, expected_depth)
+            for set_depth in (8, 16, 24, 32):
+                if set_depth == correct_depth:
+                    expected_surface = display.set_mode(expected_size, 0, set_depth)
+                else:
+                    with self.assertWarns(DeprecationWarning):
+                        expected_surface = pygame.display.set_mode(
+                            expected_size, 0, set_depth
+                        )
 
                 surface = pygame.display.get_surface()
 
                 self.assertEqual(surface, expected_surface)
                 self.assertIsInstance(surface, pygame.Surface)
                 self.assertEqual(surface.get_size(), expected_size)
-                self.assertEqual(surface.get_bitsize(), expected_depth)
+                self.assertEqual(surface.get_bitsize(), correct_depth)
 
     def test_get_surface__mode_not_set(self):
         """Ensures get_surface handles the display mode not being set."""


### PR DESCRIPTION
Fixes #635, fixes #2329 

I don't think we want to support setting the depth of the window surface