### PR TITLE
Fix SDL_ConvertSurface(Format) for SDL3

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -69,6 +69,8 @@
 
 #define PG_CreateSurface SDL_CreateSurface
 #define PG_CreateSurfaceFrom SDL_CreateSurfaceFrom
+#define PG_ConvertSurface SDL_ConvertSurface
+#define PG_ConvertSurfaceFormat SDL_ConvertSurfaceFormat
 
 #else /* ~SDL_VERSION_ATLEAST(3, 0, 0)*/
 #define PG_ShowCursor() SDL_ShowCursor(SDL_ENABLE)
@@ -95,6 +97,9 @@
     SDL_CreateRGBSurfaceWithFormat(0, width, height, 0, format)
 #define PG_CreateSurfaceFrom(pixels, width, height, pitch, format) \
     SDL_CreateRGBSurfaceWithFormatFrom(pixels, width, height, 0, pitch, format)
+#define PG_ConvertSurface(src, fmt) SDL_ConvertSurface(src, fmt, 0)
+#define PG_ConvertSurfaceFormat(src, pixel_format) \
+    SDL_ConvertSurfaceFormat(src, pixel_format, 0)
 
 #endif
 

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -264,13 +264,12 @@ pg_SavePNG_RW(SDL_Surface *surface, SDL_RWops *dst, int freedst)
                have alpha information, it should be converted to RGB24 before
                being passed through */
             png_color_type = PNG_COLOR_TYPE_RGB;
-            source =
-                SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_RGB24, 0);
+            source = PG_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_RGB24);
         }
         else if (surface->format->format != png_format) {
             /* Otherwise, (surface has alpha data), and it is not in the exact
                right format , so it should be converted to that */
-            source = SDL_ConvertSurfaceFormat(surface, png_format, 0);
+            source = PG_ConvertSurfaceFormat(surface, png_format);
         }
 
         png_set_write_fn(png_ptr, dst, png_write_fn, png_flush_fn);

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -134,7 +134,7 @@ _make_surface(pgPixelArrayObject *array, PyObject *args)
     }
 
     /* Guarantee an identical format. */
-    new_surf = SDL_ConvertSurface(temp_surf, surf->format, 0);
+    new_surf = PG_ConvertSurface(temp_surf, surf->format);
     SDL_FreeSurface(temp_surf);
     if (!new_surf) {
         return RAISE(pgExc_SDLError, SDL_GetError());

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1427,7 +1427,7 @@ surf_copy(pgSurfaceObject *self, PyObject *_null)
     SURF_INIT_CHECK(surf)
 
     pgSurface_Prep(self);
-    newsurf = SDL_ConvertSurface(surf, surf->format, 0);
+    newsurf = PG_ConvertSurface(surf, surf->format);
     pgSurface_Unprep(self);
 
     final = surf_subtype_new(Py_TYPE(self), newsurf, 1);
@@ -1473,7 +1473,7 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
     if (argobject) {
         if (pgSurface_Check(argobject)) {
             src = pgSurface_AsSurface(argobject);
-            newsurf = SDL_ConvertSurface(surf, src->format, 0);
+            newsurf = PG_ConvertSurface(surf, src->format);
         }
         else {
             /* will be updated later, initialize to make static analyzer happy
@@ -1594,7 +1594,7 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
                     SDL_SetPixelFormatPalette(&format, palette);
                 }
             }
-            newsurf = SDL_ConvertSurface(surf, &format, 0);
+            newsurf = PG_ConvertSurface(surf, &format);
             SDL_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_NONE);
             SDL_FreePalette(palette);
         }
@@ -1634,7 +1634,7 @@ pg_DisplayFormat(SDL_Surface *surface)
         return NULL;
     }
     displaysurf = pgSurface_AsSurface(pg_GetDefaultWindowSurface());
-    return SDL_ConvertSurface(surface, displaysurf->format, 0);
+    return PG_ConvertSurface(surface, displaysurf->format);
 }
 
 static SDL_Surface *
@@ -1687,7 +1687,7 @@ pg_DisplayFormatAlpha(SDL_Surface *surface)
         SDL_SetError("unknown pixel format");
         return NULL;
     }
-    return SDL_ConvertSurfaceFormat(surface, pfe, 0);
+    return PG_ConvertSurfaceFormat(surface, pfe);
 }
 
 static PyObject *
@@ -3213,7 +3213,7 @@ surf_premul_alpha(pgSurfaceObject *self, PyObject *_null)
 
     pgSurface_Prep(self);
     // Make a copy of the surface first
-    newsurf = SDL_ConvertSurface(surf, surf->format, 0);
+    newsurf = PG_ConvertSurface(surf, surf->format);
 
     if ((surf->w > 0 && surf->h > 0)) {
         // If the surface has no pixels we don't need to premul
@@ -3941,7 +3941,7 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
             newfmt.Rloss = fmt->Rloss;
             newfmt.Gloss = fmt->Gloss;
             newfmt.Bloss = fmt->Bloss;
-            src = SDL_ConvertSurface(src, &newfmt, 0);
+            src = PG_ConvertSurface(src, &newfmt);
             if (src) {
                 result = SDL_BlitSurface(src, srcrect, dst, dstrect);
                 SDL_FreeSurface(src);


### PR DESCRIPTION
SDL3 just removes the unused flags argument, so it's very easy to port.