### PR TITLE
Port last SDL_CreateRGBSurface calls to SDL3-safe PG_CreateSurface

### DIFF
--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1509,7 +1509,7 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
     Uint8 surf_alpha;
     int have_surf_colorkey = 0;
     Uint32 surf_colorkey;
-    Uint32 rmask, gmask, bmask, amask;
+    Uint32 format;
     SDL_Rect r;
     int bpp;
     Uint8 *rlebuf = NULL;
@@ -1535,7 +1535,7 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
             h.cmap_bits = 24;
         SETLE16(h.cmap_len, surface->format->palette->ncolors);
         h.pixel_bits = 8;
-        rmask = gmask = bmask = amask = 0;
+        format = SDL_PIXELFORMAT_INDEX8;
     }
     else {
         h.has_cmap = 0;
@@ -1545,21 +1545,12 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
         if (surface->format->Amask) {
             alpha = 1;
             h.pixel_bits = 32;
+            format = SDL_PIXELFORMAT_BGRA32;
         }
-        else
+        else {
             h.pixel_bits = 24;
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-        int s = alpha ? 0 : 8;
-        amask = 0x000000ff >> s;
-        rmask = 0x0000ff00 >> s;
-        gmask = 0x00ff0000 >> s;
-        bmask = 0xff000000 >> s;
-#else  /* SDL_BYTEORDER != SDL_BIG_ENDIAN */
-        amask = alpha ? 0xff000000 : 0;
-        rmask = 0x00ff0000;
-        gmask = 0x0000ff00;
-        bmask = 0x000000ff;
-#endif /* SDL_BYTEORDER != SDL_BIG_ENDIAN */
+            format = SDL_PIXELFORMAT_BGR24;
+        }
     }
     bpp = h.pixel_bits >> 3;
     if (rle)
@@ -1588,8 +1579,7 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
         }
     }
 
-    linebuf = SDL_CreateRGBSurface(0, surface->w, 1, h.pixel_bits, rmask,
-                                   gmask, bmask, amask);
+    linebuf = PG_CreateSurface(surface->w, 1, format);
     if (!linebuf)
         return -1;
 


### PR DESCRIPTION
The surface_init one could be refactored to push the mask->pixelformat conversion to only when it's actually parsing out masks from the user, and have the format live as a pixelformat most of the time. But that would be a more complex and risky diff than this one, so lets stay the course for now.

I removed `_raise_create_surface_error` because it's no longer useful. It caught a case emitted internally by SDL_CreateRGBSurface when it converts masks to pixelformat, now that we do that ourselves we can directly set ValueError there. As for it's use in subsurface, the format will never be invalid there because it comes from already initialized surfaces-- therefore there's no point with a possible ValueError about masks.