### PR TITLE
Remove RDTSC key because detection removed in SDL3

### DIFF
--- a/buildconfig/stubs/pygame/system.pyi
+++ b/buildconfig/stubs/pygame/system.pyi
@@ -5,7 +5,6 @@ from typing_extensions import TypedDict
 from pygame._data_classes import PowerState
 
 class _InstructionSets(TypedDict):
-    RDTSC: bool
     ALTIVEC: bool
     MMX: bool
     SSE: bool

--- a/docs/reST/ref/system.rst
+++ b/docs/reST/ref/system.rst
@@ -27,7 +27,6 @@
    ::
 
      {
-          'RDTSC': True,
           'ALTIVEC': False,
           'MMX': True,
           'SSE': True,
@@ -51,6 +50,9 @@
       SDL version < 2.24.0.
    
    .. versionadded:: 2.3.1
+
+    .. versionchanged:: 2.4.0 removed ``RDTSC`` key, 
+        as it has been removed in pre-release SDL3
 
 .. function:: get_total_ram
 

--- a/src_c/system.c
+++ b/src_c/system.c
@@ -23,7 +23,7 @@ pg_system_get_cpu_instruction_sets(PyObject *self, PyObject *_null)
     }                                                               \
     Py_DECREF(tmp_bool);
 
-    INSERT_INSTRUCTIONSET_INFO("RDTSC", SDL_HasRDTSC);
+    // Don't insert SDL_HasRDTSC because it's been removed in SDL3
     INSERT_INSTRUCTIONSET_INFO("ALTIVEC", SDL_HasAltiVec);
     INSERT_INSTRUCTIONSET_INFO("MMX", SDL_HasMMX);
     INSERT_INSTRUCTIONSET_INFO("SSE", SDL_HasSSE);


### PR DESCRIPTION
My rationale for straight up removing it is because I doubt anyone is using it.

I'm open to other suggestions of how to do the change management.