### PR TITLE
Fix grub-efi-amd64-signed installation failures on Ubuntu 20.04 CI builds

### DIFF
--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -56,7 +56,9 @@ jobs:
     - name: Install deps
       # install numpy from pip and not apt because the one from pip is newer,
       # and has typestubs
+      # https://github.com/actions/runner-images/issues/7192
       run: |
+        echo 'APT::Get::Always-Include-Phased-Updates "false";' | sudo tee /etc/apt/apt.conf.d/99-phased-updates
         sudo apt-get update --fix-missing
         sudo apt-get upgrade
         sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev python3-setuptools python3-dev

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -57,8 +57,9 @@ jobs:
       # install numpy from pip and not apt because the one from pip is newer,
       # and has typestubs
       # https://github.com/actions/runner-images/issues/7192
+      # https://github.com/orgs/community/discussions/47863
       run: |
-        echo RESET grub-efi/install_devices | debconf-communicate grub-pc
+        sudo apt-mark hold grub-efi-amd64-signed
         sudo apt-get update --fix-missing
         sudo apt-get upgrade
         sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev python3-setuptools python3-dev

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -58,7 +58,7 @@ jobs:
       # and has typestubs
       # https://github.com/actions/runner-images/issues/7192
       run: |
-        echo 'APT::Get::Always-Include-Phased-Updates "false";' | sudo tee /etc/apt/apt.conf.d/99-phased-updates
+        echo RESET grub-efi/install_devices | debconf-communicate grub-pc
         sudo apt-get update --fix-missing
         sudo apt-get upgrade
         sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev python3-setuptools python3-dev

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install deps
         # https://github.com/actions/runner-images/issues/7192
         run: |
-          echo 'APT::Get::Always-Include-Phased-Updates "false";' | sudo tee /etc/apt/apt.conf.d/99-phased-updates
+          echo RESET grub-efi/install_devices | debconf-communicate grub-pc
           sudo apt-get update --fix-missing
           sudo apt-get upgrade
           sudo apt install cppcheck

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -25,7 +25,9 @@ jobs:
       - uses: actions/checkout@v4.1.0
 
       - name: Install deps
+        # https://github.com/actions/runner-images/issues/7192
         run: |
+          echo 'APT::Get::Always-Include-Phased-Updates "false";' | sudo tee /etc/apt/apt.conf.d/99-phased-updates
           sudo apt-get update --fix-missing
           sudo apt-get upgrade
           sudo apt install cppcheck

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -26,8 +26,9 @@ jobs:
 
       - name: Install deps
         # https://github.com/actions/runner-images/issues/7192
+        # https://github.com/orgs/community/discussions/47863
         run: |
-          echo RESET grub-efi/install_devices | debconf-communicate grub-pc
+          sudo apt-mark hold grub-efi-amd64-signed
           sudo apt-get update --fix-missing
           sudo apt-get upgrade
           sudo apt install cppcheck


### PR DESCRIPTION
The full error looks like this:

```
Setting up grub-efi-amd64-signed (1.187.6~20.04.1+2.06-2ubuntu14.4) ...
mount: /var/lib/grub/esp: special device /dev/disk/by-id/scsi-14d53465420202020d8446e3f9983954098f1e80336f3baf3-part15 does not exist.
dpkg: error processing package grub-efi-amd64-signed (--configure):
 installed grub-efi-amd64-signed package post-installation script subprocess returned error exit status 32
```

See: https://github.com/orgs/community/discussions/47863
See also: https://github.com/actions/runner-images/issues/7192

May have to try a few things here.