### PR TITLE
Remove deprecated blend attribute from draw_aaline() & draw_aalines()

### DIFF
--- a/buildconfig/stubs/pygame/draw.pyi
+++ b/buildconfig/stubs/pygame/draw.pyi
@@ -61,12 +61,10 @@ def aaline(
     color: ColorValue,
     start_pos: Coordinate,
     end_pos: Coordinate,
-    blend: int = 1,
 ) -> Rect: ...
 def aalines(
     surface: Surface,
     color: ColorValue,
     closed: bool,
     points: Sequence[Coordinate],
-    blend: int = 1,
 ) -> Rect: ...

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -400,7 +400,6 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
    | :sl:`draw a straight antialiased line`
    | :sg:`aaline(surface, color, start_pos, end_pos) -> Rect`
-   | :sg:`aaline(surface, color, start_pos, end_pos, blend=1) -> Rect`
 
    Draws a straight antialiased line on the given surface.
 
@@ -488,8 +487,6 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
    :param end_pos: end position of the line, (x, y)
    :type end_pos: tuple(int or float, int or float) or
       list(int or float, int or float) or Vector2(int or float, int or float)
-   :param int blend: (optional) (deprecated) if non-zero (default) the line will be blended
-      with the surface's existing pixel shades, otherwise it will overwrite them
 
    :returns: a rect bounding the changed pixels, if nothing is drawn the
       bounding rect's position will be the ``start_pos`` parameter value (float
@@ -500,6 +497,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       two numbers
 
    .. versionchangedold:: 2.0.0 Added support for keyword arguments.
+   .. versionchanged:: 2.4.0 Removed deprecated 'blend' argument
 
    .. ## pygame.draw.aaline ##
 
@@ -507,7 +505,6 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
    | :sl:`draw multiple contiguous straight antialiased line segments`
    | :sg:`aalines(surface, color, closed, points) -> Rect`
-   | :sg:`aalines(surface, color, closed, points, blend=1) -> Rect`
 
    Draws a sequence of contiguous straight antialiased lines on the given
    surface.
@@ -527,9 +524,6 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       additionally if the ``closed`` parameter is ``True`` another line segment
       will be drawn from ``(x3, y3)`` to ``(x1, y1)``
    :type points: tuple(coordinate) or list(coordinate)
-   :param int blend: (optional) (deprecated) if non-zero (default) each line will be blended
-      with the surface's existing pixel shades, otherwise the pixels will be
-      overwritten
 
    :returns: a rect bounding the changed pixels, if nothing is drawn the
       bounding rect's position will be the position of the first point in the
@@ -542,6 +536,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       contain number pairs
 
    .. versionchangedold:: 2.0.0 Added support for keyword arguments.
+   .. versionchanged:: 2.4.0 Removed deprecated 'blend' argument
 
    .. ## pygame.draw.aalines ##
 

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -7,5 +7,5 @@
 #define DOC_DRAW_ARC "arc(surface, color, rect, start_angle, stop_angle) -> Rect\narc(surface, color, rect, start_angle, stop_angle, width=1) -> Rect\ndraw an elliptical arc"
 #define DOC_DRAW_LINE "line(surface, color, start_pos, end_pos) -> Rect\nline(surface, color, start_pos, end_pos, width=1) -> Rect\ndraw a straight line"
 #define DOC_DRAW_LINES "lines(surface, color, closed, points) -> Rect\nlines(surface, color, closed, points, width=1) -> Rect\ndraw multiple contiguous straight line segments"
-#define DOC_DRAW_AALINE "aaline(surface, color, start_pos, end_pos) -> Rect\naaline(surface, color, start_pos, end_pos, blend=1) -> Rect\ndraw a straight antialiased line"
+#define DOC_DRAW_AALINE "aaline(surface, color, start_pos, end_pos) -> Rect\naaline(surface, color, start_pos, end_pos) -> Rect\ndraw a straight antialiased line"
 #define DOC_DRAW_AALINES "aalines(surface, color, closed, points) -> Rect\naalines(surface, color, closed, points, blend=1) -> Rect\ndraw multiple contiguous straight antialiased line segments"

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -7,5 +7,5 @@
 #define DOC_DRAW_ARC "arc(surface, color, rect, start_angle, stop_angle) -> Rect\narc(surface, color, rect, start_angle, stop_angle, width=1) -> Rect\ndraw an elliptical arc"
 #define DOC_DRAW_LINE "line(surface, color, start_pos, end_pos) -> Rect\nline(surface, color, start_pos, end_pos, width=1) -> Rect\ndraw a straight line"
 #define DOC_DRAW_LINES "lines(surface, color, closed, points) -> Rect\nlines(surface, color, closed, points, width=1) -> Rect\ndraw multiple contiguous straight line segments"
-#define DOC_DRAW_AALINE "aaline(surface, color, start_pos, end_pos) -> Rect\naaline(surface, color, start_pos, end_pos) -> Rect\ndraw a straight antialiased line"
-#define DOC_DRAW_AALINES "aalines(surface, color, closed, points) -> Rect\naalines(surface, color, closed, points, blend=1) -> Rect\ndraw multiple contiguous straight antialiased line segments"
+#define DOC_DRAW_AALINE "aaline(surface, color, start_pos, end_pos) -> Rect\ndraw a straight antialiased line"
+#define DOC_DRAW_AALINES "aalines(surface, color, closed, points) -> Rect\ndraw multiple contiguous straight antialiased line segments"

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -108,8 +108,8 @@ aaline(PyObject *self, PyObject *arg, PyObject *kwargs)
     int drawn_area[4] = {INT_MAX, INT_MAX, INT_MIN,
                          INT_MIN}; /* Used to store bounding box values */
     Uint32 color;
-    static char *keywords[] = {"surface", "color", "start_pos",
-                               "end_pos", NULL};
+    static char *keywords[] = {"surface", "color", "start_pos", "end_pos",
+                               NULL};
 
     if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OOO|i", keywords,
                                      &pgSurface_Type, &surfobj, &colorobj,

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1072,7 +1072,7 @@ class BaseLineMixin:
         for size in ((49, 49), (50, 50)):
             for depth in (8, 16, 24, 32):
                 for flags in (0, SRCALPHA):
-                    surface = pygame.display.set_mode(size, flags, depth)
+                    surface = pygame.display.set_mode(size, flags)
                     surfaces.append(surface)
                     surfaces.append(surface.convert_alpha())
         return surfaces
@@ -2440,31 +2440,9 @@ class AALineMixin(BaseLineMixin):
     def test_aaline__args(self):
         """Ensures draw aaline accepts the correct args."""
         bounds_rect = self.draw_aaline(
-            pygame.Surface((3, 3)), (0, 10, 0, 50), (0, 0), (1, 1), 1
-        )
+            pygame.Surface((3, 3)), (0, 10, 0, 50), (0, 0), (1, 1))
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
-
-    def test_aaline__args_without_blend(self):
-        """Ensures draw aaline accepts the args without a blend."""
-        bounds_rect = self.draw_aaline(
-            pygame.Surface((2, 2)), (0, 0, 0, 50), (0, 0), (2, 2)
-        )
-
-        self.assertIsInstance(bounds_rect, pygame.Rect)
-
-    def test_aaline__blend_warning(self):
-        """From pygame 2, blend=False should raise DeprecationWarning."""
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            # Trigger DeprecationWarning.
-            self.draw_aaline(
-                pygame.Surface((2, 2)), (0, 0, 0, 50), (0, 0), (2, 2), False
-            )
-            # Check if there is only one warning and is a DeprecationWarning.
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
     def test_aaline__kwargs(self):
         """Ensures draw aaline accepts the correct kwargs"""
@@ -2913,12 +2891,12 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
         for depth in (24, 32):
             surface = pygame.Surface((5, 3), 0, depth)
             surface.fill(pygame.Color(0, 0, 0))
-            self.draw_aaline(surface, pygame.Color(255, 0, 0), (0, 1), (2, 1), 1)
+            self.draw_aaline(surface, pygame.Color(255, 0, 0), (0, 1), (2, 1))
 
             self.assertGreater(surface.get_at((1, 1)).r, 0, "there should be red here")
 
             surface.fill(pygame.Color(0, 0, 0))
-            self.draw_aaline(surface, pygame.Color(0, 0, 255), (0, 1), (2, 1), 1)
+            self.draw_aaline(surface, pygame.Color(0, 0, 255), (0, 1), (2, 1))
 
             self.assertGreater(surface.get_at((1, 1)).b, 0, "there should be blue here")
 
@@ -2930,7 +2908,7 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
             should[from_point] = should[to_point] = FG_GREEN
 
         def check_one_direction(from_point, to_point, should):
-            self.draw_aaline(self.surface, FG_GREEN, from_point, to_point, True)
+            self.draw_aaline(self.surface, FG_GREEN, from_point, to_point)
 
             for pt in check_points:
                 color = should.get(pt, BG_RED)
@@ -3185,31 +3163,9 @@ class AALinesMixin(BaseLineMixin):
     def test_aalines__args(self):
         """Ensures draw aalines accepts the correct args."""
         bounds_rect = self.draw_aalines(
-            pygame.Surface((3, 3)), (0, 10, 0, 50), False, ((0, 0), (1, 1)), 1
-        )
+            pygame.Surface((3, 3)), (0, 10, 0, 50), False, ((0, 0), (1, 1)))
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
-
-    def test_aalines__args_without_blend(self):
-        """Ensures draw aalines accepts the args without a blend."""
-        bounds_rect = self.draw_aalines(
-            pygame.Surface((2, 2)), (0, 0, 0, 50), False, ((0, 0), (1, 1))
-        )
-
-        self.assertIsInstance(bounds_rect, pygame.Rect)
-
-    def test_aalines__blend_warning(self):
-        """From pygame 2, blend=False should raise DeprecationWarning."""
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            # Trigger DeprecationWarning.
-            self.draw_aalines(
-                pygame.Surface((2, 2)), (0, 0, 0, 50), False, ((0, 0), (1, 1)), False
-            )
-            # Check if there is only one warning and is a DeprecationWarning.
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
     def test_aalines__kwargs(self):
         """Ensures draw aalines accepts the correct kwargs."""
@@ -3275,10 +3231,6 @@ class AALinesMixin(BaseLineMixin):
         color = pygame.Color("blue")
         closed = 0
         points = ((1, 2), (2, 1))
-
-        with self.assertRaises(TypeError):
-            # Invalid blend.
-            bounds_rect = self.draw_aalines(surface, color, closed, points, "1")
 
         with self.assertRaises(TypeError):
             # Invalid points.

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -2440,7 +2440,8 @@ class AALineMixin(BaseLineMixin):
     def test_aaline__args(self):
         """Ensures draw aaline accepts the correct args."""
         bounds_rect = self.draw_aaline(
-            pygame.Surface((3, 3)), (0, 10, 0, 50), (0, 0), (1, 1))
+            pygame.Surface((3, 3)), (0, 10, 0, 50), (0, 0), (1, 1)
+        )
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
 
@@ -3163,7 +3164,8 @@ class AALinesMixin(BaseLineMixin):
     def test_aalines__args(self):
         """Ensures draw aalines accepts the correct args."""
         bounds_rect = self.draw_aalines(
-            pygame.Surface((3, 3)), (0, 10, 0, 50), False, ((0, 0), (1, 1)))
+            pygame.Surface((3, 3)), (0, 10, 0, 50), False, ((0, 0), (1, 1))
+        )
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
 


### PR DESCRIPTION
Should have removed this in 2.2.0 but it got forgotten in the shuffle. It has been deprecated for some time now, this just finally pulls it all the way out

fixes #1233