### PR TITLE
Remove 'responsive' tables from docs CSS

### DIFF
--- a/docs/reST/themes/classic/static/pygame.css_t
+++ b/docs/reST/themes/classic/static/pygame.css_t
@@ -1000,10 +1000,6 @@ pre.commentContent {
 /* -- responsive design --------------------------------------------------------- */
 
 @media only screen and (max-width: 680px) {
-    /* Make tables be responsive-ish. */
-    table, thead, tbody, th, td, tr {
-        display: block;
-    }
 
     div.body img.inlined-right {
         float: none;


### PR DESCRIPTION
Related to #2495

As far as I can tell removing adding `display: block` to all table elements on mobile doesn't gain us very much?

It definitely ruins any actual tables though. Seems to be old CSS rather than recent.