### PR TITLE
Moving current scrap API docs to the top to avoid confusion

### DIFF
--- a/docs/reST/ref/scrap.rst
+++ b/docs/reST/ref/scrap.rst
@@ -21,6 +21,54 @@ in a future release of pygame.
    clipboard as the rest of the current API, but only strings are compatible with the 
    new API as of right now.
 
+.. function:: put_text
+
+   | :sl:`Places text into the clipboard.`
+   | :sg:`put_text(text) -> None`
+
+   Places the input text into the clipboard. The data should be a string.
+   This is the same clipboard as the legacy scrap API when using ``SCRAP_TEXT``.
+
+   :param string text: String to be placed into the clipboard
+   :rtype: None
+
+   :raises pygame.error: if video mode has not been set_mode
+
+   .. note:: ``pygame.display.set_mode()`` should be called before using the ``scrap`` module
+
+   .. versionadded:: 2.2.0
+
+   .. ## pygame.scrap.put_text
+
+.. function:: get_text
+   
+   | :sl:`Gets text from the clipboard.`
+   | :sg:`get_text() -> str`
+
+   Gets text from the clipboard and returns it. If the clipboard is empty,
+   returns an empty string. This is the same clipboard as the legacy scrap
+   API when using ``SCRAP_TEXT``.
+
+   :rtype: str
+
+   .. versionadded:: 2.2.0
+
+   .. ## pygame.scrap.get_text
+
+.. function:: has_text
+   
+   | :sl:`Checks if text is in the clipboard.`
+   | :sg:`has_text() -> bool`
+
+   Returns ``True`` if the clipboard has a string, otherwise returns ``False``.
+   This is the same clipboard as the legacy scrap API when using ``SCRAP_TEXT``.
+
+   :rtype: bool
+
+   .. versionadded:: 2.2.0
+
+   .. ## pygame.scrap.has_text
+
 **THE BELOW INFORMATION IS DEPRECATED IN PYGAME 2.2.0 AND WILL BE REMOVED IN THE FUTURE.**
 
 The scrap module is for transferring data to/from the clipboard. This allows
@@ -263,52 +311,4 @@ For an example of how the scrap module works refer to the examples page
    .. deprecated:: 2.2.0
 
    .. ## pygame.scrap.set_mode ##
-
-.. function:: put_text
-
-   | :sl:`Places text into the clipboard.`
-   | :sg:`put_text(text) -> None`
-
-   Places the input text into the clipboard. The data should be a string.
-   This is the same clipboard as the legacy scrap API when using ``SCRAP_TEXT``.
-
-   :param string text: String to be placed into the clipboard
-   :rtype: None
-
-   :raises pygame.error: if video mode has not been set_mode
-
-   .. note:: ``pygame.display.set_mode()`` should be called before using the ``scrap`` module
-
-   .. versionadded:: 2.2.0
-
-   .. ## pygame.scrap.put_text
-
-.. function:: get_text
-   
-   | :sl:`Gets text from the clipboard.`
-   | :sg:`get_text() -> str`
-
-   Gets text from the clipboard and returns it. If the clipboard is empty,
-   returns an empty string. This is the same clipboard as the legacy scrap
-   API when using ``SCRAP_TEXT``.
-
-   :rtype: str
-
-   .. versionadded:: 2.2.0
-
-   .. ## pygame.scrap.get_text
-
-.. function:: has_text
-   
-   | :sl:`Checks if text is in the clipboard.`
-   | :sg:`has_text() -> bool`
-
-   Returns ``True`` if the clipboard has a string, otherwise returns ``False``.
-   This is the same clipboard as the legacy scrap API when using ``SCRAP_TEXT``.
-
-   :rtype: bool
-
-   .. versionadded:: 2.2.0
-
-   .. ## pygame.scrap.has_text
 .. ## pygame.scrap ##

--- a/src_c/doc/scrap_doc.h
+++ b/src_c/doc/scrap_doc.h
@@ -1,5 +1,8 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_SCRAP "pygame module for clipboard support."
+#define DOC_SCRAP_PUTTEXT "put_text(text) -> None\nPlaces text into the clipboard."
+#define DOC_SCRAP_GETTEXT "get_text() -> str\nGets text from the clipboard."
+#define DOC_SCRAP_HASTEXT "has_text() -> bool\nChecks if text is in the clipboard."
 #define DOC_SCRAP_INIT "init() -> None\nInitializes the scrap module."
 #define DOC_SCRAP_GETINIT "get_init() -> bool\nReturns True if the scrap module is currently initialized."
 #define DOC_SCRAP_GET "get(type) -> bytes | None\nGets the data for the specified type from the clipboard."
@@ -8,6 +11,3 @@
 #define DOC_SCRAP_CONTAINS "contains(type) -> bool\nChecks whether data for a given type is available in the clipboard."
 #define DOC_SCRAP_LOST "lost() -> bool\nIndicates if the clipboard ownership has been lost by the pygame application."
 #define DOC_SCRAP_SETMODE "set_mode(mode) -> None\nSets the clipboard access mode."
-#define DOC_SCRAP_PUTTEXT "put_text(text) -> None\nPlaces text into the clipboard."
-#define DOC_SCRAP_GETTEXT "get_text() -> str\nGets text from the clipboard."
-#define DOC_SCRAP_HASTEXT "has_text() -> bool\nChecks if text is in the clipboard."


### PR DESCRIPTION
There is this notice that "everything below is deprecated" so it sort of made sense to move the working stuff to above that, I don't think that would cause confusion now (but I am not entirely sure what to do with `.. ## pygame.scrap ##` at the end of the docs, should it just stay at the end anyway? (I don't think we are using that feature anyway)).

Regarding the experimental notice, is that still relevant?