### PR TITLE
Fix problems caused by #2379

### DIFF
--- a/docs/reST/ref/sdl2_video.rst
+++ b/docs/reST/ref/sdl2_video.rst
@@ -135,7 +135,7 @@
       the window is full-screen to ensure the user is not trapped in your application.
       If you have a custom keyboard shortcut to exit fullscreen mode, you may suppress
       this behavior with an environment variable, e.g.
-       ``os.environ["SDL_ALLOW_ALT_TAB_WHILE_GRABBED"] = "0"``.
+      ``os.environ["SDL_ALLOW_ALT_TAB_WHILE_GRABBED"] = "0"``.
 
       This attribute requires SDL 2.0.16+.
 

--- a/test/window_test.py
+++ b/test/window_test.py
@@ -5,8 +5,6 @@ import os
 from pygame._sdl2.video import Window
 from pygame.version import SDL
 
-os.environ["SDL_VIDEODRIVER"] = "dummy"
-
 pygame.init()
 
 


### PR DESCRIPTION
1. Fix `Unexpected indentation` in `sdl2_video.rst`

2. Remove `os.environ["SDL_VIDEODRIVER"] = "dummy"` in window_test.py. That line was commented before.