### PR TITLE
Update pygame.examples.go_over_there for Python 3.12

### DIFF
--- a/examples/go_over_there.py
+++ b/examples/go_over_there.py
@@ -40,7 +40,7 @@ def reset():
     balls = []
     for x in range(MAX_BALLS):
         pos = pygame.Vector2(
-            random.randint(0, SCREEN_SIZE.x), random.randint(0, SCREEN_SIZE.y)
+            random.randint(0, int(SCREEN_SIZE.x)), random.randint(0, int(SCREEN_SIZE.y))
         )
         speed = random.uniform(MIN_SPEED, MAX_SPEED)
 


### PR DESCRIPTION
Python 3.12 function `random.randint()` expects integer arguments only. The go_over_there example was passing a float as the second argument.