### PR TITLE
Add docs for "devicename" parameter in 'pygame.mixer.init()'

### DIFF
--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -67,6 +67,10 @@ change the default buffer by calling :func:`pygame.mixer.pre_init` before
    playback. The buffer size must be a power of two (if not it is rounded up to
    the next nearest power of 2).
 
+   The devicename parameter is the name of sound device to open for audio
+   playback.  Allowed device names will vary based on the host system.
+   If left as ``None`` then a sensible default will be chosen for you.
+
    Some platforms require the :mod:`pygame.mixer` module to be initialized
    after the display modules have initialized. The top level ``pygame.init()``
    takes care of this automatically, but cannot pass any arguments to the mixer


### PR DESCRIPTION
Just noticed that this parameter wasn't documented so I asked around in the discord server to see what it does.  You can use `pygame._sdl2.audio.get_audio_device_names()` to get the valid names for it but since the module is hidden I just mentioned that it changes based on device.  Maybe in a future PR we add a public function for it?  It seems odd to have a parameter just dangle like this.