### PR TITLE
Fix RLE usage in the transform module

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -106,7 +106,19 @@
 #define PG_SurfaceHasRLE SDL_HasSurfaceRLE
 #else
 // vendored in until our lowest SDL version is 2.0.14
-#include "_blit_info.h"
+struct SDL_BlitMap
+{
+    SDL_Surface *dst;
+    int identity;
+    SDL_blit blit;
+    void *data;
+    SDL_BlitInfo info;
+
+    /* the version count matches the destination; mismatch indicates
+       an invalid mapping */
+    Uint32 dst_palette_version;
+    Uint32 src_palette_version;
+};
 #define SDL_COPY_RLE_DESIRED 0x00001000
 
 SDL_bool

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -138,18 +138,7 @@ struct SDL_BlitMap {
 #define SDL_COPY_RLE_DESIRED 0x00001000
 
 SDL_bool
-PG_SurfaceHasRLE(SDL_Surface *surface)
-{
-    if (surface == NULL) {
-        return SDL_FALSE;
-    }
-
-    if (!(surface->map->info.flags & SDL_COPY_RLE_DESIRED)) {
-        return SDL_FALSE;
-    }
-
-    return SDL_TRUE;
-}
+PG_SurfaceHasRLE(SDL_Surface *surface);
 #endif
 
 #endif

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -72,6 +72,8 @@
 #define PG_ConvertSurface SDL_ConvertSurface
 #define PG_ConvertSurfaceFormat SDL_ConvertSurfaceFormat
 
+#define PG_SurfaceHasRLE(src) SDL_SurfaceHasRLE(src)
+
 #else /* ~SDL_VERSION_ATLEAST(3, 0, 0)*/
 #define PG_ShowCursor() SDL_ShowCursor(SDL_ENABLE)
 #define PG_HideCursor() SDL_ShowCursor(SDL_DISABLE)
@@ -100,7 +102,7 @@
 #define PG_ConvertSurface(src, fmt) SDL_ConvertSurface(src, fmt, 0)
 #define PG_ConvertSurfaceFormat(src, pixel_format) \
     SDL_ConvertSurfaceFormat(src, pixel_format, 0)
-
+#define PG_SurfaceHasRLE(src) SDL_HasSurfaceRLE(src)
 #endif
 
 /* DictProxy is useful for event posting with an arbitrary dict. Maintains

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -121,14 +121,14 @@ typedef struct {
     int flags;
     Uint32 colorkey;
     Uint8 r, g, b, a;
-} SDL_BlitInfo;
+} SDL_InternalBlitInfo;
 
 struct SDL_BlitMap {
     SDL_Surface *dst;
     int identity;
     SDL_blit blit;
     void *data;
-    SDL_BlitInfo info;
+    SDL_InternalBlitInfo info;
 
     /* the version count matches the destination; mismatch indicates
        an invalid mapping */

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -106,6 +106,9 @@
 #define PG_SurfaceHasRLE SDL_HasSurfaceRLE
 #else
 // vendored in until our lowest SDL version is 2.0.14
+#include "_blit_info.h"
+#define SDL_COPY_RLE_DESIRED 0x00001000
+
 SDL_bool
 PG_SurfaceHasRLE(SDL_Surface *surface)
 {

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -106,8 +106,25 @@
 #define PG_SurfaceHasRLE SDL_HasSurfaceRLE
 #else
 // vendored in until our lowest SDL version is 2.0.14
-struct SDL_BlitMap
-{
+typedef struct {
+    int width;
+    int height;
+    Uint8 *s_pixels;
+    int s_pxskip;
+    int s_skip;
+    Uint8 *d_pixels;
+    int d_pxskip;
+    int d_skip;
+    SDL_PixelFormat *src;
+    SDL_PixelFormat *dst;
+    Uint8 src_blanket_alpha;
+    int src_has_colorkey;
+    Uint32 src_colorkey;
+    SDL_BlendMode src_blend;
+    SDL_BlendMode dst_blend;
+} SDL_BlitInfo;
+
+struct SDL_BlitMap {
     SDL_Surface *dst;
     int identity;
     SDL_blit blit;

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -102,7 +102,25 @@
 #define PG_ConvertSurface(src, fmt) SDL_ConvertSurface(src, fmt, 0)
 #define PG_ConvertSurfaceFormat(src, pixel_format) \
     SDL_ConvertSurfaceFormat(src, pixel_format, 0)
+#if SDL_VERSION_ATLEAST(2, 0, 14)
 #define PG_SurfaceHasRLE SDL_HasSurfaceRLE
+#else
+// vendored in until our lowest SDL version is 2.0.14
+SDL_bool
+PG_SurfaceHasRLE(SDL_Surface *surface)
+{
+    if (surface == NULL) {
+        return SDL_FALSE;
+    }
+
+    if (!(surface->map->info.flags & SDL_COPY_RLE_DESIRED)) {
+        return SDL_FALSE;
+    }
+
+    return SDL_TRUE;
+}
+#endif
+
 #endif
 
 /* DictProxy is useful for event posting with an arbitrary dict. Maintains

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -72,7 +72,7 @@
 #define PG_ConvertSurface SDL_ConvertSurface
 #define PG_ConvertSurfaceFormat SDL_ConvertSurfaceFormat
 
-#define PG_SurfaceHasRLE(src) SDL_SurfaceHasRLE(src)
+#define PG_SurfaceHasRLE SDL_SurfaceHasRLE
 
 #else /* ~SDL_VERSION_ATLEAST(3, 0, 0)*/
 #define PG_ShowCursor() SDL_ShowCursor(SDL_ENABLE)
@@ -102,7 +102,7 @@
 #define PG_ConvertSurface(src, fmt) SDL_ConvertSurface(src, fmt, 0)
 #define PG_ConvertSurfaceFormat(src, pixel_format) \
     SDL_ConvertSurfaceFormat(src, pixel_format, 0)
-#define PG_SurfaceHasRLE(src) SDL_HasSurfaceRLE(src)
+#define PG_SurfaceHasRLE SDL_HasSurfaceRLE
 #endif
 
 /* DictProxy is useful for event posting with an arbitrary dict. Maintains

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -107,21 +107,20 @@
 #else
 // vendored in until our lowest SDL version is 2.0.14
 typedef struct {
-    int width;
-    int height;
-    Uint8 *s_pixels;
-    int s_pxskip;
-    int s_skip;
-    Uint8 *d_pixels;
-    int d_pxskip;
-    int d_skip;
-    SDL_PixelFormat *src;
-    SDL_PixelFormat *dst;
-    Uint8 src_blanket_alpha;
-    int src_has_colorkey;
-    Uint32 src_colorkey;
-    SDL_BlendMode src_blend;
-    SDL_BlendMode dst_blend;
+    Uint8 *src;
+    int src_w, src_h;
+    int src_pitch;
+    int src_skip;
+    Uint8 *dst;
+    int dst_w, dst_h;
+    int dst_pitch;
+    int dst_skip;
+    SDL_PixelFormat *src_fmt;
+    SDL_PixelFormat *dst_fmt;
+    Uint8 *table;
+    int flags;
+    Uint32 colorkey;
+    Uint8 r, g, b, a;
 } SDL_BlitInfo;
 
 struct SDL_BlitMap {

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -12,22 +12,6 @@
 */
 
 #include "_pygame.h"
-
-#if !SDL_VERSION_ATLEAST(2, 0, 14)
-SDL_bool
-PG_SurfaceHasRLE(SDL_Surface *surface)
-{
-    if (surface == NULL) {
-        return SDL_FALSE;
-    }
-
-    if (!(surface->map->info.flags & SDL_COPY_RLE_DESIRED)) {
-        return SDL_FALSE;
-    }
-
-    return SDL_TRUE;
-}
-#endif
 #define NO_PYGAME_C_API
 #include "pygame.h"
 
@@ -46,6 +30,23 @@ typedef struct tColorRGBA {
 #endif
 #ifndef M_PI
 #define M_PI 3.141592654
+#endif
+
+#if !SDL_VERSION_ATLEAST(2, 0, 14)
+// Remove this when our minimum version is 2.0.14 or larger
+SDL_bool
+PG_SurfaceHasRLE(SDL_Surface *surface)
+{
+    if (surface == NULL) {
+        return SDL_FALSE;
+    }
+
+    if (!(surface->map->info.flags & SDL_COPY_RLE_DESIRED)) {
+        return SDL_FALSE;
+    }
+
+    return SDL_TRUE;
+}
 #endif
 
 /*

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -511,6 +511,7 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
     int dstwidth, dstheight;
     int is32bit;
     int src_converted;
+    Uint32 colorkey;
 
     /*
      * Sanity check
@@ -556,6 +557,7 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
         /*
          * -----------------------
          */
+
         int dstwidthhalf, dstheighthalf;
         double sanglezoom, canglezoom, sanglezoominv, canglezoominv;
 
@@ -583,6 +585,13 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
          * Target surface is 32bit with source RGBA/ABGR ordering
          */
         rz_dst = PG_CreateSurface(dstwidth, dstheight, rz_src->format->format);
+        if (SDL_GetColorKey(src, &colorkey) == 0) {
+            if (SDL_SetColorKey(rz_dst, SDL_TRUE, colorkey) != 0 ||
+                SDL_SetSurfaceRLE(rz_dst, SDL_TRUE) != 0) {
+                SDL_FreeSurface(rz_dst);
+                return NULL;
+            }
+        }
 
         /*
          * Lock source surface
@@ -629,6 +638,13 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
          * Target surface is 32bit with source RGBA/ABGR ordering
          */
         rz_dst = PG_CreateSurface(dstwidth, dstheight, rz_src->format->format);
+        if (SDL_GetColorKey(src, &colorkey) == 0) {
+            if (SDL_SetColorKey(rz_dst, SDL_TRUE, colorkey) != 0 ||
+                SDL_SetSurfaceRLE(rz_dst, SDL_TRUE) != 0) {
+                SDL_FreeSurface(rz_dst);
+                return NULL;
+            }
+        }
 
         /*
          * Lock source surface

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -557,7 +557,6 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
         /*
          * -----------------------
          */
-
         int dstwidthhalf, dstheighthalf;
         double sanglezoom, canglezoom, sanglezoominv, canglezoominv;
 

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -12,6 +12,22 @@
 */
 
 #include "_pygame.h"
+
+#if !SDL_VERSION_ATLEAST(2, 0, 14)
+SDL_bool
+PG_SurfaceHasRLE(SDL_Surface *surface)
+{
+    if (surface == NULL) {
+        return SDL_FALSE;
+    }
+
+    if (!(surface->map->info.flags & SDL_COPY_RLE_DESIRED)) {
+        return SDL_FALSE;
+    }
+
+    return SDL_TRUE;
+}
+#endif
 #define NO_PYGAME_C_API
 #include "pygame.h"
 

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -11,6 +11,7 @@
 
 */
 
+#include "_pygame.h"
 #define NO_PYGAME_C_API
 #include "pygame.h"
 
@@ -585,8 +586,11 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
          */
         rz_dst = PG_CreateSurface(dstwidth, dstheight, rz_src->format->format);
         if (SDL_GetColorKey(src, &colorkey) == 0) {
-            if (SDL_SetColorKey(rz_dst, SDL_TRUE, colorkey) != 0 ||
-                SDL_SetSurfaceRLE(rz_dst, SDL_TRUE) != 0) {
+            if (SDL_SetColorKey(rz_dst, SDL_TRUE, colorkey) != 0) {
+                SDL_FreeSurface(rz_dst);
+                return NULL;
+            }
+            if (PG_SurfaceHasRLE(src) && SDL_SetSurfaceRLE(rz_dst, SDL_TRUE) != 0) {
                 SDL_FreeSurface(rz_dst);
                 return NULL;
             }
@@ -636,10 +640,14 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
         /*
          * Target surface is 32bit with source RGBA/ABGR ordering
          */
+
         rz_dst = PG_CreateSurface(dstwidth, dstheight, rz_src->format->format);
         if (SDL_GetColorKey(src, &colorkey) == 0) {
-            if (SDL_SetColorKey(rz_dst, SDL_TRUE, colorkey) != 0 ||
-                SDL_SetSurfaceRLE(rz_dst, SDL_TRUE) != 0) {
+            if (SDL_SetColorKey(rz_dst, SDL_TRUE, colorkey) != 0) {
+                SDL_FreeSurface(rz_dst);
+                return NULL;
+            }
+            if (PG_SurfaceHasRLE(src) && SDL_SetSurfaceRLE(rz_dst, SDL_TRUE) != 0) {
                 SDL_FreeSurface(rz_dst);
                 return NULL;
             }

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -590,7 +590,8 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
                 SDL_FreeSurface(rz_dst);
                 return NULL;
             }
-            if (PG_SurfaceHasRLE(src) && SDL_SetSurfaceRLE(rz_dst, SDL_TRUE) != 0) {
+            if (PG_SurfaceHasRLE(src) &&
+                SDL_SetSurfaceRLE(rz_dst, SDL_TRUE) != 0) {
                 SDL_FreeSurface(rz_dst);
                 return NULL;
             }
@@ -647,7 +648,8 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
                 SDL_FreeSurface(rz_dst);
                 return NULL;
             }
-            if (PG_SurfaceHasRLE(src) && SDL_SetSurfaceRLE(rz_dst, SDL_TRUE) != 0) {
+            if (PG_SurfaceHasRLE(src) &&
+                SDL_SetSurfaceRLE(rz_dst, SDL_TRUE) != 0) {
                 SDL_FreeSurface(rz_dst);
                 return NULL;
             }

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -179,7 +179,12 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
     }
 
     if (SDL_GetColorKey(surf, &colorkey) == 0) {
-        if (SDL_SetColorKey(newsurf, SDL_TRUE, colorkey) != 0 ||
+        if (SDL_SetColorKey(newsurf, SDL_TRUE, colorkey) != 0) {
+            PyErr_SetString(pgExc_SDLError, SDL_GetError());
+            SDL_FreeSurface(newsurf);
+            return NULL;
+        }
+        if (PG_SurfaceHasRLE(surf) &&
             SDL_SetSurfaceRLE(newsurf, SDL_TRUE) != 0) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -890,6 +890,9 @@ surf_rotozoom(PyObject *self, PyObject *args, PyObject *kwargs)
 
     Py_BEGIN_ALLOW_THREADS;
     newsurf = rotozoomSurface(surf32, angle, scale, 1);
+    if (newsurf == NULL) {
+        PyErr_SetString(pgExc_SDLError, SDL_GetError());
+    }
     Py_END_ALLOW_THREADS;
 
     if (surf32 == surf)

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -890,10 +890,11 @@ surf_rotozoom(PyObject *self, PyObject *args, PyObject *kwargs)
 
     Py_BEGIN_ALLOW_THREADS;
     newsurf = rotozoomSurface(surf32, angle, scale, 1);
+    Py_END_ALLOW_THREADS;
     if (newsurf == NULL) {
         PyErr_SetString(pgExc_SDLError, SDL_GetError());
+        return NULL;
     }
-    Py_END_ALLOW_THREADS;
 
     if (surf32 == surf)
         pgSurface_Unlock(surfobj);
@@ -1955,86 +1956,79 @@ clamp_4
 
 */
 
-#define SURF_GET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format, p_pix)    \
-    switch (p_format->BytesPerPixel) {                                       \
-        case 1:                                                              \
-            p_color = (Uint32) *                                             \
-                      ((Uint8 *)(p_pixels) + (p_y) * p_surf->pitch + (p_x)); \
-            break;                                                           \
-        case 2:                                                              \
-            p_color =                                                        \
-                (Uint32) *                                                   \
-                ((Uint16 *)((p_pixels) + (p_y) * p_surf->pitch) + (p_x));    \
-            break;                                                           \
-        case 3:                                                              \
-            p_pix =                                                          \
-                ((Uint8 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x) * 3);   \
-            p_color = (SDL_BYTEORDER == SDL_LIL_ENDIAN)                      \
-                          ? (p_pix[0]) + (p_pix[1] << 8) + (p_pix[2] << 16)  \
-                          : (p_pix[2]) + (p_pix[1] << 8) + (p_pix[0] << 16); \
-            break;                                                           \
-        default: /* case 4: */                                               \
-            p_color =                                                        \
-                *((Uint32 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x));     \
-            break;                                                           \
+#define SURF_GET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format, p_pix)     \
+    switch (p_format->BytesPerPixel) {                                        \
+        case 1:                                                               \
+            p_color = (Uint32) *                                              \
+                      ((Uint8 *)(p_pixels) + (p_y)*p_surf->pitch + (p_x));    \
+            break;                                                            \
+        case 2:                                                               \
+            p_color = (Uint32) *                                              \
+                      ((Uint16 *)((p_pixels) + (p_y)*p_surf->pitch) + (p_x)); \
+            break;                                                            \
+        case 3:                                                               \
+            p_pix = ((Uint8 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)*3);    \
+            p_color = (SDL_BYTEORDER == SDL_LIL_ENDIAN)                       \
+                          ? (p_pix[0]) + (p_pix[1] << 8) + (p_pix[2] << 16)   \
+                          : (p_pix[2]) + (p_pix[1] << 8) + (p_pix[0] << 16);  \
+            break;                                                            \
+        default: /* case 4: */                                                \
+            p_color = *((Uint32 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x));  \
+            break;                                                            \
     }
 
 #if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
 
-#define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,       \
-                    p_byte_buf)                                          \
-    switch (p_format->BytesPerPixel) {                                   \
-        case 1:                                                          \
-            *((Uint8 *)p_pixels + (p_y) * p_surf->pitch + (p_x)) =       \
-                (Uint8)p_color;                                          \
-            break;                                                       \
-        case 2:                                                          \
-            *((Uint16 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
-                (Uint16)p_color;                                         \
-            break;                                                       \
-        case 3:                                                          \
-            p_byte_buf =                                                 \
-                (Uint8 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x) * 3; \
-            *(p_byte_buf + (p_format->Rshift >> 3)) =                    \
-                (Uint8)(p_color >> p_format->Rshift);                    \
-            *(p_byte_buf + (p_format->Gshift >> 3)) =                    \
-                (Uint8)(p_color >> p_format->Gshift);                    \
-            *(p_byte_buf + (p_format->Bshift >> 3)) =                    \
-                (Uint8)(p_color >> p_format->Bshift);                    \
-            break;                                                       \
-        default:                                                         \
-            *((Uint32 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
-                p_color;                                                 \
-            break;                                                       \
+#define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,            \
+                    p_byte_buf)                                               \
+    switch (p_format->BytesPerPixel) {                                        \
+        case 1:                                                               \
+            *((Uint8 *)p_pixels + (p_y)*p_surf->pitch + (p_x)) =              \
+                (Uint8)p_color;                                               \
+            break;                                                            \
+        case 2:                                                               \
+            *((Uint16 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)) =           \
+                (Uint16)p_color;                                              \
+            break;                                                            \
+        case 3:                                                               \
+            p_byte_buf = (Uint8 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)*3; \
+            *(p_byte_buf + (p_format->Rshift >> 3)) =                         \
+                (Uint8)(p_color >> p_format->Rshift);                         \
+            *(p_byte_buf + (p_format->Gshift >> 3)) =                         \
+                (Uint8)(p_color >> p_format->Gshift);                         \
+            *(p_byte_buf + (p_format->Bshift >> 3)) =                         \
+                (Uint8)(p_color >> p_format->Bshift);                         \
+            break;                                                            \
+        default:                                                              \
+            *((Uint32 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)) = p_color;  \
+            break;                                                            \
     }
 
 #else
 
-#define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,       \
-                    p_byte_buf)                                          \
-    switch (p_format->BytesPerPixel) {                                   \
-        case 1:                                                          \
-            *((Uint8 *)p_pixels + (p_y) * p_surf->pitch + (p_x)) =       \
-                (Uint8)p_color;                                          \
-            break;                                                       \
-        case 2:                                                          \
-            *((Uint16 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
-                (Uint16)p_color;                                         \
-            break;                                                       \
-        case 3:                                                          \
-            p_byte_buf =                                                 \
-                (Uint8 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x) * 3; \
-            *(p_byte_buf + 2 - (p_format->Rshift >> 3)) =                \
-                (Uint8)(p_color >> p_format->Rshift);                    \
-            *(p_byte_buf + 2 - (p_format->Gshift >> 3)) =                \
-                (Uint8)(p_color >> p_format->Gshift);                    \
-            *(p_byte_buf + 2 - (p_format->Bshift >> 3)) =                \
-                (Uint8)(p_color >> p_format->Bshift);                    \
-            break;                                                       \
-        default:                                                         \
-            *((Uint32 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
-                p_color;                                                 \
-            break;                                                       \
+#define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,            \
+                    p_byte_buf)                                               \
+    switch (p_format->BytesPerPixel) {                                        \
+        case 1:                                                               \
+            *((Uint8 *)p_pixels + (p_y)*p_surf->pitch + (p_x)) =              \
+                (Uint8)p_color;                                               \
+            break;                                                            \
+        case 2:                                                               \
+            *((Uint16 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)) =           \
+                (Uint16)p_color;                                              \
+            break;                                                            \
+        case 3:                                                               \
+            p_byte_buf = (Uint8 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)*3; \
+            *(p_byte_buf + 2 - (p_format->Rshift >> 3)) =                     \
+                (Uint8)(p_color >> p_format->Rshift);                         \
+            *(p_byte_buf + 2 - (p_format->Gshift >> 3)) =                     \
+                (Uint8)(p_color >> p_format->Gshift);                         \
+            *(p_byte_buf + 2 - (p_format->Bshift >> 3)) =                     \
+                (Uint8)(p_color >> p_format->Bshift);                         \
+            break;                                                            \
+        default:                                                              \
+            *((Uint32 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)) = p_color;  \
+            break;                                                            \
     }
 
 #endif

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1956,79 +1956,86 @@ clamp_4
 
 */
 
-#define SURF_GET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format, p_pix)     \
-    switch (p_format->BytesPerPixel) {                                        \
-        case 1:                                                               \
-            p_color = (Uint32) *                                              \
-                      ((Uint8 *)(p_pixels) + (p_y)*p_surf->pitch + (p_x));    \
-            break;                                                            \
-        case 2:                                                               \
-            p_color = (Uint32) *                                              \
-                      ((Uint16 *)((p_pixels) + (p_y)*p_surf->pitch) + (p_x)); \
-            break;                                                            \
-        case 3:                                                               \
-            p_pix = ((Uint8 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)*3);    \
-            p_color = (SDL_BYTEORDER == SDL_LIL_ENDIAN)                       \
-                          ? (p_pix[0]) + (p_pix[1] << 8) + (p_pix[2] << 16)   \
-                          : (p_pix[2]) + (p_pix[1] << 8) + (p_pix[0] << 16);  \
-            break;                                                            \
-        default: /* case 4: */                                                \
-            p_color = *((Uint32 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x));  \
-            break;                                                            \
+#define SURF_GET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format, p_pix)    \
+    switch (p_format->BytesPerPixel) {                                       \
+        case 1:                                                              \
+            p_color = (Uint32) *                                             \
+                      ((Uint8 *)(p_pixels) + (p_y) * p_surf->pitch + (p_x)); \
+            break;                                                           \
+        case 2:                                                              \
+            p_color =                                                        \
+                (Uint32) *                                                   \
+                ((Uint16 *)((p_pixels) + (p_y) * p_surf->pitch) + (p_x));    \
+            break;                                                           \
+        case 3:                                                              \
+            p_pix =                                                          \
+                ((Uint8 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x) * 3);   \
+            p_color = (SDL_BYTEORDER == SDL_LIL_ENDIAN)                      \
+                          ? (p_pix[0]) + (p_pix[1] << 8) + (p_pix[2] << 16)  \
+                          : (p_pix[2]) + (p_pix[1] << 8) + (p_pix[0] << 16); \
+            break;                                                           \
+        default: /* case 4: */                                               \
+            p_color =                                                        \
+                *((Uint32 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x));     \
+            break;                                                           \
     }
 
 #if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
 
-#define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,            \
-                    p_byte_buf)                                               \
-    switch (p_format->BytesPerPixel) {                                        \
-        case 1:                                                               \
-            *((Uint8 *)p_pixels + (p_y)*p_surf->pitch + (p_x)) =              \
-                (Uint8)p_color;                                               \
-            break;                                                            \
-        case 2:                                                               \
-            *((Uint16 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)) =           \
-                (Uint16)p_color;                                              \
-            break;                                                            \
-        case 3:                                                               \
-            p_byte_buf = (Uint8 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)*3; \
-            *(p_byte_buf + (p_format->Rshift >> 3)) =                         \
-                (Uint8)(p_color >> p_format->Rshift);                         \
-            *(p_byte_buf + (p_format->Gshift >> 3)) =                         \
-                (Uint8)(p_color >> p_format->Gshift);                         \
-            *(p_byte_buf + (p_format->Bshift >> 3)) =                         \
-                (Uint8)(p_color >> p_format->Bshift);                         \
-            break;                                                            \
-        default:                                                              \
-            *((Uint32 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)) = p_color;  \
-            break;                                                            \
+#define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,       \
+                    p_byte_buf)                                          \
+    switch (p_format->BytesPerPixel) {                                   \
+        case 1:                                                          \
+            *((Uint8 *)p_pixels + (p_y) * p_surf->pitch + (p_x)) =       \
+                (Uint8)p_color;                                          \
+            break;                                                       \
+        case 2:                                                          \
+            *((Uint16 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
+                (Uint16)p_color;                                         \
+            break;                                                       \
+        case 3:                                                          \
+            p_byte_buf =                                                 \
+                (Uint8 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x) * 3; \
+            *(p_byte_buf + (p_format->Rshift >> 3)) =                    \
+                (Uint8)(p_color >> p_format->Rshift);                    \
+            *(p_byte_buf + (p_format->Gshift >> 3)) =                    \
+                (Uint8)(p_color >> p_format->Gshift);                    \
+            *(p_byte_buf + (p_format->Bshift >> 3)) =                    \
+                (Uint8)(p_color >> p_format->Bshift);                    \
+            break;                                                       \
+        default:                                                         \
+            *((Uint32 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
+                p_color;                                                 \
+            break;                                                       \
     }
 
 #else
 
-#define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,            \
-                    p_byte_buf)                                               \
-    switch (p_format->BytesPerPixel) {                                        \
-        case 1:                                                               \
-            *((Uint8 *)p_pixels + (p_y)*p_surf->pitch + (p_x)) =              \
-                (Uint8)p_color;                                               \
-            break;                                                            \
-        case 2:                                                               \
-            *((Uint16 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)) =           \
-                (Uint16)p_color;                                              \
-            break;                                                            \
-        case 3:                                                               \
-            p_byte_buf = (Uint8 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)*3; \
-            *(p_byte_buf + 2 - (p_format->Rshift >> 3)) =                     \
-                (Uint8)(p_color >> p_format->Rshift);                         \
-            *(p_byte_buf + 2 - (p_format->Gshift >> 3)) =                     \
-                (Uint8)(p_color >> p_format->Gshift);                         \
-            *(p_byte_buf + 2 - (p_format->Bshift >> 3)) =                     \
-                (Uint8)(p_color >> p_format->Bshift);                         \
-            break;                                                            \
-        default:                                                              \
-            *((Uint32 *)(p_pixels + (p_y)*p_surf->pitch) + (p_x)) = p_color;  \
-            break;                                                            \
+#define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,       \
+                    p_byte_buf)                                          \
+    switch (p_format->BytesPerPixel) {                                   \
+        case 1:                                                          \
+            *((Uint8 *)p_pixels + (p_y) * p_surf->pitch + (p_x)) =       \
+                (Uint8)p_color;                                          \
+            break;                                                       \
+        case 2:                                                          \
+            *((Uint16 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
+                (Uint16)p_color;                                         \
+            break;                                                       \
+        case 3:                                                          \
+            p_byte_buf =                                                 \
+                (Uint8 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x) * 3; \
+            *(p_byte_buf + 2 - (p_format->Rshift >> 3)) =                \
+                (Uint8)(p_color >> p_format->Rshift);                    \
+            *(p_byte_buf + 2 - (p_format->Gshift >> 3)) =                \
+                (Uint8)(p_color >> p_format->Gshift);                    \
+            *(p_byte_buf + 2 - (p_format->Bshift >> 3)) =                \
+                (Uint8)(p_color >> p_format->Bshift);                    \
+            break;                                                       \
+        default:                                                         \
+            *((Uint32 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
+                p_color;                                                 \
+            break;                                                       \
     }
 
 #endif

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1637,7 +1637,9 @@ class TransformDisplayModuleTest(unittest.TestCase):
         pygame.Surface((100, 100)).blit(scaled_surf, (0, 0))
 
         self.assertEqual(
-            surf.get_flags() & pygame.RLEACCEL, scaled_surf.get_flags() & pygame.RLEACCEL)
+            surf.get_flags() & pygame.RLEACCEL,
+            scaled_surf.get_flags() & pygame.RLEACCEL,
+        )
         self.assertEqual(scaled_surf.get_at((8, 8)), (255, 0, 0, 255))
 
 

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1626,6 +1626,20 @@ class TransformDisplayModuleTest(unittest.TestCase):
         self.assertEqual(surf.get_at((0, 0)), surf2.get_at((0, 0)))
         self.assertEqual(surf2.get_at((0, 0)), (255, 0, 0, 255))
 
+    def test_unwanted_rle_not_added(self):
+        surf = pygame.Surface((16, 16))
+        surf.fill((255, 0, 0))
+        surf.set_colorkey((0, 0, 0))
+        surf.set_alpha(64)
+
+        #  scale it to the same size (size doesn't matter here)
+        scaled_surf = pygame.transform.scale(surf, (16, 16))
+        pygame.Surface((100, 100)).blit(scaled_surf, (0, 0))
+
+        self.assertEqual(
+            scaled_surf.get_flags() & pygame.RLEACCEL, scaled_surf.get_flags() & pygame.RLEACCEL)
+        self.assertEqual(scaled_surf.get_at((8, 8)), (255, 0, 0, 255))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1287,6 +1287,17 @@ class TransformModuleTest(unittest.TestCase):
         self.assertEqual(s1.get_rect(), pygame.Rect(0, 0, 0, 0))
         self.assertEqual(s2.get_rect(), pygame.Rect(0, 0, 0, 0))
 
+    def test_rotozoom_keeps_colorkey(self):
+        image = pygame.Surface((64, 64))
+        image.set_colorkey('black')
+        pygame.draw.circle(image, 'red', (32, 32), 32, width=0)
+
+        no_rot = pygame.transform.rotozoom(image, 0, 1.1)
+        self.assertEqual(image.get_colorkey(), no_rot.get_colorkey())
+
+        with_rot = pygame.transform.rotozoom(image, 5, 1.1)
+        self.assertEqual(image.get_colorkey(), with_rot.get_colorkey())
+
     def test_invert(self):
         surface = pygame.Surface((10, 10), depth=32)
 

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1637,7 +1637,7 @@ class TransformDisplayModuleTest(unittest.TestCase):
         pygame.Surface((100, 100)).blit(scaled_surf, (0, 0))
 
         self.assertEqual(
-            scaled_surf.get_flags() & pygame.RLEACCEL, scaled_surf.get_flags() & pygame.RLEACCEL)
+            surf.get_flags() & pygame.RLEACCEL, scaled_surf.get_flags() & pygame.RLEACCEL)
         self.assertEqual(scaled_surf.get_at((8, 8)), (255, 0, 0, 255))
 
 

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1289,8 +1289,8 @@ class TransformModuleTest(unittest.TestCase):
 
     def test_rotozoom_keeps_colorkey(self):
         image = pygame.Surface((64, 64))
-        image.set_colorkey('black')
-        pygame.draw.circle(image, 'red', (32, 32), 32, width=0)
+        image.set_colorkey("black")
+        pygame.draw.circle(image, "red", (32, 32), 32, width=0)
 
         no_rot = pygame.transform.rotozoom(image, 0, 1.1)
         self.assertEqual(image.get_colorkey(), no_rot.get_colorkey())


### PR DESCRIPTION
Building on work done in #2491. Don't merge this until that has gone in.

This makes sure we don't add the RLE flag to surfaces that didn't already have it before they were transformed. This was breaking output after transforms on color key surfaces - and there is no reason for us to be doing it. 

fixes #1668