### PR TITLE
Update `pygame.version` to not be an autogen file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /Setup
 *.pyc
 /build/
-/src_py/version.py
 
 # Windows prebuilt external libraries
 /prebuilt-x??

--- a/buildconfig/stubs/gen_stubs.py
+++ b/buildconfig/stubs/gen_stubs.py
@@ -69,7 +69,9 @@ PG_AUTOIMPORT_CLASSES = {
     "mixer": ["Channel"],
     "time": ["Clock"],
     "joystick": ["Joystick"],
-    "geometry": ["Circle"],
+    "base": ["__version__"],  # need an explicit import
+    # uncomment below line if Circle is added to the base namespace later
+    # "geometry": ["Circle"], 
 }
 
 # pygame modules from which __init__.py does the equivalent of
@@ -95,7 +97,11 @@ for k, v in PG_AUTOIMPORT_CLASSES.items():
     pygame_all_imports[f".{k}"] = v
 
 for k in PG_STAR_IMPORTS:
-    pygame_all_imports[f".{k}"] = get_all(getattr(pygame, k))
+    val = get_all(getattr(pygame, k))
+    try:
+        pygame_all_imports[f".{k}"].extend(val)
+    except KeyError:
+        pygame_all_imports[f".{k}"] = val
 
 # misc stubs that must be added to __init__.pyi
 misc_stubs = """"""

--- a/buildconfig/stubs/pygame/__init__.pyi
+++ b/buildconfig/stubs/pygame/__init__.pyi
@@ -37,6 +37,7 @@ from pygame import (
     sysfont as sysfont,
     _debug as _debug,
     system as system,
+    geometry as geometry,
 )
 
 from .rect import Rect as Rect, FRect as FRect
@@ -54,6 +55,7 @@ from .mixer import Channel as Channel
 from .time import Clock as Clock
 from .joystick import Joystick as Joystick
 from .base import (
+    __version__ as __version__,
     BufferError as BufferError,
     HAVE_NEWBUF as HAVE_NEWBUF,
     error as error,

--- a/buildconfig/stubs/pygame/base.pyi
+++ b/buildconfig/stubs/pygame/base.pyi
@@ -1,5 +1,7 @@
 from typing import Any, Tuple, Callable
 
+__version__: str
+
 class error(RuntimeError): ...
 class BufferError(Exception): ...
 

--- a/setup.py
+++ b/setup.py
@@ -526,58 +526,6 @@ add_datafiles(data_files, 'pygame/docs/generated',
                   ['ref',
                    ['*.txt']]]]]])
 
-
-# generate the version module
-def parse_version(ver):
-    return ', '.join(s for s in re.findall(r'\d+', ver)[0:3])
-
-
-def parse_source_version():
-    pgh_major = -1
-    pgh_minor = -1
-    pgh_patch = -1
-    major_exp_search = re.compile(r'define\s+PG_MAJOR_VERSION\s+([0-9]+)').search
-    minor_exp_search = re.compile(r'define\s+PG_MINOR_VERSION\s+([0-9]+)').search
-    patch_exp_search = re.compile(r'define\s+PG_PATCH_VERSION\s+([0-9]+)').search
-    pg_header = os.path.join('src_c', 'include', '_pygame.h')
-    with open(pg_header) as f:
-        for line in f:
-            if pgh_major == -1:
-                m = major_exp_search(line)
-                if m: pgh_major = int(m.group(1))
-            if pgh_minor == -1:
-                m = minor_exp_search(line)
-                if m: pgh_minor = int(m.group(1))
-            if pgh_patch == -1:
-                m = patch_exp_search(line)
-                if m: pgh_patch = int(m.group(1))
-    if pgh_major == -1:
-        raise SystemExit("_pygame.h: cannot find PG_MAJOR_VERSION")
-    if pgh_minor == -1:
-        raise SystemExit("_pygame.h: cannot find PG_MINOR_VERSION")
-    if pgh_patch == -1:
-        raise SystemExit("_pygame.h: cannot find PG_PATCH_VERSION")
-    return (pgh_major, pgh_minor, pgh_patch)
-
-
-def write_version_module(pygame_version, revision):
-    vernum = parse_version(pygame_version)
-    src_vernum = parse_source_version()
-    if vernum != ', '.join(str(e) for e in src_vernum):
-        raise SystemExit("_pygame.h version differs from 'METADATA' version"
-                         ": %s vs %s" % (vernum, src_vernum))
-    with open(os.path.join('buildconfig', 'version.py.in')) as header_file:
-        header = header_file.read()
-    with open(os.path.join('src_py', 'version.py'), 'w') as version_file:
-        version_file.write(header)
-        version_file.write('ver = "' + pygame_version + '"  # pylint: disable=invalid-name\n')
-        version_file.write(f'vernum = PygameVersion({vernum})\n')
-        version_file.write('rev = "' + revision + '"  # pylint: disable=invalid-name\n')
-        version_file.write('\n__all__ = ["SDL", "ver", "vernum", "rev"]\n')
-
-
-write_version_module(METADATA['version'], revision)
-
 # required. This will be filled if doing a Windows build.
 cmdclass = {}
 

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -2275,6 +2275,17 @@ MODINIT_DEFINE(base)
         goto error;
     }
 
+    PyObject *version =
+        PyUnicode_FromFormat("%d.%d.%d.%s", PG_MAJOR_VERSION, PG_MINOR_VERSION,
+                             PG_PATCH_VERSION, PG_VERSION_TAG);
+    if (!version) {
+        goto error;
+    }
+    if (PyModule_AddObject(module, "__version__", version)) {
+        Py_DECREF(version);
+        goto error;
+    }
+
     /*some initialization*/
     PyObject *quit = PyObject_GetAttrString(module, "quit");
     PyObject *rval;

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -2276,7 +2276,7 @@ MODINIT_DEFINE(base)
     }
 
     PyObject *version =
-        PyUnicode_FromFormat("%d.%d.%d.%s", PG_MAJOR_VERSION, PG_MINOR_VERSION,
+        PyUnicode_FromFormat("%d.%d.%d%s", PG_MAJOR_VERSION, PG_MINOR_VERSION,
                              PG_PATCH_VERSION, PG_VERSION_TAG);
     if (!version) {
         goto error;

--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -58,6 +58,7 @@
 #define PG_MAJOR_VERSION 2
 #define PG_MINOR_VERSION 4
 #define PG_PATCH_VERSION 0
+#define PG_VERSION_TAG "dev3"
 #define PG_VERSIONNUM(MAJOR, MINOR, PATCH) \
     (1000 * (MAJOR) + 100 * (MINOR) + (PATCH))
 #define PG_VERSION_ATLEAST(MAJOR, MINOR, PATCH)                             \

--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -58,7 +58,9 @@
 #define PG_MAJOR_VERSION 2
 #define PG_MINOR_VERSION 4
 #define PG_PATCH_VERSION 0
-#define PG_VERSION_TAG "dev3"
+/* The below is of the form ".devX" for dev releases, and "" (empty) for full
+ * releases */
+#define PG_VERSION_TAG ".dev3"
 #define PG_VERSIONNUM(MAJOR, MINOR, PATCH) \
     (1000 * (MAJOR) + 100 * (MINOR) + (PATCH))
 #define PG_VERSION_ATLEAST(MAJOR, MINOR, PATCH)                             \

--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -141,7 +141,7 @@ import pygame.math
 Vector2 = pygame.math.Vector2
 Vector3 = pygame.math.Vector3
 
-__version__ = ver
+from pygame.base import __version__
 
 # next, the "standard" modules
 # we still allow them to be missing for stripped down pygame distributions

--- a/src_py/version.py
+++ b/src_py/version.py
@@ -26,16 +26,15 @@ pygame version without importing the main pygame module.
 The python version information should always compare greater than any previous
 releases. (hmm, until we get to versions > 10)
 """
-from pygame.base import get_sdl_version
 
-###############
-# This file is generated with version.py.in
-##
+from pygame.base import get_sdl_version, __version__
+
 
 class SoftwareVersion(tuple):
     """
     A class for storing data about software versions.
     """
+
     __slots__ = ()
     fields = "major", "minor", "patch"
 
@@ -53,15 +52,24 @@ class SoftwareVersion(tuple):
     minor = property(lambda self: self[1])
     patch = property(lambda self: self[2])
 
+
 class PygameVersion(SoftwareVersion):
     """
     Pygame Version class.
     """
+
 
 class SDLVersion(SoftwareVersion):
     """
     SDL Version class.
     """
 
+
 _sdl_tuple = get_sdl_version()
 SDL = SDLVersion(_sdl_tuple[0], _sdl_tuple[1], _sdl_tuple[2])
+
+ver = __version__  # pylint: disable=invalid-name
+vernum = PygameVersion(*map(int, ver.split(".")[:3]))
+rev = ""  # pylint: disable=invalid-name
+
+__all__ = ["SDL", "ver", "vernum", "rev"]

--- a/test/version_test.py
+++ b/test/version_test.py
@@ -1,6 +1,9 @@
 import os
 import unittest
 
+from importlib.metadata import version
+
+import pygame
 
 pg_header = os.path.join("src_c", "include", "_pygame.h")
 
@@ -10,8 +13,6 @@ class VersionTest(unittest.TestCase):
         not os.path.isfile(pg_header), "Skipping because we cannot find _pygame.h"
     )
     def test_pg_version_consistency(self):
-        from pygame import version
-
         pgh_major = -1
         pgh_minor = -1
         pgh_patch = -1
@@ -34,14 +35,16 @@ class VersionTest(unittest.TestCase):
                     m = patch_exp_search(line)
                     if m:
                         pgh_patch = int(m.group(1))
-        self.assertEqual(pgh_major, version.vernum[0])
-        self.assertEqual(pgh_minor, version.vernum[1])
-        self.assertEqual(pgh_patch, version.vernum[2])
+        self.assertEqual(pgh_major, pygame.version.vernum[0])
+        self.assertEqual(pgh_minor, pygame.version.vernum[1])
+        self.assertEqual(pgh_patch, pygame.version.vernum[2])
 
     def test_sdl_version(self):
-        from pygame import version
+        self.assertEqual(len(pygame.version.SDL), 3)
 
-        self.assertEqual(len(version.SDL), 3)
+    def test_installed_version_and_dunder(self):
+        self.assertEqual(pygame.__version__, pygame.version.ver)
+        self.assertEqual(pygame.__version__, version("pygame-ce"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The idea here is to simplify buildconfig a tiny bit.

Instead of having `pygame.version` auto-generated by `setup.py` on every build (by doing a hacky lookup into C sources), the version information would be exported via `pygame.base` as a regular python string.

Also improved tests a bit.