### PR TITLE
Compile SSE2 smoothscale intrinsics on NEON

### DIFF
--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1221,7 +1221,8 @@ smoothscale_init(struct _module_state *st)
         return;
     }
 
-#ifdef SCALE_MMX_SUPPORT
+#if !defined(__EMSCRIPTEN__)
+#if PG_ENABLE_SSE_NEON
     if (SDL_HasSSE2()) {
         st->filter_type = "SSE2";
         st->filter_shrink_X = filter_shrink_X_SSE2;
@@ -1229,6 +1230,16 @@ smoothscale_init(struct _module_state *st)
         st->filter_expand_X = filter_expand_X_SSE2;
         st->filter_expand_Y = filter_expand_Y_SSE2;
     }
+    else if (SDL_HasNEON()) {
+        st->filter_type = "NEON";
+        st->filter_shrink_X = filter_shrink_X_SSE2;
+        st->filter_shrink_Y = filter_shrink_Y_SSE2;
+        st->filter_expand_X = filter_expand_X_SSE2;
+        st->filter_expand_Y = filter_expand_Y_SSE2;
+    }
+#endif /* PG_ENABLE_SSE_NEON */
+#endif /* !__EMSCRIPTEN__ */
+#ifdef SCALE_MMX_SUPPORT
     else if (SDL_HasSSE()) {
         st->filter_type = "SSE";
         st->filter_shrink_X = filter_shrink_X_SSE;
@@ -1563,7 +1574,6 @@ surf_set_smoothscale_backend(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s", keywords, &type))
         return NULL;
 
-#if defined(SCALE_MMX_SUPPORT)
     if (strcmp(type, "GENERIC") == 0) {
         st->filter_type = "GENERIC";
         st->filter_shrink_X = filter_shrink_X_ONLYC;
@@ -1571,6 +1581,7 @@ surf_set_smoothscale_backend(PyObject *self, PyObject *args, PyObject *kwargs)
         st->filter_expand_X = filter_expand_X_ONLYC;
         st->filter_expand_Y = filter_expand_Y_ONLYC;
     }
+#if defined(SCALE_MMX_SUPPORT)
     else if (strcmp(type, "MMX") == 0) {
         if (!SDL_HasMMX()) {
             return RAISE(PyExc_ValueError,
@@ -1593,6 +1604,15 @@ surf_set_smoothscale_backend(PyObject *self, PyObject *args, PyObject *kwargs)
         st->filter_expand_X = filter_expand_X_SSE;
         st->filter_expand_Y = filter_expand_Y_SSE;
     }
+#else
+    else if (strcmp(st->filter_type, "MMX") == 0 ||
+             strcmp(st->filter_type, "SSE") == 0) {
+        return PyErr_Format(PyExc_ValueError,
+                            "%s not supported on this machine", type);
+    }
+#endif /* ~defined(SCALE_MMX_SUPPORT) */
+#if !defined(__EMSCRIPTEN__)
+#if PG_ENABLE_SSE_NEON
     else if (strcmp(type, "SSE2") == 0) {
         if (!SDL_HasSSE2()) {
             return RAISE(PyExc_ValueError,
@@ -1604,22 +1624,24 @@ surf_set_smoothscale_backend(PyObject *self, PyObject *args, PyObject *kwargs)
         st->filter_expand_X = filter_expand_X_SSE2;
         st->filter_expand_Y = filter_expand_Y_SSE2;
     }
+
+    else if (strcmp(type, "NEON") == 0) {
+        if (!SDL_HasNEON()) {
+            return RAISE(PyExc_ValueError,
+                         "NEON not supported on this machine");
+        }
+        st->filter_type = "NEON";
+        st->filter_shrink_X = filter_shrink_X_SSE2;
+        st->filter_shrink_Y = filter_shrink_Y_SSE2;
+        st->filter_expand_X = filter_expand_X_SSE2;
+        st->filter_expand_Y = filter_expand_Y_SSE2;
+    }
+#endif /* PG_ENABLE_SSE_NEON */
+#endif /* !__EMSCRIPTEN__ */
     else {
         return PyErr_Format(PyExc_ValueError, "Unknown backend type %s", type);
     }
     Py_RETURN_NONE;
-#else  /* Not an x86 processor */
-    if (strcmp(type, "GENERIC") != 0) {
-        if (strcmp(st->filter_type, "MMX") == 0 ||
-            strcmp(st->filter_type, "SSE") == 0 ||
-            strcmp(st->filter_type, "SSE2") == 0) {
-            return PyErr_Format(PyExc_ValueError,
-                                "%s not supported on this machine", type);
-        }
-        return PyErr_Format(PyExc_ValueError, "Unknown backend type %s", type);
-    }
-    Py_RETURN_NONE;
-#endif /* defined(SCALE_MMX_SUPPORT) */
 }
 
 /* _get_color_move_pixels is for iterating over pixels in a Surface.

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1229,45 +1229,43 @@ smoothscale_init(struct _module_state *st)
         st->filter_shrink_Y = filter_shrink_Y_SSE2;
         st->filter_expand_X = filter_expand_X_SSE2;
         st->filter_expand_Y = filter_expand_Y_SSE2;
+        return;
     }
-    else if (SDL_HasNEON()) {
+    if (SDL_HasNEON()) {
         st->filter_type = "NEON";
         st->filter_shrink_X = filter_shrink_X_SSE2;
         st->filter_shrink_Y = filter_shrink_Y_SSE2;
         st->filter_expand_X = filter_expand_X_SSE2;
         st->filter_expand_Y = filter_expand_Y_SSE2;
+        return;
     }
 #endif /* PG_ENABLE_SSE_NEON */
 #endif /* !__EMSCRIPTEN__ */
 #ifdef SCALE_MMX_SUPPORT
-    else if (SDL_HasSSE()) {
+    if (SDL_HasSSE()) {
         st->filter_type = "SSE";
         st->filter_shrink_X = filter_shrink_X_SSE;
         st->filter_shrink_Y = filter_shrink_Y_SSE;
         st->filter_expand_X = filter_expand_X_SSE;
         st->filter_expand_Y = filter_expand_Y_SSE;
+        return;
     }
-    else if (SDL_HasMMX()) {
+    if (SDL_HasMMX()) {
         st->filter_type = "MMX";
         st->filter_shrink_X = filter_shrink_X_MMX;
         st->filter_shrink_Y = filter_shrink_Y_MMX;
         st->filter_expand_X = filter_expand_X_MMX;
         st->filter_expand_Y = filter_expand_Y_MMX;
+        return;
     }
-    else {
-        st->filter_type = "GENERIC";
-        st->filter_shrink_X = filter_shrink_X_ONLYC;
-        st->filter_shrink_Y = filter_shrink_Y_ONLYC;
-        st->filter_expand_X = filter_expand_X_ONLYC;
-        st->filter_expand_Y = filter_expand_Y_ONLYC;
-    }
-#else  /* ~SCALE_MMX_SUPPORT */
+#endif /* ~SCALE_MMX_SUPPORT */
+
+    /* If no accelerated options were selected, falls through to generic */
     st->filter_type = "GENERIC";
     st->filter_shrink_X = filter_shrink_X_ONLYC;
     st->filter_shrink_Y = filter_shrink_Y_ONLYC;
     st->filter_expand_X = filter_expand_X_ONLYC;
     st->filter_expand_Y = filter_expand_Y_ONLYC;
-#endif /* ~SCALE_MMX_SUPPORT */
 }
 
 static void

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1160,7 +1160,7 @@ class TransformModuleTest(unittest.TestCase):
 
     def test_get_smoothscale_backend(self):
         filter_type = pygame.transform.get_smoothscale_backend()
-        self.assertTrue(filter_type in ["GENERIC", "MMX", "SSE", "SSE2"])
+        self.assertTrue(filter_type in ["GENERIC", "MMX", "SSE", "SSE2", "NEON"])
         # It would be nice to test if a non-generic type corresponds to an x86
         # processor. But there is no simple test for this. platform.machine()
         # returns process version specific information, like 'i686'.


### PR DESCRIPTION
Follow on to #2473 

On x86, these routines represented a ~20-25% speedup over the already accelerated SSE instructions. However, on ARM there is no acceleration at all (besides any compiler autovectorization). I don't have an ARM device to test, but I expect it to be a ~60% speedup, given the difference between GENERIC (no acceleration) and SSE2 on x86.

I split out the legacy "SCALE_MMX_SUPPORT" define to only govern the old MMX and SSE routines, and used the same defines as the blitters for the new SSE2 and faux-NEON routines.

Myre's perf test program for ARM testing: https://github.com/pygame-community/pygame-ce/pull/2473#pullrequestreview-1651874211