### PR TITLE
Fix segfault when passing empty StringIO/File object to Font

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -221,13 +221,13 @@ static unsigned int current_freetype_generation = 0;
 
 #define RAISE_FREETYPE_QUIT_ERROR(r, font)                       \
     char message[120];                                           \
-    PyOS_snprintf(message, sizeof(message),                            \
-                  "Invalid freetype font (freetype module quit "       \
-                  "since freetype font "                               \
-                  "created) font generation: %d, "                     \
-                  "module generation: %d",                             \
-                  ((pgFontObject *)(font))->init_generation,          \
-                   current_freetype_generation);                       \
+    PyOS_snprintf(message, sizeof(message),                      \
+                  "Invalid freetype font (freetype module quit " \
+                  "since freetype font "                         \
+                  "created) font generation: %d, "               \
+                  "module generation: %d",                       \
+                  ((pgFontObject *)(font))->init_generation,     \
+                  current_freetype_generation);                  \
     RAISERETURN(pgExc_SDLError, message, r);
 
 static PyObject *
@@ -671,6 +671,7 @@ _ftfont_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
         obj->bgcolor[1] = 0;
         obj->bgcolor[2] = 0;
         obj->bgcolor[3] = 0;
+        obj->init_generation = current_freetype_generation;
     }
     return (PyObject *)obj;
 }
@@ -908,12 +909,10 @@ _ftfont_init(pgFontObject *self, PyObject *args, PyObject *kwds)
     */
     self->freetype = ft;
     ++ft->ref_count;
-    self->init_generation = current_freetype_generation;
 
     rval = 0;
 
 end:
-    self->init_generation = current_freetype_generation;
     Py_XDECREF(file);
     return rval;
 }

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -220,7 +220,7 @@ static unsigned int current_freetype_generation = 0;
     (((pgFontObject *)(x))->init_generation == current_freetype_generation)
 
 #define RAISE_FREETYPE_QUIT_ERROR(r, font)                       \
-    char message[100];                                           \
+    char message[120];                                           \
     PyOS_snprintf(message, sizeof(message),                            \
                   "Invalid freetype font (freetype module quit "       \
                   "since freetype font "                               \

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -909,6 +909,7 @@ _ftfont_init(pgFontObject *self, PyObject *args, PyObject *kwds)
     rval = 0;
 
 end:
+    self->init_generation = current_freetype_generation;
     Py_XDECREF(file);
     return rval;
 }

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -783,6 +783,13 @@ _ftfont_init(pgFontObject *self, PyObject *args, PyObject *kwds)
             goto end;
         }
 
+        if (source->size(source) <= 0) {
+            PyErr_Format(PyExc_ValueError,
+                         "Font file object has an invalid file size: %lld",
+                         source->size(source));
+            goto end;
+        }
+
         path = PyObject_GetAttrString(original_file, "name");
         if (!path) {
             PyErr_Clear();
@@ -824,6 +831,13 @@ _ftfont_init(pgFontObject *self, PyObject *args, PyObject *kwds)
         goto end;
     source = pgRWops_FromObject(file, NULL);
     if (!source) {
+        goto end;
+    }
+
+    if (source->size(source) <= 0) {
+        PyErr_Format(PyExc_ValueError,
+                     "Font file object has an invalid file size: %lld",
+                     source->size(source));
         goto end;
     }
 

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -219,16 +219,12 @@ static unsigned int current_freetype_generation = 0;
 #define FreetypeFont_GenerationCheck(x) \
     (((pgFontObject *)(x))->init_generation == current_freetype_generation)
 
-#define RAISE_FREETYPE_QUIT_ERROR(r, font)                       \
-    char message[120];                                           \
-    PyOS_snprintf(message, sizeof(message),                      \
-                  "Invalid freetype font (freetype module quit " \
-                  "since freetype font "                         \
-                  "created) font generation: %d, "               \
-                  "module generation: %d",                       \
-                  ((pgFontObject *)(font))->init_generation,     \
-                  current_freetype_generation);                  \
-    RAISERETURN(pgExc_SDLError, message, r);
+#define RAISE_FREETYPE_QUIT_ERROR(r)                                       \
+    RAISERETURN(                                                           \
+        pgExc_SDLError,                                                    \
+        "Invalid freetype font (freetype module quit since freetype font " \
+        "created)",                                                        \
+        r);
 
 static PyObject *
 load_font_res(const char *filename)
@@ -936,7 +932,7 @@ static PyObject *
 _ftfont_getstyle_flag(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     const intptr_t style_flag = (intptr_t)closure;
@@ -948,7 +944,7 @@ static int
 _ftfont_setstyle_flag(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1, self);
+        RAISE_FREETYPE_QUIT_ERROR(-1);
     }
 
     const intptr_t style_flag = (intptr_t)closure;
@@ -984,7 +980,7 @@ static PyObject *
 _ftfont_getstyle(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     return PyLong_FromLong(self->style);
@@ -994,7 +990,7 @@ static int
 _ftfont_setstyle(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1, self);
+        RAISE_FREETYPE_QUIT_ERROR(-1);
     }
 
     FT_UInt32 style;
@@ -1038,7 +1034,7 @@ static PyObject *
 _ftfont_getstrength(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     return PyFloat_FromDouble(self->strength);
@@ -1048,7 +1044,7 @@ static int
 _ftfont_setstrength(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1, self);
+        RAISE_FREETYPE_QUIT_ERROR(-1);
     }
 
     PyObject *strengthobj = PyNumber_Float(value);
@@ -1074,7 +1070,7 @@ static PyObject *
 _ftfont_getsize(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     if (self->face_size.y == 0) {
@@ -1088,7 +1084,7 @@ static int
 _ftfont_setsize(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1, self);
+        RAISE_FREETYPE_QUIT_ERROR(-1);
     }
 
     Scale_t face_size;
@@ -1108,7 +1104,7 @@ static PyObject *
 _ftfont_getunderlineadjustment(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     return PyFloat_FromDouble(self->underline_adjustment);
@@ -1119,7 +1115,7 @@ _ftfont_setunderlineadjustment(pgFontObject *self, PyObject *value,
                                void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1, self);
+        RAISE_FREETYPE_QUIT_ERROR(-1);
     }
 
     PyObject *adjustmentobj;
@@ -1152,7 +1148,7 @@ static PyObject *
 _ftfont_getfontmetric(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     typedef long (*getter)(FreeTypeInstance *, pgFontObject *);
@@ -1170,7 +1166,7 @@ static PyObject *
 _ftfont_getname(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     if (pgFont_IS_ALIVE(self)) {
@@ -1185,7 +1181,7 @@ static PyObject *
 _ftfont_getstylename(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     if (pgFont_IS_ALIVE(self)) {
@@ -1200,7 +1196,7 @@ static PyObject *
 _ftfont_getpath(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     PyObject *path = ((pgFontObject *)self)->path;
@@ -1217,7 +1213,7 @@ static PyObject *
 _ftfont_getscalable(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     ASSERT_SELF_IS_ALIVE(self)
@@ -1228,7 +1224,7 @@ static PyObject *
 _ftfont_getfixedwidth(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     long fixed_width;
@@ -1243,7 +1239,7 @@ static PyObject *
 _ftfont_getfixedsizes(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     long num_fixed_sizes;
@@ -1258,7 +1254,7 @@ static PyObject *
 _ftfont_getrender_flag(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     const intptr_t render_flag = (intptr_t)closure;
@@ -1270,7 +1266,7 @@ static int
 _ftfont_setrender_flag(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1, self);
+        RAISE_FREETYPE_QUIT_ERROR(-1);
     }
 
     const intptr_t render_flag = (intptr_t)closure;
@@ -1298,7 +1294,7 @@ static PyObject *
 _ftfont_getresolution(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     return PyLong_FromUnsignedLong((unsigned long)self->resolution);
@@ -1309,7 +1305,7 @@ static PyObject *
 _ftfont_getrotation(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     return PyLong_FromLong((long)FX16_ROUND_TO_INT(self->rotation));
@@ -1319,7 +1315,7 @@ static int
 _ftfont_setrotation(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1, self);
+        RAISE_FREETYPE_QUIT_ERROR(-1);
     }
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("rotation", value);
@@ -1343,7 +1339,7 @@ static PyObject *
 _ftfont_getfgcolor(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     return pgColor_New(self->fgcolor);
@@ -1353,7 +1349,7 @@ static int
 _ftfont_setfgcolor(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1, self);
+        RAISE_FREETYPE_QUIT_ERROR(-1);
     }
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("fgcolor", value);
@@ -1371,7 +1367,7 @@ static PyObject *
 _ftfont_getbgcolor(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     return pgColor_New(self->bgcolor);
@@ -1381,7 +1377,7 @@ static int
 _ftfont_setbgcolor(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1, self);
+        RAISE_FREETYPE_QUIT_ERROR(-1);
     }
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("bgcolor", value);
@@ -1426,7 +1422,7 @@ static PyObject *
 _ftfont_getrect(pgFontObject *self, PyObject *args, PyObject *kwds)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     /* MODIFIED
@@ -1526,7 +1522,7 @@ static PyObject *
 _ftfont_getmetrics(pgFontObject *self, PyObject *args, PyObject *kwds)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     /* keyword list */
@@ -1578,7 +1574,7 @@ static PyObject *
 _ftfont_getsizedascender(pgFontObject *self, PyObject *args)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     Scale_t face_size = FACE_SIZE_NONE;
@@ -1609,7 +1605,7 @@ static PyObject *
 _ftfont_getsizeddescender(pgFontObject *self, PyObject *args)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     Scale_t face_size = FACE_SIZE_NONE;
@@ -1641,7 +1637,7 @@ static PyObject *
 _ftfont_getsizedheight(pgFontObject *self, PyObject *args)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     Scale_t face_size = FACE_SIZE_NONE;
@@ -1672,7 +1668,7 @@ static PyObject *
 _ftfont_getsizedglyphheight(pgFontObject *self, PyObject *args)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     Scale_t face_size = FACE_SIZE_NONE;
@@ -1704,7 +1700,7 @@ static PyObject *
 _ftfont_getsizes(pgFontObject *self, PyObject *_null)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     int nsizes;
@@ -1745,7 +1741,7 @@ static PyObject *
 _ftfont_render_raw(pgFontObject *self, PyObject *args, PyObject *kwds)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     /* keyword list */
@@ -1812,7 +1808,7 @@ static PyObject *
 _ftfont_render_raw_to(pgFontObject *self, PyObject *args, PyObject *kwds)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     /* keyword list */
@@ -1881,7 +1877,7 @@ static PyObject *
 _ftfont_render(pgFontObject *self, PyObject *args, PyObject *kwds)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     /* keyword list */
@@ -2009,7 +2005,7 @@ static PyObject *
 _ftfont_render_to(pgFontObject *self, PyObject *args, PyObject *kwds)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
+        RAISE_FREETYPE_QUIT_ERROR(NULL);
     }
 
     /* keyword list */

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -219,12 +219,16 @@ static unsigned int current_freetype_generation = 0;
 #define FreetypeFont_GenerationCheck(x) \
     (((pgFontObject *)(x))->init_generation == current_freetype_generation)
 
-#define RAISE_FREETYPE_QUIT_ERROR(r)                                       \
-    RAISERETURN(                                                           \
-        pgExc_SDLError,                                                    \
-        "Invalid freetype font (freetype module quit since freetype font " \
-        "created)",                                                        \
-        r);
+#define RAISE_FREETYPE_QUIT_ERROR(r, font)                       \
+    char message[100];                                           \
+    PyOS_snprintf(message, sizeof(message),                            \
+                  "Invalid freetype font (freetype module quit "       \
+                  "since freetype font "                               \
+                  "created) font generation: %d, "                     \
+                  "module generation: %d",                             \
+                  ((pgFontObject *)(font))->init_generation,          \
+                   current_freetype_generation);                       \
+    RAISERETURN(pgExc_SDLError, message, r);
 
 static PyObject *
 load_font_res(const char *filename)
@@ -933,7 +937,7 @@ static PyObject *
 _ftfont_getstyle_flag(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     const intptr_t style_flag = (intptr_t)closure;
@@ -945,7 +949,7 @@ static int
 _ftfont_setstyle_flag(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1);
+        RAISE_FREETYPE_QUIT_ERROR(-1, self);
     }
 
     const intptr_t style_flag = (intptr_t)closure;
@@ -981,7 +985,7 @@ static PyObject *
 _ftfont_getstyle(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     return PyLong_FromLong(self->style);
@@ -991,7 +995,7 @@ static int
 _ftfont_setstyle(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1);
+        RAISE_FREETYPE_QUIT_ERROR(-1, self);
     }
 
     FT_UInt32 style;
@@ -1035,7 +1039,7 @@ static PyObject *
 _ftfont_getstrength(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     return PyFloat_FromDouble(self->strength);
@@ -1045,7 +1049,7 @@ static int
 _ftfont_setstrength(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1);
+        RAISE_FREETYPE_QUIT_ERROR(-1, self);
     }
 
     PyObject *strengthobj = PyNumber_Float(value);
@@ -1071,7 +1075,7 @@ static PyObject *
 _ftfont_getsize(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     if (self->face_size.y == 0) {
@@ -1085,7 +1089,7 @@ static int
 _ftfont_setsize(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1);
+        RAISE_FREETYPE_QUIT_ERROR(-1, self);
     }
 
     Scale_t face_size;
@@ -1105,7 +1109,7 @@ static PyObject *
 _ftfont_getunderlineadjustment(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     return PyFloat_FromDouble(self->underline_adjustment);
@@ -1116,7 +1120,7 @@ _ftfont_setunderlineadjustment(pgFontObject *self, PyObject *value,
                                void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1);
+        RAISE_FREETYPE_QUIT_ERROR(-1, self);
     }
 
     PyObject *adjustmentobj;
@@ -1149,7 +1153,7 @@ static PyObject *
 _ftfont_getfontmetric(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     typedef long (*getter)(FreeTypeInstance *, pgFontObject *);
@@ -1167,7 +1171,7 @@ static PyObject *
 _ftfont_getname(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     if (pgFont_IS_ALIVE(self)) {
@@ -1182,7 +1186,7 @@ static PyObject *
 _ftfont_getstylename(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     if (pgFont_IS_ALIVE(self)) {
@@ -1197,7 +1201,7 @@ static PyObject *
 _ftfont_getpath(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     PyObject *path = ((pgFontObject *)self)->path;
@@ -1214,7 +1218,7 @@ static PyObject *
 _ftfont_getscalable(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     ASSERT_SELF_IS_ALIVE(self)
@@ -1225,7 +1229,7 @@ static PyObject *
 _ftfont_getfixedwidth(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     long fixed_width;
@@ -1240,7 +1244,7 @@ static PyObject *
 _ftfont_getfixedsizes(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     long num_fixed_sizes;
@@ -1255,7 +1259,7 @@ static PyObject *
 _ftfont_getrender_flag(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     const intptr_t render_flag = (intptr_t)closure;
@@ -1267,7 +1271,7 @@ static int
 _ftfont_setrender_flag(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1);
+        RAISE_FREETYPE_QUIT_ERROR(-1, self);
     }
 
     const intptr_t render_flag = (intptr_t)closure;
@@ -1295,7 +1299,7 @@ static PyObject *
 _ftfont_getresolution(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     return PyLong_FromUnsignedLong((unsigned long)self->resolution);
@@ -1306,7 +1310,7 @@ static PyObject *
 _ftfont_getrotation(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     return PyLong_FromLong((long)FX16_ROUND_TO_INT(self->rotation));
@@ -1316,7 +1320,7 @@ static int
 _ftfont_setrotation(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1);
+        RAISE_FREETYPE_QUIT_ERROR(-1, self);
     }
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("rotation", value);
@@ -1340,7 +1344,7 @@ static PyObject *
 _ftfont_getfgcolor(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     return pgColor_New(self->fgcolor);
@@ -1350,7 +1354,7 @@ static int
 _ftfont_setfgcolor(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1);
+        RAISE_FREETYPE_QUIT_ERROR(-1, self);
     }
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("fgcolor", value);
@@ -1368,7 +1372,7 @@ static PyObject *
 _ftfont_getbgcolor(pgFontObject *self, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     return pgColor_New(self->bgcolor);
@@ -1378,7 +1382,7 @@ static int
 _ftfont_setbgcolor(pgFontObject *self, PyObject *value, void *closure)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(-1);
+        RAISE_FREETYPE_QUIT_ERROR(-1, self);
     }
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("bgcolor", value);
@@ -1423,7 +1427,7 @@ static PyObject *
 _ftfont_getrect(pgFontObject *self, PyObject *args, PyObject *kwds)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     /* MODIFIED
@@ -1523,7 +1527,7 @@ static PyObject *
 _ftfont_getmetrics(pgFontObject *self, PyObject *args, PyObject *kwds)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     /* keyword list */
@@ -1575,7 +1579,7 @@ static PyObject *
 _ftfont_getsizedascender(pgFontObject *self, PyObject *args)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     Scale_t face_size = FACE_SIZE_NONE;
@@ -1606,7 +1610,7 @@ static PyObject *
 _ftfont_getsizeddescender(pgFontObject *self, PyObject *args)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     Scale_t face_size = FACE_SIZE_NONE;
@@ -1638,7 +1642,7 @@ static PyObject *
 _ftfont_getsizedheight(pgFontObject *self, PyObject *args)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     Scale_t face_size = FACE_SIZE_NONE;
@@ -1669,7 +1673,7 @@ static PyObject *
 _ftfont_getsizedglyphheight(pgFontObject *self, PyObject *args)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     Scale_t face_size = FACE_SIZE_NONE;
@@ -1701,7 +1705,7 @@ static PyObject *
 _ftfont_getsizes(pgFontObject *self, PyObject *_null)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     int nsizes;
@@ -1742,7 +1746,7 @@ static PyObject *
 _ftfont_render_raw(pgFontObject *self, PyObject *args, PyObject *kwds)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     /* keyword list */
@@ -1809,7 +1813,7 @@ static PyObject *
 _ftfont_render_raw_to(pgFontObject *self, PyObject *args, PyObject *kwds)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     /* keyword list */
@@ -1878,7 +1882,7 @@ static PyObject *
 _ftfont_render(pgFontObject *self, PyObject *args, PyObject *kwds)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     /* keyword list */
@@ -2006,7 +2010,7 @@ static PyObject *
 _ftfont_render_to(pgFontObject *self, PyObject *args, PyObject *kwds)
 {
     if (!FreetypeFont_GenerationCheck(self)) {
-        RAISE_FREETYPE_QUIT_ERROR(NULL);
+        RAISE_FREETYPE_QUIT_ERROR(NULL, self);
     }
 
     /* keyword list */

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -1184,6 +1184,12 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
     if (fontsize <= 1)
         fontsize = 1;
 
+    if (rw->size(rw) == -1 || rw->size(rw) == 0) {
+        PyErr_Format(PyExc_RuntimeError,
+                     "Font file object appears to be empty");
+        goto error;
+    }
+
     Py_BEGIN_ALLOW_THREADS;
     font = TTF_OpenFontRW(rw, 1, fontsize);
     Py_END_ALLOW_THREADS;

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -1184,9 +1184,10 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
     if (fontsize <= 1)
         fontsize = 1;
 
-    if (rw->size(rw) == -1 || rw->size(rw) == 0) {
-        PyErr_Format(PyExc_RuntimeError,
-                     "Font file object appears to be empty");
+    if (rw->size(rw) <= 0) {
+        PyErr_Format(PyExc_ValueError,
+                     "Font file object has an invalid file size: %lld",
+                     rw->size(rw));
         goto error;
     }
 

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -710,6 +710,7 @@ class FontTypeTest(unittest.TestCase):
             font = pygame_font.Font(f)
 
     def test_load_from_invalid_sized_file_obj(self):
+        pygame.font.init()
         f = io.StringIO()
         with self.assertRaises(ValueError):
             font = pygame.font.Font(f)

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -2,6 +2,7 @@
 from re import T
 import sys
 import os
+import io
 import unittest
 import pathlib
 import platform
@@ -707,6 +708,11 @@ class FontTypeTest(unittest.TestCase):
         )
         with open(font_path, "rb") as f:
             font = pygame_font.Font(f)
+
+    def test_load_from_invalid_sized_file_obj(self):
+        f = io.StringIO()
+        with self.assertRaises(ValueError):
+            font = pygame.font.Font(f)
 
     def test_load_default_font_filename(self):
         # In font_init, a special case is when the filename argument is

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -549,12 +549,16 @@ class FreeTypeFontTest(unittest.TestCase):
         f = self._TEST_FONTS["fixed"]
         self.assertEqual(f.name, "Inconsolata")
 
-        with self.assertRaises(AttributeError or pygame.error):
+        with self.assertRaises(Exception) as cm:
             # this test raises an attribute error locally but
             # a pygame.error on the CI - I assume this is multi-threading
             # related.
             null_font = ft.Font.__new__(ft.Font)
             null_font.name
+        exception_type = type(cm.exception)
+        self.assertTrue(
+            (exception_type == pygame.error) or (exception_type == AttributeError)
+        )
 
     def test_freetype_Font_size(self):
         f = ft.Font(None, size=12)
@@ -1360,12 +1364,16 @@ class FreeTypeFontTest(unittest.TestCase):
     def test_freetype_Font_path(self):
         self.assertEqual(self._TEST_FONTS["sans"].path, self._sans_path)
 
-        with self.assertRaises(AttributeError or pygame.error):
+        with self.assertRaises(Exception) as cm:
             # this test raises an attribute error locally but
             # a pygame.error on the CI - I assume this is multi-threading
             # related.
             nullfont = ft.Font.__new__(ft.Font)
             nullfont.path
+        exception_type = type(cm.exception)
+        self.assertTrue(
+            (exception_type == pygame.error) or (exception_type == AttributeError)
+        )
 
     # This Font cache test is conditional on freetype being built by a debug
     # version of Python or with the C macro PGFT_DEBUG_CACHE defined.

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -549,16 +549,9 @@ class FreeTypeFontTest(unittest.TestCase):
         f = self._TEST_FONTS["fixed"]
         self.assertEqual(f.name, "Inconsolata")
 
-        with self.assertRaises(Exception) as cm:
-            # this test raises an attribute error locally but
-            # a pygame.error on the CI - I assume this is multi-threading
-            # related.
+        with self.assertRaises(AttributeError):
             null_font = ft.Font.__new__(ft.Font)
             null_font.name
-        exception_type = type(cm.exception)
-        self.assertTrue(
-            (exception_type == pygame.error) or (exception_type == AttributeError)
-        )
 
     def test_freetype_Font_size(self):
         f = ft.Font(None, size=12)
@@ -1364,16 +1357,9 @@ class FreeTypeFontTest(unittest.TestCase):
     def test_freetype_Font_path(self):
         self.assertEqual(self._TEST_FONTS["sans"].path, self._sans_path)
 
-        with self.assertRaises(Exception) as cm:
-            # this test raises an attribute error locally but
-            # a pygame.error on the CI - I assume this is multi-threading
-            # related.
+        with self.assertRaises(AttributeError):
             nullfont = ft.Font.__new__(ft.Font)
             nullfont.path
-        exception_type = type(cm.exception)
-        self.assertTrue(
-            (exception_type == pygame.error) or (exception_type == AttributeError)
-        )
 
     # This Font cache test is conditional on freetype being built by a debug
     # version of Python or with the C macro PGFT_DEBUG_CACHE defined.

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -549,7 +549,9 @@ class FreeTypeFontTest(unittest.TestCase):
         f = self._TEST_FONTS["fixed"]
         self.assertEqual(f.name, "Inconsolata")
 
-        self.assertRaises(AttributeError, lambda: nullfont().name)
+        with self.assertRaises(AttributeError):
+            nullfont = ft.Font.__new__(ft.Font)
+            nullfont.name
 
     def test_freetype_Font_size(self):
         f = ft.Font(None, size=12)
@@ -1354,7 +1356,10 @@ class FreeTypeFontTest(unittest.TestCase):
 
     def test_freetype_Font_path(self):
         self.assertEqual(self._TEST_FONTS["sans"].path, self._sans_path)
-        self.assertRaises(AttributeError, lambda: nullfont().path)
+
+        with self.assertRaises(AttributeError):
+            nullfont = ft.Font.__new__(ft.Font)
+            nullfont.path
 
     # This Font cache test is conditional on freetype being built by a debug
     # version of Python or with the C macro PGFT_DEBUG_CACHE defined.

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -549,9 +549,12 @@ class FreeTypeFontTest(unittest.TestCase):
         f = self._TEST_FONTS["fixed"]
         self.assertEqual(f.name, "Inconsolata")
 
-        with self.assertRaises(AttributeError):
-            nullfont = ft.Font.__new__(ft.Font)
-            nullfont.name
+        with self.assertRaises(AttributeError or pygame.error):
+            # this test raises an attribute error locally but
+            # a pygame.error on the CI - I assume this is multi-threading
+            # related.
+            null_font = ft.Font.__new__(ft.Font)
+            null_font.name
 
     def test_freetype_Font_size(self):
         f = ft.Font(None, size=12)
@@ -1357,7 +1360,10 @@ class FreeTypeFontTest(unittest.TestCase):
     def test_freetype_Font_path(self):
         self.assertEqual(self._TEST_FONTS["sans"].path, self._sans_path)
 
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(AttributeError or pygame.error):
+            # this test raises an attribute error locally but
+            # a pygame.error on the CI - I assume this is multi-threading
+            # related.
             nullfont = ft.Font.__new__(ft.Font)
             nullfont.path
 

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1,5 +1,5 @@
 import os
-
+import io
 import unittest
 import ctypes
 import weakref
@@ -157,6 +157,11 @@ class FreeTypeFontTest(unittest.TestCase):
         self.assertEqual(f.size, (x_ppem, y_ppem))
         f.__init__(self._bmp_8_75dpi_path, size=12)
         self.assertEqual(f.size, 12.0)
+
+    def test_load_from_invalid_sized_file_obj(self):
+        f = io.StringIO()
+        with self.assertRaises(ValueError):
+            font = f = ft.Font(f, size=24)
 
     @unittest.skipIf(IS_PYPY, "PyPy doesn't use refcounting")
     def test_freetype_Font_dealloc(self):
@@ -544,7 +549,7 @@ class FreeTypeFontTest(unittest.TestCase):
         f = self._TEST_FONTS["fixed"]
         self.assertEqual(f.name, "Inconsolata")
 
-        self.assertRaises(RuntimeError, lambda: nullfont().name)
+        self.assertRaises(AttributeError, lambda: nullfont().name)
 
     def test_freetype_Font_size(self):
         f = ft.Font(None, size=12)
@@ -1349,7 +1354,7 @@ class FreeTypeFontTest(unittest.TestCase):
 
     def test_freetype_Font_path(self):
         self.assertEqual(self._TEST_FONTS["sans"].path, self._sans_path)
-        self.assertRaises(pygame.error, lambda: nullfont().path)
+        self.assertRaises(AttributeError, lambda: nullfont().path)
 
     # This Font cache test is conditional on freetype being built by a debug
     # version of Python or with the C macro PGFT_DEBUG_CACHE defined.


### PR DESCRIPTION
Related to #2295

Also fixes freetype submodule's `Font` to track submodule generation on `__new__` instead of on `__init__` for more reliable performance of the unit tests with uninitialized Font objects. Previously I was getting different results running on the CI versus locally.  