### PR TITLE
Pkgdata rework

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -172,7 +172,7 @@ _ftfont_getdebugcachestats(pgFontObject *, void *);
 static PyObject *
 get_metrics(FontRenderMode *, pgFontObject *, PGFT_String *);
 static PyObject *
-load_font_res(const char *);
+ft_get_default_font_path();
 static int
 parse_dest(PyObject *, int *, int *);
 static int
@@ -211,8 +211,19 @@ free_string(PGFT_String *);
     }
 
 #define DEFAULT_FONT_NAME "freesansbold.ttf"
-#define PKGDATA_MODULE_NAME "pygame.pkgdata"
-#define RESOURCE_FUNC_NAME "getResource"
+
+static PyObject *
+ft_get_default_font_path()
+{
+    PyObject *pkgdata_mod = PyImport_ImportModule("pygame.pkgdata");
+    if (!pkgdata_mod)
+        return NULL;
+    PyObject *path_function =
+        PyObject_GetAttrString(pkgdata_mod, "get_resource_path");
+    if (!path_function)
+        return NULL;
+    return PyObject_CallFunction(path_function, "s", DEFAULT_FONT_NAME);
+}
 
 static unsigned int current_freetype_generation = 0;
 
@@ -225,55 +236,6 @@ static unsigned int current_freetype_generation = 0;
         "Invalid freetype font (freetype module quit since freetype font " \
         "created)",                                                        \
         r);
-
-static PyObject *
-load_font_res(const char *filename)
-{
-    PyObject *load_basicfunc = 0;
-    PyObject *pkgdatamodule = 0;
-    PyObject *resourcefunc = 0;
-    PyObject *result = 0;
-    PyObject *tmp;
-
-    pkgdatamodule = PyImport_ImportModule(PKGDATA_MODULE_NAME);
-    if (!pkgdatamodule) {
-        goto font_resource_end;
-    }
-
-    resourcefunc = PyObject_GetAttrString(pkgdatamodule, RESOURCE_FUNC_NAME);
-    if (!resourcefunc) {
-        goto font_resource_end;
-    }
-
-    result = PyObject_CallFunction(resourcefunc, "s", filename);
-    if (!result) {
-        goto font_resource_end;
-    }
-
-    tmp = PyObject_GetAttrString(result, "name");
-    if (tmp) {
-        PyObject *closeret;
-        if (!(closeret = PyObject_CallMethod(result, "close", NULL))) {
-            Py_DECREF(result);
-            Py_DECREF(tmp);
-            result = NULL;
-            goto font_resource_end;
-        }
-        Py_DECREF(closeret);
-
-        Py_DECREF(result);
-        result = tmp;
-    }
-    else {
-        PyErr_Clear();
-    }
-
-font_resource_end:
-    Py_XDECREF(pkgdatamodule);
-    Py_XDECREF(resourcefunc);
-    Py_XDECREF(load_basicfunc);
-    return result;
-}
 
 static int
 parse_dest(PyObject *dest, int *x, int *y)
@@ -740,7 +702,7 @@ _ftfont_init(pgFontObject *self, PyObject *args, PyObject *kwds)
         self->resolution = FREETYPE_STATE->resolution;
     }
     if (file == Py_None) {
-        file = load_font_res(DEFAULT_FONT_NAME);
+        file = ft_get_default_font_path();
 
         if (!file) {
             PyErr_SetString(PyExc_RuntimeError, "Failed to find default font");

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -97,87 +97,17 @@ _display_state_cleanup(_DisplayState *state)
 // (this code block is copied by window.c)
 #ifndef BUILD_STATIC
 
-#if !defined(__APPLE__)
-static char *icon_defaultname = "pygame_icon.bmp";
-static int icon_colorkey = 0;
-#else
-static char *icon_defaultname = "pygame_icon_mac.bmp";
-static int icon_colorkey = -1;
-#endif
-
-static char *pkgdatamodule_name = "pygame.pkgdata";
-static char *imagemodule_name = "pygame.image";
-static char *resourcefunc_name = "getResource";
-static char *load_basicfunc_name = "load_basic";
-
-static void
-pg_close_file(PyObject *fileobj)
-{
-    PyObject *result = PyObject_CallMethod(fileobj, "close", NULL);
-    if (result) {
-        Py_DECREF(result);
-    }
-    else {
-        PyErr_Clear();
-    }
-}
-
 static PyObject *
-pg_display_resource(char *filename)
+pg_load_pygame_icon()
 {
-    PyObject *imagemodule = NULL;
-    PyObject *load_basicfunc = NULL;
-    PyObject *pkgdatamodule = NULL;
-    PyObject *resourcefunc = NULL;
-    PyObject *fresult = NULL;
-    PyObject *result = NULL;
-    PyObject *name = NULL;
-
-    pkgdatamodule = PyImport_ImportModule(pkgdatamodule_name);
-    if (!pkgdatamodule)
-        goto display_resource_end;
-
-    resourcefunc = PyObject_GetAttrString(pkgdatamodule, resourcefunc_name);
-    if (!resourcefunc)
-        goto display_resource_end;
-
-    imagemodule = PyImport_ImportModule(imagemodule_name);
-    if (!imagemodule)
-        goto display_resource_end;
-
-    load_basicfunc = PyObject_GetAttrString(imagemodule, load_basicfunc_name);
-    if (!load_basicfunc)
-        goto display_resource_end;
-
-    fresult = PyObject_CallFunction(resourcefunc, "s", filename);
-    if (!fresult)
-        goto display_resource_end;
-
-    name = PyObject_GetAttrString(fresult, "name");
-    if (name != NULL) {
-        if (PyUnicode_Check(name)) {
-            pg_close_file(fresult);
-            Py_DECREF(fresult);
-            fresult = name;
-            name = NULL;
-        }
-    }
-    else {
-        PyErr_Clear();
-    }
-
-    result = PyObject_CallFunction(load_basicfunc, "O", fresult);
-    if (!result)
-        goto display_resource_end;
-
-display_resource_end:
-    Py_XDECREF(pkgdatamodule);
-    Py_XDECREF(resourcefunc);
-    Py_XDECREF(imagemodule);
-    Py_XDECREF(load_basicfunc);
-    Py_XDECREF(fresult);
-    Py_XDECREF(name);
-    return result;
+    PyObject *pkgdata_mod = PyImport_ImportModule("pygame.pkgdata");
+    if (!pkgdata_mod)
+        return NULL;
+    PyObject *loader_function =
+        PyObject_GetAttrString(pkgdata_mod, "load_pygame_icon");
+    if (!loader_function)
+        return NULL;
+    return PyObject_CallFunction(loader_function, "");
 }
 
 #endif  // BUILD_STATIC
@@ -1342,13 +1272,9 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
 
     /*set the window icon*/
     if (!state->icon) {
-        state->icon = pg_display_resource(icon_defaultname);
+        state->icon = pg_load_pygame_icon();
         if (!state->icon)
             PyErr_Clear();
-        else if (icon_colorkey != -1) {
-            SDL_SetColorKey(pgSurface_AsSurface(state->icon), SDL_TRUE,
-                            icon_colorkey);
-        }
     }
     if (state->icon)
         SDL_SetWindowIcon(win, pgSurface_AsSurface(state->icon));

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -71,70 +71,21 @@ static unsigned int current_ttf_generation = 0;
 static int font_initialized = 1;
 #else
 static int font_initialized = 0;
-static const char pkgdatamodule_name[] = "pygame.pkgdata";
-static const char resourcefunc_name[] = "getResource";
 #endif
 static const char font_defaultname[] = "freesansbold.ttf";
 static const int font_defaultsize = 20;
 
-/* Return an encoded file path, a file-like object or a NULL pointer.
- * May raise a Python error. Use PyErr_Occurred to check.
- */
 static PyObject *
-font_resource(const char *filename)
+font_get_default_font_path()
 {
-    PyObject *pkgdatamodule = NULL;
-    PyObject *resourcefunc = NULL;
-    PyObject *result = NULL;
-    PyObject *tmp;
-
-    pkgdatamodule = PyImport_ImportModule(pkgdatamodule_name);
-    if (pkgdatamodule == NULL) {
+    PyObject *pkgdata_mod = PyImport_ImportModule("pygame.pkgdata");
+    if (!pkgdata_mod)
         return NULL;
-    }
-
-    resourcefunc = PyObject_GetAttrString(pkgdatamodule, resourcefunc_name);
-    Py_DECREF(pkgdatamodule);
-    if (resourcefunc == NULL) {
+    PyObject *path_function =
+        PyObject_GetAttrString(pkgdata_mod, "get_resource_path");
+    if (!path_function)
         return NULL;
-    }
-
-    result = PyObject_CallFunction(resourcefunc, "s", filename);
-    Py_DECREF(resourcefunc);
-    if (result == NULL) {
-        return NULL;
-    }
-
-    tmp = PyObject_GetAttrString(result, "name");
-    if (tmp != NULL) {
-        PyObject *closeret;
-        if (!(closeret = PyObject_CallMethod(result, "close", NULL))) {
-            Py_DECREF(result);
-            Py_DECREF(tmp);
-            return NULL;
-        }
-        Py_DECREF(closeret);
-        Py_DECREF(result);
-        result = tmp;
-    }
-    else if (!PyErr_ExceptionMatches(PyExc_MemoryError)) {
-        PyErr_Clear();
-    }
-
-    tmp = pg_EncodeString(result, "UTF-8", NULL, NULL);
-    if (tmp == NULL) {
-        Py_DECREF(result);
-        return NULL;
-    }
-    else if (tmp != Py_None) {
-        Py_DECREF(result);
-        result = tmp;
-    }
-    else {
-        Py_DECREF(tmp);
-    }
-
-    return result;
+    return PyObject_CallFunction(path_function, "s", font_defaultname);
 }
 
 static PyObject *
@@ -1114,6 +1065,7 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
     TTF_Font *font = NULL;
     PyObject *obj = Py_None;
     SDL_RWops *rw;
+    SDL_bool use_default_font = SDL_FALSE;
 
     static char *kwlist[] = {"filename", "size", NULL};
 
@@ -1136,45 +1088,35 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
     }
 
     if (obj == Py_None) {
-        /* default font */
-        Py_DECREF(obj);
-        obj = font_resource(font_defaultname);
-        if (obj == NULL) {
-            if (PyErr_Occurred() == NULL) {
-                PyErr_Format(PyExc_RuntimeError,
-                             "default font '%.1024s' not found",
-                             font_defaultname);
-            }
-            goto error;
-        }
+        use_default_font = SDL_TRUE;
         fontsize = (int)(fontsize * .6875);
     }
-
-    rw = pgRWops_FromObject(obj, NULL);
-
-    if (rw == NULL && PyUnicode_Check(obj)) {
-        if (!PyUnicode_CompareWithASCIIString(obj, font_defaultname)) {
-            /* clear out existing file loading error before attempt to get
-             * default font */
+    else {
+        rw = pgRWops_FromObject(obj, NULL);
+        if (rw == NULL && PyUnicode_Check(obj) &&
+            !PyUnicode_CompareWithASCIIString(obj, font_defaultname)) {
+            // if font not found, but the font name is the default name,
+            // then load the default font.
             PyErr_Clear();
-            Py_DECREF(obj);
-            obj = font_resource(font_defaultname);
-            if (obj == NULL) {
-                if (PyErr_Occurred() == NULL) {
-                    PyErr_Format(PyExc_RuntimeError,
-                                 "default font '%.1024s' not found",
-                                 font_defaultname);
-                }
-                goto error;
-            }
+            use_default_font = SDL_TRUE;
             /* Unlike when the default font is loaded with None, the fontsize
              * is not scaled down here. This was probably unintended
              * implementation detail,
              * but this rewritten code aims to keep the exact behavior as the
              * old one */
-
-            rw = pgRWops_FromObject(obj, NULL);
         }
+    }
+
+    if (use_default_font) {
+        Py_DECREF(obj);
+        obj = font_get_default_font_path();
+        if (obj == NULL) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "Unable to load default font '%.1024s'",
+                         font_defaultname);
+            goto error;
+        }
+        rw = pgRWops_FromObject(obj, NULL);
     }
 
     if (rw == NULL) {

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -6,89 +6,17 @@
 
 #include "doc/sdl2_video_doc.h"
 
-#if !defined(__APPLE__)
-static char *icon_defaultname = "pygame_icon.bmp";
-static int icon_colorkey = 0;
-#else
-static char *icon_defaultname = "pygame_icon_mac.bmp";
-static int icon_colorkey = -1;
-#endif
-
-static char *pkgdatamodule_name = "pygame.pkgdata";
-static char *imagemodule_name = "pygame.image";
-static char *resourcefunc_name = "getResource";
-static char *load_basicfunc_name = "load_basic";
-
-// Copied from display.c
-static void
-pg_close_file(PyObject *fileobj)
-{
-    PyObject *result = PyObject_CallMethod(fileobj, "close", NULL);
-    if (result) {
-        Py_DECREF(result);
-    }
-    else {
-        PyErr_Clear();
-    }
-}
-
-// Copied from display.c
 static PyObject *
-pg_display_resource(char *filename)
+pg_load_pygame_icon()
 {
-    PyObject *imagemodule = NULL;
-    PyObject *load_basicfunc = NULL;
-    PyObject *pkgdatamodule = NULL;
-    PyObject *resourcefunc = NULL;
-    PyObject *fresult = NULL;
-    PyObject *result = NULL;
-    PyObject *name = NULL;
-
-    pkgdatamodule = PyImport_ImportModule(pkgdatamodule_name);
-    if (!pkgdatamodule)
-        goto display_resource_end;
-
-    resourcefunc = PyObject_GetAttrString(pkgdatamodule, resourcefunc_name);
-    if (!resourcefunc)
-        goto display_resource_end;
-
-    imagemodule = PyImport_ImportModule(imagemodule_name);
-    if (!imagemodule)
-        goto display_resource_end;
-
-    load_basicfunc = PyObject_GetAttrString(imagemodule, load_basicfunc_name);
-    if (!load_basicfunc)
-        goto display_resource_end;
-
-    fresult = PyObject_CallFunction(resourcefunc, "s", filename);
-    if (!fresult)
-        goto display_resource_end;
-
-    name = PyObject_GetAttrString(fresult, "name");
-    if (name != NULL) {
-        if (PyUnicode_Check(name)) {
-            pg_close_file(fresult);
-            Py_DECREF(fresult);
-            fresult = name;
-            name = NULL;
-        }
-    }
-    else {
-        PyErr_Clear();
-    }
-
-    result = PyObject_CallFunction(load_basicfunc, "O", fresult);
-    if (!result)
-        goto display_resource_end;
-
-display_resource_end:
-    Py_XDECREF(pkgdatamodule);
-    Py_XDECREF(resourcefunc);
-    Py_XDECREF(imagemodule);
-    Py_XDECREF(load_basicfunc);
-    Py_XDECREF(fresult);
-    Py_XDECREF(name);
-    return result;
+    PyObject *pkgdata_mod = PyImport_ImportModule("pygame.pkgdata");
+    if (!pkgdata_mod)
+        return NULL;
+    PyObject *loader_function =
+        PyObject_GetAttrString(pkgdata_mod, "load_pygame_icon");
+    if (!loader_function)
+        return NULL;
+    return PyObject_CallFunction(loader_function, "");
 }
 
 static PyTypeObject pgWindow_Type;
@@ -824,17 +752,7 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
 
     SDL_SetWindowData(_win, "pg_window", self);
 
-    PyObject *icon = pg_display_resource(icon_defaultname);
-    if (!icon) {
-        return -1;
-    }
-    if (icon_colorkey != -1) {
-        if (SDL_SetColorKey(pgSurface_AsSurface(icon), SDL_TRUE,
-                            icon_colorkey) < 0) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
-            return -1;
-        }
-    }
+    PyObject *icon = pg_load_pygame_icon();
     SDL_SetWindowIcon(self->_win, pgSurface_AsSurface(icon));
 
     return 0;

--- a/src_py/pkgdata.py
+++ b/src_py/pkgdata.py
@@ -1,25 +1,40 @@
 """
 pkgdata is a simple, extensible way for a package to acquire data file
 resources.
-
-The getResource function is equivalent to the standard idioms, such as
-the following minimal implementation:
-
-    import sys, os
-
-    def getResource(identifier, pkgname=__name__):
-        pkgpath = os.path.dirname(sys.modules[pkgname].__file__)
-        path = os.path.join(pkgpath, identifier)
-        return file(os.path.normpath(path), mode='rb')
-
-When a __loader__ is present on the module given by __name__, it will defer
-getResource to its get_data implementation and return it as a file-like
-object (such as StringIO).
 """
 
-__all__ = ["getResource"]
-import sys
+__all__ = [
+    "get_resource_path",
+    "load_pygame_icon",
+    "getResource",
+]
+
 import os
+import platform
+
+import pygame
+
+
+def get_resource_path(resource_name: str) -> str:
+    path = os.path.join(os.path.dirname(pygame.__file__), resource_name)
+    return os.path.normpath(path)
+
+
+def load_pygame_icon() -> pygame.Surface:
+    if platform.system() == "Darwin":
+        path = get_resource_path("pygame_icon_mac.bmp")
+        icon = pygame.image.load(path)
+    else:
+        path = get_resource_path("pygame_icon.bmp")
+        icon = pygame.image.load(path)
+        icon.set_colorkey(0)
+    return icon
+
+
+# legacy pkgdata code
+
+import sys
+import warnings
 
 try:
     from pkg_resources import resource_stream, resource_exists
@@ -58,6 +73,10 @@ def getResource(identifier, pkgname=__name__):
     rather than use it as a file-like object.  For example, you may
     be handing data off to a C API.
     """
+    warnings.warn(
+        DeprecationWarning,
+        "pygame.pkgdata.getResource is deprecated. Use pygame.pkgdata.get_resource_path instead",
+    )
 
     # When pyinstaller (or similar tools) are used, resource_exists may raise
     # NotImplemented error

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -32,8 +32,7 @@ def test_magic(f, magic_hexes):
 class ImageModuleTest(unittest.TestCase):
     def testLoadIcon(self):
         """see if we can load the pygame icon."""
-        f = pygame.pkgdata.getResource("pygame_icon.bmp")
-        self.assertEqual(f.mode, "rb")
+        f = pygame.pkgdata.get_resource_path("pygame_icon.bmp")
 
         surf = pygame.image.load_basic(f)
 
@@ -1722,9 +1721,7 @@ class ImageModuleTest(unittest.TestCase):
         self.assertEqual(s.get_at((0, 0)), (255, 255, 255, 255))
 
         # test loading from io.BufferedReader
-        f = pygame.pkgdata.getResource("pygame_icon.bmp")
-        self.assertEqual(f.mode, "rb")
-
+        f = open(example_path("data/asprite.bmp"), "rb")
         surf = pygame.image.load_basic(f)
 
         self.assertEqual(surf.get_at((0, 0)), (5, 4, 5, 255))


### PR DESCRIPTION
- [x] Deprecte `getResource()`
  Reasons:
  -  `pkg_resources` lib is out dated.
  - Most of use cases in our c code only need the resource path. Why not return a path directly instead of a file object?
- [x] Add `get_resource_path()`
  Get the pygame resource path by its filename
  Example:
  ```py
  >>> get_resource_path("pygame_icon.bmp") 
  'C:\\Users\\yunline\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\pygame_ce-2.4.0.dev3-py3.10-win-amd64.egg\\pygame\\pygame_icon.bmp'
  ```
- [x] Add `load_pygame_icon()` 
  Load the default pygame icon
- [x] Update C code and Python code to use `load_pygame_icon()`  and `get_resource_path()`
- [x] All these should work with pyinstaller