### PR TITLE
Attempt to make pygame.Rect() possible - DRAFT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ dist
 *.so
 __pycache__
 _headers/*
+
+# Damus666 @damusss
+
+Scripts/
+Lib/
+Include/

--- a/mytest.py
+++ b/mytest.py
@@ -1,0 +1,5 @@
+import pygame
+
+rect = pygame.Rect()
+
+print(rect)

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@
 
 import platform
 import sysconfig
+import os
 
 with open('README.rst', encoding='utf-8') as readme:
     LONG_DESCRIPTION = readme.read()

--- a/src_c/doc/rect_doc.h
+++ b/src_c/doc/rect_doc.h
@@ -1,5 +1,5 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
-#define DOC_RECT "Rect(left, top, width, height) -> Rect\nRect((left, top), (width, height)) -> Rect\nRect(object) -> Rect\nFRect(left, top, width, height) -> FRect\nFRect((left, top), (width, height)) -> FRect\nFRect(object) -> FRect\npygame object for storing rectangular coordinates"
+#define DOC_RECT "Rect(left, top, width, height) -> Rect\nRect((left, top), (width, height)) -> Rect\nRect(object) -> Rect\nRect() -> Rect\n FRect(left, top, width, height) -> FRect\nFRect((left, top), (width, height)) -> FRect\nFRect(object) -> FRect\nFRect() -> FRect()\npygame object for storing rectangular coordinates"
 #define DOC_RECT_COPY "copy() -> Rect\ncopy the rectangle"
 #define DOC_RECT_MOVE "move(x, y) -> Rect\nmoves the rectangle"
 #define DOC_RECT_MOVEIP "move_ip(x, y) -> None\nmoves the rectangle, in place"

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -613,6 +613,7 @@ int RectOptional_Freelist_Num = -1;
 static InnerRect *
 RectExport_RectFromObject(PyObject *obj, InnerRect *temp)
 {
+    printf("I AM RUNNING LITTLE BITCHHH\n");
     Py_ssize_t length;
 
     if (RectCheck(obj)) {
@@ -653,9 +654,15 @@ RectExport_RectFromObject(PyObject *obj, InnerRect *temp)
             // afaik the tuple  passed could be the args, so it would make pygame.Rect() possible?
             if (length == 1) {
                 return RectExport_RectFromObject(items[0], temp);
-            } else {
+            } else if (length == 0) {
+                printf("I am in PyTupleCheck UwU OwO\n");
+                temp->x = 0;
+                temp->y = 0;
+                temp->w = 0;
+                temp->h = 0;
                 return temp;
             }
+            return NULL;
         }
         else {
             return NULL;
@@ -727,8 +734,14 @@ RectExport_RectFromObject(PyObject *obj, InnerRect *temp)
         else if (length == 0) {
             // if the length of the sequence passed is 0 return temp? temp should be a 0,0,0,0 rect right?
             // afaik the sequence passed could be the args, so it would make pygame.Rect() possible?
+            printf("I am in PySequenceCheck OWOWOEUIWEUIW UwU OwO\n");
+            temp->x = 0;
+            temp->y = 0;
+            temp->w = 0;
+            temp->h = 0;
             return temp;
         }
+        return NULL;
     }
 
     /* Try to get the rect attribute */

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -613,7 +613,6 @@ int RectOptional_Freelist_Num = -1;
 static InnerRect *
 RectExport_RectFromObject(PyObject *obj, InnerRect *temp)
 {
-    printf("I AM RUNNING LITTLE BITCHHH\n");
     Py_ssize_t length;
 
     if (RectCheck(obj)) {
@@ -655,7 +654,6 @@ RectExport_RectFromObject(PyObject *obj, InnerRect *temp)
             if (length == 1) {
                 return RectExport_RectFromObject(items[0], temp);
             } else if (length == 0) {
-                printf("I am in PyTupleCheck UwU OwO\n");
                 temp->x = 0;
                 temp->y = 0;
                 temp->w = 0;
@@ -734,7 +732,6 @@ RectExport_RectFromObject(PyObject *obj, InnerRect *temp)
         else if (length == 0) {
             // if the length of the sequence passed is 0 return temp? temp should be a 0,0,0,0 rect right?
             // afaik the sequence passed could be the args, so it would make pygame.Rect() possible?
-            printf("I am in PySequenceCheck OWOWOEUIWEUIW UwU OwO\n");
             temp->x = 0;
             temp->y = 0;
             temp->w = 0;

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -648,8 +648,14 @@ RectExport_RectFromObject(PyObject *obj, InnerRect *temp)
             }
             return temp;
         }
-        else if (PyTuple_Check(obj) && length == 1) {
-            return RectExport_RectFromObject(items[0], temp);
+        else if (PyTuple_Check(obj)) {
+            // If this is a tuple and the legth is 0, return temp? temp should be a 0,0,0,0 rect right?
+            // afaik the tuple  passed could be the args, so it would make pygame.Rect() possible?
+            if (length == 1) {
+                return RectExport_RectFromObject(items[0], temp);
+            } else {
+                return temp;
+            }
         }
         else {
             return NULL;
@@ -717,6 +723,11 @@ RectExport_RectFromObject(PyObject *obj, InnerRect *temp)
             }
             InnerRect *returnrect = RectExport_RectFromObject(item, temp);
             return returnrect;
+        }
+        else if (length == 0) {
+            // if the length of the sequence passed is 0 return temp? temp should be a 0,0,0,0 rect right?
+            // afaik the sequence passed could be the args, so it would make pygame.Rect() possible?
+            return temp;
         }
     }
 

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -30,6 +30,13 @@ class RectTypeTest(unittest.TestCase):
         self.assertEqual(3, r.width)
         self.assertEqual(4, r.height)
 
+    def testConstructionNoArgs(self):
+        r = Rect()
+        self.assertEqual(0, r.left)
+        self.assertEqual(0, r.top)
+        self.assertEqual(0, r.width)
+        self.assertEqual(0, r.height)
+
     def testCalculatedAttributes(self):
         r = Rect(1, 2, 3, 4)
 


### PR DESCRIPTION
The reason I'm making a draft PR is because I'm having issues with setting up a local environment, in particular with the vsvarsal.bat file. If anyone reading this want to help, I'm on the dc pygame-ce server as Damus666 (@damusss).
Making the PR should technically give me compilation and run the py tests automatically.

There are a few reasons why I think pygame.Rect() should be a thing:
- Less code, faster to type. Typing pygame.Rect(0,0,0,0) is different than pygame.Rect()
- Cleaner code. pygame.Rect() is a lot cleaner than the other version
- Consistency. If pygame.Vector2() exists, not forced to type pygame.Vector2(0,0), why shouldn't pygame.Rect() be a thing?

Where could you need to make an empty rect?
- When you want to make a rect and assign positions using the attributes
- When you need a rect you want to assign the properties of later

I've never edited the C source code in a PR (except for some PyObject *_null arguments, which i couldn't really mess up) so i could mess up a lot of things, reviews are welcome.