### PR TITLE
Fix setDaemon() deprecation error

### DIFF
--- a/src_py/threads/__init__.py
+++ b/src_py/threads/__init__.py
@@ -140,7 +140,7 @@ class WorkerQueue:
             self.pool.append(Thread(target=self.threadloop))
 
         for a_thread in self.pool:
-            a_thread.setDaemon(True)
+            a_thread.daemon = True
             a_thread.start()
 
     def do(self, f, *args, **kwArgs):


### PR DESCRIPTION
Deprecated in Python 3.10.

`.daemon` is not a new attribute replacing `.setDaemon()` it is just now being put forth as the **only** way to set this attribute.