### PR TITLE
Add `Window.mouse_rect`

### DIFF
--- a/buildconfig/stubs/pygame/_window.pyi
+++ b/buildconfig/stubs/pygame/_window.pyi
@@ -1,7 +1,8 @@
 from typing import Optional, Tuple, Union, final
 
-from pygame._common import Coordinate
+from pygame._common import Coordinate, RectValue
 from pygame.locals import WINDOWPOS_UNDEFINED
+from pygame.rect import Rect
 from pygame.surface import Surface
 
 def get_grabbed_window() -> Optional[Window]: ...
@@ -43,6 +44,10 @@ class Window:
     def id(self) -> int: ...
     @property
     def display_index(self) -> int: ...
+    @property
+    def mouse_rect(self) -> Optional[Rect]: ...
+    @mouse_rect.setter
+    def mouse_rect(self, value: Optional[RectValue]) -> None: ...
     @property
     def size(self) -> Tuple[int, int]: ...
     @size.setter

--- a/docs/reST/ref/sdl2_video.rst
+++ b/docs/reST/ref/sdl2_video.rst
@@ -240,7 +240,7 @@
       Setting this attribute to a :class:`pygame.Rect` to confine the
       cursor to the specified area of this window.
 
-      This attribute can be None, representing there is no mouse rect.
+      This attribute can be None, meaning that there is no mouse rect.
       
       Note that this does NOT grab the cursor, it only defines the area a
       cursor is restricted to when the window has mouse focus.

--- a/docs/reST/ref/sdl2_video.rst
+++ b/docs/reST/ref/sdl2_video.rst
@@ -237,7 +237,7 @@
       | :sl:`Get or set the mouse confinement rectangle of the window`
       | :sg:`mouse_rect -> Rect|None`
 
-      Setting this attribute to a :class:`pygame.Rect` to confine the
+      Setting this attribute to a rect-like object confines the
       cursor to the specified area of this window.
 
       This attribute can be None, meaning that there is no mouse rect.

--- a/docs/reST/ref/sdl2_video.rst
+++ b/docs/reST/ref/sdl2_video.rst
@@ -231,6 +231,21 @@
 
       | :sl:`Get the unique window ID (**read-only**)`
       | :sg:`id -> int`
+   
+   .. attribute:: mouse_rect
+
+      | :sl:`Get or set the mouse confinement rectangle of the window`
+      | :sg:`mouse_rect -> Rect|None`
+
+      Setting this attribute to a :class:`pygame.Rect` to confine the
+      cursor to the specified area of this window.
+
+      This attribute can be None, representing there is no mouse rect.
+      
+      Note that this does NOT grab the cursor, it only defines the area a
+      cursor is restricted to when the window has mouse focus.
+
+      .. versionadded:: 2.4.0
 
    .. attribute:: size
 

--- a/src_c/doc/sdl2_video_doc.h
+++ b/src_c/doc/sdl2_video_doc.h
@@ -15,6 +15,7 @@
 #define DOC_SDL2_VIDEO_WINDOW_BORDERLESS "borderless -> bool\nGet or set whether the window is borderless"
 #define DOC_SDL2_VIDEO_WINDOW_ALWAYSONTOP "always_on_top -> bool\nGet or set whether the window is always on top"
 #define DOC_SDL2_VIDEO_WINDOW_ID "id -> int\nGet the unique window ID (**read-only**)"
+#define DOC_SDL2_VIDEO_WINDOW_MOUSERECT "mouse_rect -> Rect|None\nGet or set the mouse confinement rectangle of the window"
 #define DOC_SDL2_VIDEO_WINDOW_SIZE "size -> (int, int)\nGet or set the window size in pixels"
 #define DOC_SDL2_VIDEO_WINDOW_MINIMUMSIZE "minimum_size -> (int, int)\nGet or set the minimum size of the window's client area"
 #define DOC_SDL2_VIDEO_WINDOW_MAXIMUMSIZE "maximum_size -> (int, int)\nGet or set the maximum size of the window's client area"

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -448,10 +448,10 @@ window_get_mouse_rect(pgWindowObject *self, void *v)
 #else
     if (PyErr_WarnEx(PyExc_Warning,
                      "Getting 'mouse_rect' requires SDL 2.0.18+", 1) == -1) {
-        return -1;
+        return NULL;
     }
+    Py_RETURN_NONE;
 #endif  // SDL_VERSION_ATLEAST(2, 0, 18)
-    return 0;
 }
 
 static int

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -414,6 +414,47 @@ window_get_window_id(pgWindowObject *self, PyObject *_null)
 }
 
 static int
+window_set_mouse_rect(pgWindowObject *self, PyObject *arg, void *v)
+{
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+    SDL_Rect tmp_rect;
+    SDL_Rect *mouse_rect_p = pgRect_FromObject(arg, &tmp_rect);
+    if (mouse_rect_p == NULL && arg != Py_None) {
+        PyErr_SetString(PyExc_TypeError,
+                        "mouse_rect should be a Rect-like object or None");
+        return -1;
+    }
+    if (SDL_SetWindowMouseRect(self->_win, mouse_rect_p) < 0) {
+        PyErr_SetString(pgExc_SDLError, SDL_GetError());
+        return -1;
+    }
+#else
+    if (PyErr_WarnEx(PyExc_Warning,
+                     "Setting 'mouse_rect' requires SDL 2.0.18+", 1) == -1) {
+        return -1;
+    }
+#endif  // SDL_VERSION_ATLEAST(2, 0, 18)
+    return 0;
+}
+
+static PyObject *
+window_get_mouse_rect(pgWindowObject *self, void *v)
+{
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+    const SDL_Rect *mouse_rect_p = SDL_GetWindowMouseRect(self->_win);
+    if (mouse_rect_p == NULL)
+        Py_RETURN_NONE;
+    return pgRect_New((SDL_Rect *)mouse_rect_p);
+#else
+    if (PyErr_WarnEx(PyExc_Warning,
+                     "Getting 'mouse_rect' requires SDL 2.0.18+", 1) == -1) {
+        return -1;
+    }
+#endif  // SDL_VERSION_ATLEAST(2, 0, 18)
+    return 0;
+}
+
+static int
 window_set_size(pgWindowObject *self, PyObject *arg, void *v)
 {
     int w, h;
@@ -935,6 +976,8 @@ static PyGetSetDef _window_getset[] = {
     {"relative_mouse", (getter)mouse_get_relative_mode,
      (setter)mouse_set_relative_mode, DOC_SDL2_VIDEO_WINDOW_RELATIVEMOUSE,
      NULL},
+    {"mouse_rect", (getter)window_get_mouse_rect,
+     (setter)window_set_mouse_rect, DOC_SDL2_VIDEO_WINDOW_MOUSERECT, NULL},
     {"size", (getter)window_get_size, (setter)window_set_size,
      DOC_SDL2_VIDEO_WINDOW_SIZE, NULL},
     {"minimum_size", (getter)window_get_minimum_size,

--- a/test/window_test.py
+++ b/test/window_test.py
@@ -104,6 +104,26 @@ class WindowTypeTest(unittest.TestCase):
         self.win.always_on_top = False
         self.assertFalse(self.win.always_on_top)
 
+    @unittest.skipIf(
+        SDL < (2, 0, 18),
+        "requires SDL 2.0.18+",
+    )
+    def test_mouse_rect(self):
+        self.win.mouse_rect = None
+        self.assertIsNone(self.win.mouse_rect)
+
+        TEST_MOUSE_RECT = (10, 10, 123, 456)
+        self.win.mouse_rect = TEST_MOUSE_RECT
+        self.assertIsInstance(self.win.mouse_rect, pygame.Rect)
+        self.assertTupleEqual(tuple(self.win.mouse_rect), TEST_MOUSE_RECT)
+
+        self.assertRaises(
+            TypeError, lambda: setattr(self.win, "mouse_rect", "Incorrect type")
+        )
+
+        # clean the status
+        self.win.mouse_rect = None
+
     def test_size(self):
         self.win.size = (1280, 720)
         self.assertTupleEqual(self.win.size, (1280, 720))


### PR DESCRIPTION
```py
import pygame
from pygame._sdl2 import video

screen = pygame.display.set_mode((640, 480))

win = video.Window.from_display_module()

MOUSE_RECT = (100, 100, 300, 200)
mouse_rect_color = "green"

mouse_restricted = False


def toggle_restricted():
    global mouse_restricted, mouse_rect_color
    mouse_restricted = not mouse_restricted
    if mouse_restricted:
        mouse_rect_color = "red"
        win.mouse_rect = MOUSE_RECT
    else:
        mouse_rect_color = "green"
        win.mouse_rect = None
    print(f"mouse rect: {win.mouse_rect}")


print("Press space key to enable/disable mouse rect")

clock = pygame.time.Clock()
running = True
while running:
    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            running = False
        elif event.type == pygame.KEYDOWN and event.key == pygame.K_SPACE:
            toggle_restricted()

    screen.fill("black")
    pygame.draw.rect(screen, mouse_rect_color, MOUSE_RECT, width=1)
    pygame.display.flip()
    clock.tick(30)
```