### PR TITLE
Added missing AVX2 fillers

### DIFF
--- a/src_c/simd_fill.h
+++ b/src_c/simd_fill.h
@@ -11,3 +11,27 @@ surface_fill_blend_add_avx2(SDL_Surface *surface, SDL_Rect *rect,
 int
 surface_fill_blend_rgba_add_avx2(SDL_Surface *surface, SDL_Rect *rect,
                                  Uint32 color);
+int
+surface_fill_blend_sub_avx2(SDL_Surface *surface, SDL_Rect *rect,
+                            Uint32 color);
+int
+surface_fill_blend_rgba_sub_avx2(SDL_Surface *surface, SDL_Rect *rect,
+                                 Uint32 color);
+int
+surface_fill_blend_mult_avx2(SDL_Surface *surface, SDL_Rect *rect,
+                             Uint32 color);
+int
+surface_fill_blend_rgba_mult_avx2(SDL_Surface *surface, SDL_Rect *rect,
+                                  Uint32 color);
+int
+surface_fill_blend_min_avx2(SDL_Surface *surface, SDL_Rect *rect,
+                            Uint32 color);
+int
+surface_fill_blend_rgba_min_avx2(SDL_Surface *surface, SDL_Rect *rect,
+                                 Uint32 color);
+int
+surface_fill_blend_max_avx2(SDL_Surface *surface, SDL_Rect *rect,
+                            Uint32 color);
+int
+surface_fill_blend_rgba_max_avx2(SDL_Surface *surface, SDL_Rect *rect,
+                                 Uint32 color);

--- a/src_c/simd_surface_fill_avx2.c
+++ b/src_c/simd_surface_fill_avx2.c
@@ -84,38 +84,116 @@ _pg_has_avx2()
         pixels += skip;                                             \
     }
 
+/* Setup for RUN_16BIT_SHUFFLE_OUT */
+#define SETUP_SHUFFLE                                                         \
+    __m256i shuff_out_A =                                                     \
+        _mm256_set_epi8(0x80, 23, 0x80, 22, 0x80, 21, 0x80, 20, 0x80, 19,     \
+                        0x80, 18, 0x80, 17, 0x80, 16, 0x80, 7, 0x80, 6, 0x80, \
+                        5, 0x80, 4, 0x80, 3, 0x80, 2, 0x80, 1, 0x80, 0);      \
+                                                                              \
+    __m256i shuff_out_B = _mm256_set_epi8(                                    \
+        0x80, 31, 0x80, 30, 0x80, 29, 0x80, 28, 0x80, 27, 0x80, 26, 0x80, 25, \
+        0x80, 24, 0x80, 15, 0x80, 14, 0x80, 13, 0x80, 12, 0x80, 11, 0x80, 10, \
+        0x80, 9, 0x80, 8);                                                    \
+                                                                              \
+    __m256i shuff_dst, _shuff16_temp, mm256_colorA, mm256_colorB;             \
+    mm256_colorA = _mm256_shuffle_epi8(mm256_color, shuff_out_A);             \
+    mm256_colorB = _mm256_shuffle_epi8(mm256_color, shuff_out_B);
+
+#define RUN_16BIT_SHUFFLE_OUT(FILL_CODE)                       \
+    /* ==== shuffle pixels out into two registers each, src */ \
+    /* and dst set up for 16 bit math, like 0A0R0G0B ==== */   \
+    shuff_dst = _mm256_shuffle_epi8(mm256_dst, shuff_out_A);   \
+    mm256_color = mm256_colorA;                                \
+                                                               \
+    {FILL_CODE}                                                \
+                                                               \
+    _shuff16_temp = shuff_dst;                                 \
+                                                               \
+    shuff_dst = _mm256_shuffle_epi8(mm256_dst, shuff_out_B);   \
+    mm256_color = mm256_colorB;                                \
+                                                               \
+    {FILL_CODE}                                                \
+                                                               \
+    /* ==== recombine A and B pixels ==== */                   \
+    mm256_dst = _mm256_packus_epi16(_shuff16_temp, shuff_dst);
+
+#define FILLERS(NAME, COLOR_PROCESS_CODE, FILL_CODE)                        \
+    int surface_fill_blend_##NAME##_avx2(SDL_Surface *surface,              \
+                                         SDL_Rect *rect, Uint32 color)      \
+    {                                                                       \
+        SETUP_AVX2_FILLER(COLOR_PROCESS_CODE)                               \
+        RUN_AVX2_FILLER(FILL_CODE)                                          \
+        return 0;                                                           \
+    }                                                                       \
+    int surface_fill_blend_rgba_##NAME##_avx2(SDL_Surface *surface,         \
+                                              SDL_Rect *rect, Uint32 color) \
+    {                                                                       \
+        SETUP_AVX2_FILLER({})                                               \
+        RUN_AVX2_FILLER(FILL_CODE)                                          \
+        return 0;                                                           \
+    }
+
+#define FILLERS_SHUFF(NAME, COLOR_PROCESS_CODE, FILL_CODE)                  \
+    int surface_fill_blend_##NAME##_avx2(SDL_Surface *surface,              \
+                                         SDL_Rect *rect, Uint32 color)      \
+    {                                                                       \
+        SETUP_AVX2_FILLER(COLOR_PROCESS_CODE)                               \
+        SETUP_SHUFFLE                                                       \
+        RUN_AVX2_FILLER(RUN_16BIT_SHUFFLE_OUT(FILL_CODE))                   \
+        return 0;                                                           \
+    }                                                                       \
+    int surface_fill_blend_rgba_##NAME##_avx2(SDL_Surface *surface,         \
+                                              SDL_Rect *rect, Uint32 color) \
+    {                                                                       \
+        SETUP_AVX2_FILLER({})                                               \
+        SETUP_SHUFFLE                                                       \
+        RUN_AVX2_FILLER(RUN_16BIT_SHUFFLE_OUT(FILL_CODE))                   \
+        return 0;                                                           \
+    }
+
+#define INVALID_DEFS(NAME)                                                  \
+    int surface_fill_blend_##NAME##_avx2(SDL_Surface *surface,              \
+                                         SDL_Rect *rect, Uint32 color)      \
+    {                                                                       \
+        BAD_AVX2_FUNCTION_CALL;                                             \
+        return -1;                                                          \
+    }                                                                       \
+    int surface_fill_blend_rgba_##NAME##_avx2(SDL_Surface *surface,         \
+                                              SDL_Rect *rect, Uint32 color) \
+    {                                                                       \
+        BAD_AVX2_FUNCTION_CALL;                                             \
+        return -1;                                                          \
+    }
+
+#define ADD_CODE mm256_dst = _mm256_adds_epu8(mm256_dst, mm256_color);
+#define SUB_CODE mm256_dst = _mm256_subs_epu8(mm256_dst, mm256_color);
+#define MIN_CODE mm256_dst = _mm256_min_epu8(mm256_dst, mm256_color);
+#define MAX_CODE mm256_dst = _mm256_max_epu8(mm256_dst, mm256_color);
+#define MULT_CODE                                               \
+    {                                                           \
+        shuff_dst = _mm256_mullo_epi16(shuff_dst, mm256_color); \
+        shuff_dst = _mm256_srli_epi16(shuff_dst, 8);            \
+    }
+
 #if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
     !defined(SDL_DISABLE_IMMINTRIN_H)
-int
-surface_fill_blend_add_avx2(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
-{
-    SETUP_AVX2_FILLER({ color &= ~amask; })
-    RUN_AVX2_FILLER({ mm256_dst = _mm256_adds_epu8(mm256_dst, mm256_color); });
-    return 0;
-}
-
-int
-surface_fill_blend_rgba_add_avx2(SDL_Surface *surface, SDL_Rect *rect,
-                                 Uint32 color)
-{
-    SETUP_AVX2_FILLER({})
-    RUN_AVX2_FILLER({ mm256_dst = _mm256_adds_epu8(mm256_dst, mm256_color); });
-    return 0;
-}
+FILLERS(add, color &= ~amask;, ADD_CODE)
+FILLERS(sub, color &= ~amask;, SUB_CODE)
+FILLERS(min, color &= ~amask;, MIN_CODE)
+FILLERS(max, color &= ~amask;, MAX_CODE)
+FILLERS_SHUFF(
+    mult,
+    {
+        color &= ~amask;               /* clear the alpha channel */
+        color |= (0x01010101 & amask); /* set the alpha channel to 1 */
+    },
+    MULT_CODE)
 #else
-int
-surface_fill_blend_add_avx2(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
-{
-    BAD_AVX2_FUNCTION_CALL;
-    return -1;
-}
-
-int
-surface_fill_blend_rgba_add_avx2(SDL_Surface *surface, SDL_Rect *rect,
-                                 Uint32 color)
-{
-    BAD_AVX2_FUNCTION_CALL;
-    return -1;
-}
+INVALID_DEFS(add)
+INVALID_DEFS(sub)
+INVALID_DEFS(min)
+INVALID_DEFS(max)
+INVALID_DEFS(mult)
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
  !defined(SDL_DISABLE_IMMINTRIN_H) */

--- a/src_c/simd_surface_fill_avx2.c
+++ b/src_c/simd_surface_fill_avx2.c
@@ -170,25 +170,20 @@ _pg_has_avx2()
 #define SUB_CODE mm256_dst = _mm256_subs_epu8(mm256_dst, mm256_color);
 #define MIN_CODE mm256_dst = _mm256_min_epu8(mm256_dst, mm256_color);
 #define MAX_CODE mm256_dst = _mm256_max_epu8(mm256_dst, mm256_color);
-#define MULT_CODE                                               \
-    {                                                           \
-        shuff_dst = _mm256_mullo_epi16(shuff_dst, mm256_color); \
-        shuff_dst = _mm256_srli_epi16(shuff_dst, 8);            \
+#define MULT_CODE                                                         \
+    {                                                                     \
+        shuff_dst = _mm256_mullo_epi16(shuff_dst, mm256_color);           \
+        shuff_dst = _mm256_adds_epu16(shuff_dst, _mm256_set1_epi16(255)); \
+        shuff_dst = _mm256_srli_epi16(shuff_dst, 8);                      \
     }
 
 #if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
     !defined(SDL_DISABLE_IMMINTRIN_H)
 FILLERS(add, color &= ~amask;, ADD_CODE)
 FILLERS(sub, color &= ~amask;, SUB_CODE)
-FILLERS(min, color &= ~amask;, MIN_CODE)
+FILLERS(min, color |= amask;, MIN_CODE)
 FILLERS(max, color &= ~amask;, MAX_CODE)
-FILLERS_SHUFF(
-    mult,
-    {
-        color &= ~amask;               /* clear the alpha channel */
-        color |= (0x01010101 & amask); /* set the alpha channel to 1 */
-    },
-    MULT_CODE)
+FILLERS_SHUFF(mult, color |= amask;, MULT_CODE)
 #else
 INVALID_DEFS(add)
 INVALID_DEFS(sub)

--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -879,18 +879,50 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
             break;
         }
         case PYGAME_BLEND_SUB: {
+#if !defined(__EMSCRIPTEN__)
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+            if (surface->format->BytesPerPixel == 4 && _pg_has_avx2()) {
+                result = surface_fill_blend_sub_avx2(surface, rect, color);
+                break;
+            }
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
+#endif /* __EMSCRIPTEN__ */
             result = surface_fill_blend_sub(surface, rect, color);
             break;
         }
         case PYGAME_BLEND_MULT: {
+#if !defined(__EMSCRIPTEN__)
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+            if (surface->format->BytesPerPixel == 4 && _pg_has_avx2()) {
+                result = surface_fill_blend_mult_avx2(surface, rect, color);
+                break;
+            }
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
+#endif /* __EMSCRIPTEN__ */
             result = surface_fill_blend_mult(surface, rect, color);
             break;
         }
         case PYGAME_BLEND_MIN: {
+#if !defined(__EMSCRIPTEN__)
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+            if (surface->format->BytesPerPixel == 4 && _pg_has_avx2()) {
+                result = surface_fill_blend_min_avx2(surface, rect, color);
+                break;
+            }
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
+#endif /* __EMSCRIPTEN__ */
             result = surface_fill_blend_min(surface, rect, color);
             break;
         }
         case PYGAME_BLEND_MAX: {
+#if !defined(__EMSCRIPTEN__)
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+            if (surface->format->BytesPerPixel == 4 && _pg_has_avx2()) {
+                result = surface_fill_blend_max_avx2(surface, rect, color);
+                break;
+            }
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
+#endif /* __EMSCRIPTEN__ */
             result = surface_fill_blend_max(surface, rect, color);
             break;
         }
@@ -909,18 +941,54 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
             break;
         }
         case PYGAME_BLEND_RGBA_SUB: {
+#if !defined(__EMSCRIPTEN__)
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+            if (surface->format->BytesPerPixel == 4 && _pg_has_avx2()) {
+                result =
+                    surface_fill_blend_rgba_sub_avx2(surface, rect, color);
+                break;
+            }
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
+#endif /* __EMSCRIPTEN__ */
             result = surface_fill_blend_rgba_sub(surface, rect, color);
             break;
         }
         case PYGAME_BLEND_RGBA_MULT: {
+#if !defined(__EMSCRIPTEN__)
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+            if (surface->format->BytesPerPixel == 4 && _pg_has_avx2()) {
+                result =
+                    surface_fill_blend_rgba_mult_avx2(surface, rect, color);
+                break;
+            }
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
+#endif /* __EMSCRIPTEN__ */
             result = surface_fill_blend_rgba_mult(surface, rect, color);
             break;
         }
         case PYGAME_BLEND_RGBA_MIN: {
+#if !defined(__EMSCRIPTEN__)
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+            if (surface->format->BytesPerPixel == 4 && _pg_has_avx2()) {
+                result =
+                    surface_fill_blend_rgba_min_avx2(surface, rect, color);
+                break;
+            }
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
+#endif /* __EMSCRIPTEN__ */
             result = surface_fill_blend_rgba_min(surface, rect, color);
             break;
         }
         case PYGAME_BLEND_RGBA_MAX: {
+#if !defined(__EMSCRIPTEN__)
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+            if (surface->format->BytesPerPixel == 4 && _pg_has_avx2()) {
+                result =
+                    surface_fill_blend_rgba_max_avx2(surface, rect, color);
+                break;
+            }
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
+#endif /* __EMSCRIPTEN__ */
             result = surface_fill_blend_rgba_max(surface, rect, color);
             break;
         }


### PR DESCRIPTION
This PR is a continuation of #2382 and adds the `SUB`, `MIN`, `MAX`, and `MULT` blend flags. this should be a 70X to 110X perf improvement over the current fillers with blend flags and is 35% faster than caching a surface with a color and blitting (with AVX2).

Results and test program:
**ON MAIN**
```
Flag: BLEND_SUB
fill: 1.8767017999998643
blit: 0.021530719999827853
--------------------
Flag: BLEND_MULT
fill: 1.7614726199999495
blit: 0.03417129999997996
--------------------
Flag: BLEND_MIN
fill: 1.82431628000013
blit: 0.02125239999986661
--------------------
Flag: BLEND_MAX
fill: 1.872223340000346
blit: 0.021590140000080284
--------------------
```

**WITH THIS PR**
```
Flag: BLEND_SUB
fill: 0.01598090000006778
blit: 0.021626579999974638
--------------------
Flag: BLEND_MULT
fill: 0.024974719999954688
blit: 0.03429605999972409
--------------------
Flag: BLEND_MIN
fill: 0.01568092000015895
blit: 0.021365460000197345
--------------------
Flag: BLEND_MAX
fill: 0.015678200000002106
blit: 0.021505839999917953
--------------------
```

**Test Program**
```Py
from timeit import repeat

import pygame

pygame.init()

surf = pygame.Surface((500, 500))
surf.fill((132, 33, 200))

color = pygame.Surface((500, 500))
color.fill((24, 24, 24))

flags = [
    "BLEND_SUB",
    "BLEND_MULT",
    "BLEND_MIN",
    "BLEND_MAX",
]

G = globals()

for flag in flags:
    print(f"Flag: {flag}")
    teststr = "surf.fill((24, 24, 24), None, pygame." + flag + ")"
    l = [min(repeat(teststr, globals=G, number=1000, repeat=10)) for _ in range(5)]
    print(f"fill: {sum(l) / len(l)}")

    teststr = "surf.blit(color, (0, 0), None, pygame." + flag + ")"
    l = [min(repeat(teststr, globals=G, number=1000, repeat=10)) for _ in range(5)]
    print(f"blit: {sum(l) / len(l)}")
    print("-" * 20)
```