### PR TITLE
Fix compiler warnings in event, camera and display

### DIFF
--- a/src_c/camera.h
+++ b/src_c/camera.h
@@ -58,18 +58,25 @@
 #include <mftransform.h>
 #endif
 
+#ifndef v4l2_fourcc
+/* Four-character-code (FOURCC), taken from v4l source */
+#define v4l2_fourcc(a, b, c, d)                               \
+    ((Uint32)(a) | ((Uint32)(b) << 8) | ((Uint32)(c) << 16) | \
+     ((Uint32)(d) << 24))
+#endif
+
 /* some constants used which are not defined on non-v4l machines. */
 #ifndef V4L2_PIX_FMT_RGB24
-#define V4L2_PIX_FMT_RGB24 'RGB3'
+#define V4L2_PIX_FMT_RGB24 v4l2_fourcc('R', 'G', 'B', '3')
 #endif
 #ifndef V4L2_PIX_FMT_RGB444
-#define V4L2_PIX_FMT_RGB444 'R444'
+#define V4L2_PIX_FMT_RGB444 v4l2_fourcc('R', '4', '4', '4')
 #endif
 #ifndef V4L2_PIX_FMT_YUYV
-#define V4L2_PIX_FMT_YUYV 'YUYV'
+#define V4L2_PIX_FMT_YUYV v4l2_fourcc('Y', 'U', 'Y', 'V')
 #endif
 #ifndef V4L2_PIX_FMT_XBGR32
-#define V4L2_PIX_FMT_XBGR32 'XR24'
+#define V4L2_PIX_FMT_XBGR32 v4l2_fourcc('X', 'R', '2', '4')
 #endif
 
 #define CLEAR(x) memset(&(x), 0, sizeof(x))

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -859,7 +859,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
     int w, h;
     PyObject *size = NULL;
     int vsync = SDL_FALSE;
-    uint64_t hwnd = 0;
+    intptr_t hwnd = 0;
     /* display will get overwritten by ParseTupleAndKeywords only if display
        parameter is given. By default, put the new window on the same
        screen as the old one */
@@ -880,7 +880,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
         return NULL;
 
     if (hwnd == 0 && winid_env != NULL) {
-        hwnd = SDL_strtoull(winid_env, NULL, 0);
+        hwnd = (intptr_t)SDL_strtoull(winid_env, NULL, 0);
     }
 
     if (scale_env != NULL) {

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -275,7 +275,9 @@ _pg_put_event_unicode(SDL_Event *event, char *uni)
 static PyObject *
 _pg_get_event_unicode(SDL_Event *event)
 {
-    char c;
+    /* We only deal with one byte here, but still declare an array to silence
+     * compiler warnings. The other 3 bytes are unused */
+    char c[4];
     int i;
     for (i = 0; i < MAX_SCAN_UNICODE; i++) {
         if (scanunicode[i].key == event->key.keysym.scancode) {
@@ -289,8 +291,8 @@ _pg_get_event_unicode(SDL_Event *event)
     }
     /* fallback to function that determines unicode from the event.
      * We try to get the unicode attribute, and store it in memory*/
-    c = _pg_unicode_from_event(event);
-    if (_pg_put_event_unicode(event, &c))
+    *c = _pg_unicode_from_event(event);
+    if (_pg_put_event_unicode(event, c))
         return _pg_get_event_unicode(event);
     return PyUnicode_FromString("");
 }


### PR DESCRIPTION
These warnings were caught on my meson buildconfig branch. For some reason, the current buildconfig code does not actually `-Werror` on linux builds (where these warnings are reported)
