### PR TITLE
Support collide_mask as collided argument in spritecollide

### DIFF
--- a/buildconfig/stubs/pygame/sprite.pyi
+++ b/buildconfig/stubs/pygame/sprite.pyi
@@ -273,11 +273,11 @@ def collide_mask(
     left: _SupportsCollideMask, right: _SupportsCollideMask
 ) -> Optional[Tuple[int, int]]: ...
 def spritecollide(
-    sprite: _TSprite,
-    group: AbstractGroup[_TSprite2],
+    sprite: _HasRect,
+    group: AbstractGroup[_TSprite],
     dokill: bool,
     collided: Optional[Callable[[_TSprite, _TSprite2], Any]] = None,
-) -> List[_TSprite2]: ...
+) -> List[_TSprite]: ...
 def groupcollide(
     groupa: AbstractGroup[_TSprite],
     groupb: AbstractGroup[_TSprite2],
@@ -286,7 +286,7 @@ def groupcollide(
     collided: Optional[Callable[[_TSprite, _TSprite2], Any]] = None,
 ) -> Dict[_TSprite, List[_TSprite2]]: ...
 def spritecollideany(
-    sprite: _TSprite,
-    group: AbstractGroup[_TSprite2],
+    sprite: _HasRect,
+    group: AbstractGroup[_TSprite],
     collided: Optional[Callable[[_TSprite, _TSprite2], Any]] = None,
-) -> Optional[_TSprite2]: ...
+) -> Optional[_TSprite]: ...

--- a/buildconfig/stubs/pygame/sprite.pyi
+++ b/buildconfig/stubs/pygame/sprite.pyi
@@ -276,23 +276,17 @@ def spritecollide(
     sprite: _TSprite,
     group: AbstractGroup[_TSprite2],
     dokill: bool,
-    collided: Optional[
-        Callable[[_TSprite, _TSprite2], bool | Optional[Tuple[int, int]]]
-    ] = None,
+    collided: Optional[Callable[[_TSprite, _TSprite2], Any]] = None,
 ) -> List[_TSprite2]: ...
 def groupcollide(
     groupa: AbstractGroup[_TSprite],
     groupb: AbstractGroup[_TSprite2],
     dokilla: bool,
     dokillb: bool,
-    collided: Optional[
-        Callable[[_TSprite, _TSprite2], bool | Optional[Tuple[int, int]]]
-    ] = None,
+    collided: Optional[Callable[[_TSprite, _TSprite2], Any]] = None,
 ) -> Dict[_TSprite, List[_TSprite2]]: ...
 def spritecollideany(
     sprite: _TSprite,
     group: AbstractGroup[_TSprite2],
-    collided: Optional[
-        Callable[[_TSprite, _TSprite2], bool | Optional[Tuple[int, int]]]
-    ] = None,
+    collided: Optional[Callable[[_TSprite, _TSprite2], Any]] = None,
 ) -> Optional[_TSprite2]: ...

--- a/buildconfig/stubs/pygame/sprite.pyi
+++ b/buildconfig/stubs/pygame/sprite.pyi
@@ -273,20 +273,26 @@ def collide_mask(
     left: _SupportsCollideMask, right: _SupportsCollideMask
 ) -> Optional[Tuple[int, int]]: ...
 def spritecollide(
-    sprite: _HasRect,
-    group: AbstractGroup[_TSprite],
+    sprite: _TSprite,
+    group: AbstractGroup[_TSprite2],
     dokill: bool,
-    collided: Optional[Callable[[_HasRect, _TSprite], bool]] = None,
-) -> List[_TSprite]: ...
+    collided: Optional[
+        Callable[[_TSprite, _TSprite2], bool | Optional[Tuple[int, int]]]
+    ] = None,
+) -> List[_TSprite2]: ...
 def groupcollide(
     groupa: AbstractGroup[_TSprite],
     groupb: AbstractGroup[_TSprite2],
     dokilla: bool,
     dokillb: bool,
-    collided: Optional[Callable[[_TSprite, _TSprite2], bool]] = None,
+    collided: Optional[
+        Callable[[_TSprite, _TSprite2], bool | Optional[Tuple[int, int]]]
+    ] = None,
 ) -> Dict[_TSprite, List[_TSprite2]]: ...
 def spritecollideany(
-    sprite: _HasRect,
-    group: AbstractGroup[_TSprite],
-    collided: Optional[Callable[[_HasRect, _TSprite], bool]] = None,
-) -> Optional[_TSprite]: ...
+    sprite: _TSprite,
+    group: AbstractGroup[_TSprite2],
+    collided: Optional[
+        Callable[[_TSprite, _TSprite2], bool | Optional[Tuple[int, int]]]
+    ] = None,
+) -> Optional[_TSprite2]: ...


### PR DESCRIPTION
This PR attempts to fix #2568 by making the type of the `collided` argument of `pygame.sprite.spritecollide`, `pygame.sprite.spritecollideany` and `pygame.sprite.groupcollide` more strict/precise.
It also adds the `pygame.sprite.collide_mask` return type as one of the possible return types besides a boolean.
