### PR TITLE
Compile windows _camera on MSVC only

### DIFF
--- a/src_c/camera.h
+++ b/src_c/camera.h
@@ -47,7 +47,7 @@
 #include <linux/videodev2.h>
 #endif
 
-#if defined(__WIN32__)
+#if defined(__WIN32__) && defined(_MSC_VER)
 #define PYGAME_WINDOWS_CAMERA 1
 
 #include <mfapi.h>

--- a/src_c/camera.h
+++ b/src_c/camera.h
@@ -47,6 +47,9 @@
 #include <linux/videodev2.h>
 #endif
 
+/* At the time of writing of this comment, _camera does not compile on windows
+ * while using the MinGW compiler (due to missing API). So we do a _MSC_VER
+ * check here to compile this only under the MSVC compiler */
 #if defined(__WIN32__) && defined(_MSC_VER)
 #define PYGAME_WINDOWS_CAMERA 1
 

--- a/src_c/camera_windows.c
+++ b/src_c/camera_windows.c
@@ -37,6 +37,8 @@
 #include "_camera.h"
 #include "pgcompat.h"
 
+#ifdef PYGAME_WINDOWS_CAMERA
+
 /*these are already included in camera.h, but having them here
  * makes all the types be recognized by VS code */
 #include <mfapi.h>
@@ -890,3 +892,5 @@ windows_read_raw(pgCameraObject *self)
     /* should this be an error instead? */
     Py_RETURN_NONE;
 }
+
+#endif /* PYGAME_WINDOWS_CAMERA */


### PR DESCRIPTION
The goal is to get pygame compiling on mingw (intended for pygame contributors on windows who would prefer it), and currently `_camera` is the only thing that doesn't compile under mingw. So take the easy route and not try to compile it (this shouldn't really affect anything, we should still be doing releases with MSVC)

@Starbuck5 requesting your review (oh and also, do you think we should also do a compiler version check, and if yes, to what?)