### PR TITLE
Make `font.metrics()` match docs for unrecognised characters

### DIFF
--- a/src_c/font.c
+++ b/src_c/font.c
@@ -881,11 +881,9 @@ font_metrics(PyObject *self, PyObject *textobj)
     for (i = 1 /* skip BOM */; i < length; i++) {
         ch = buffer[i];
         surrogate = Py_UNICODE_IS_SURROGATE(ch);
-        /* TODO:
-         * TTF_GlyphMetrics() seems to return a value for any character,
-         * using the default invalid character, if the char is not found.
-         */
-        if (!surrogate && /* conditional and */
+
+        if ((TTF_GlyphIsProvided(font, ch) != 0) &&
+            !surrogate && /* conditional and */
             !TTF_GlyphMetrics(font, (Uint16)ch, &minx, &maxx, &miny, &maxy,
                               &advance)) {
             listitem =

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -400,23 +400,8 @@ class FontTypeTest(unittest.TestCase):
         self.assertEqual(len(bm), 1)
         self.assertIsNone(bm[0])
 
-        return  # unfinished
-        # The documentation is useless here. How large a list?
-        # How do list positions relate to character codes?
-        # What about unicode characters?
-
-        # __doc__ (as of 2008-08-02) for pygame_font.Font.metrics:
-
-        # Font.metrics(text): return list
-        # Gets the metrics for each character in the passed string.
-        #
-        # The list contains tuples for each character, which contain the
-        # minimum X offset, the maximum X offset, the minimum Y offset, the
-        # maximum Y offset and the advance offset (bearing plus width) of the
-        # character. [(minx, maxx, miny, maxy, advance), (minx, maxx, miny,
-        # maxy, advance), ...]
-
-        self.fail()
+        unrecognized_char_metrics = f.metrics("経")
+        self.assertEqual(unrecognized_char_metrics[0], None)
 
     def test_render(self):
         f = pygame_font.Font(None, 20)


### PR DESCRIPTION
Currently the documentation for font.metrics() says:

> **metrics()**[¶](https://www.pygame.org/docs/ref/font.html#pygame.font.Font.metrics)
_gets the metrics for each character in the passed string_
`metrics(text) -> list`
The list contains tuples for each character, which contain the minimum X offset, the maximum X offset, the minimum Y offset, the maximum Y offset and the advance offset (bearing plus width) of the character. [(minx, maxx, miny, maxy, advance), (minx, maxx, miny, maxy, advance), ...]. **None is entered in the list for each unrecognized character.**

The last sentence bolded for emphasis. I take this to mean that if you pass it a character it cannot find in the font's database of glyphs it will return `None` for that character in the list giving a you a handy way to figure out if a font supports a given unicode character.

However, what actually happens at the minute is that it always returns metric information, including for unsupported glyphs.

In the code there is the following TODO:

> /* TODO:
         * TTF_GlyphMetrics() seems to return a value for any character,
         * using the default invalid character, if the char is not found.
         */

Which implies that this was intended to be fixed at some point, but nobody has done it.

Anyway this PR fixes the code to match the docs, which provides some useful utility.

**_HOWEVER_** - we may not actually want to fix this in this way, While it is hard to imagine much useful code depending on getting accurate glyph info for invalid characters, this is  change in behaviour.

Right now pygame will render whatever the font's fallback character is for an unsupported character when calling render, so if people are using glpyh metric to calculate the length of text lines containing invalid characters (despite the docs saying it won't work) then we would break that code.

So, we either fix this code to match the docs - as this PR does, **or** we fix the docs to match the current behaviour, and add a new API to font to test if characters are supported by the font as metrics purported to do.

Opinions welcome!