### PR TITLE
SDL_image 2.8.0

### DIFF
--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -62,7 +62,7 @@ jobs:
         sudo apt-mark hold grub-efi-amd64-signed
         sudo apt-get update --fix-missing
         sudo apt-get upgrade
-        sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev python3-setuptools python3-dev
+        sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev python3-setuptools python3-dev
         pip3 install sphinx"<7.2.0" numpy>=1.21.0
 
     - name: Make sdist and install it

--- a/buildconfig/Setup.Android.SDL2.in
+++ b/buildconfig/Setup.Android.SDL2.in
@@ -4,9 +4,7 @@ SDL = {sdl_includes} -D_REENTRANT -DSDL2 -lSDL2
 FONT = {sdl_ttf_includes} -lSDL2_ttf
 IMAGE = {sdl_image_includes} -lSDL2_image
 MIXER = {sdl_mixer_includes} -lSDL2_mixer
-JPEG = {jpeg_includes} -ljpeg
 SCRAP =
-PNG = {png_includes} -lpng16
 FREETYPE = {freetype_includes} -lfreetype -lharfbuzz
 
 DEBUG =
@@ -15,7 +13,7 @@ DEBUG =
 #everything you can, but you can ignore ones you don't have
 #dependencies for, just comment them out
 
-imageext src_c/imageext.c $(SDL) $(IMAGE) $(PNG) $(JPEG) $(DEBUG)
+imageext src_c/imageext.c $(SDL) $(IMAGE) $(DEBUG)
 font src_c/font.c $(SDL) $(FONT) $(DEBUG)
 mixer src_c/mixer.c $(SDL) $(MIXER) $(DEBUG)
 mixer_music src_c/music.c $(SDL) $(MIXER) $(DEBUG)

--- a/buildconfig/Setup.Emscripten.SDL2.in
+++ b/buildconfig/Setup.Emscripten.SDL2.in
@@ -4,9 +4,7 @@
 #FONT = -lSDL2_ttf
 #IMAGE = -lSDL2_image
 #MIXER = -lSDL2_mixer
-#JPEG = -ljpeg
 #SCRAP =
-#PNG = -lpng
 #FREETYPE = -lfreetype -lharfbuzz
 
 DEBUG =

--- a/buildconfig/Setup.SDL2.in
+++ b/buildconfig/Setup.SDL2.in
@@ -11,8 +11,6 @@ SDL = -I/usr/include -D_REENTRANT -DSDL2 -lSDL2
 FONT = -lSDL2_ttf
 IMAGE = -lSDL2_image
 MIXER = -lSDL2_mixer
-PNG = -lpng
-JPEG = -ljpeg
 SCRAP = -lX11
 PORTMIDI = -lportmidi
 PORTTIME = -lporttime
@@ -25,7 +23,7 @@ DEBUG =
 #everything you can, but you can ignore ones you don't have
 #dependencies for, just comment them out
 
-imageext src_c/imageext.c $(SDL) $(IMAGE) $(PNG) $(JPEG) $(DEBUG)
+imageext src_c/imageext.c $(SDL) $(IMAGE) $(DEBUG)
 font src_c/font.c $(SDL) $(FONT) $(DEBUG)
 mixer src_c/mixer.c $(SDL) $(MIXER) $(DEBUG)
 mixer_music src_c/music.c $(SDL) $(MIXER) $(DEBUG)

--- a/buildconfig/config_darwin.py
+++ b/buildconfig/config_darwin.py
@@ -130,8 +130,6 @@ def main(auto_config=False):
     ]
 
     DEPS.extend([
-        Dependency('PNG', 'png.h', 'libpng', ['png']),
-        Dependency('JPEG', 'jpeglib.h', 'libjpeg', ['jpeg']),
         Dependency('PORTMIDI', 'portmidi.h', 'libportmidi', ['portmidi']),
         Dependency('PORTTIME', 'porttime.h', '', []),
         find_freetype()

--- a/buildconfig/config_emsdk.py
+++ b/buildconfig/config_emsdk.py
@@ -33,7 +33,7 @@ EMCC_CFLAGS = os.environ.get("EMCC_CFLAGS", "")
 
 # user build, make sure ports are pulled in.
 if os.environ.get("SDK_VERSION", None) is None:
-    EMCC_CFLAGS += " -sUSE_SDL=2 -sUSE_LIBPNG -sUSE_LIBJPEG"
+    EMCC_CFLAGS += " -sUSE_SDL=2"
 else:
     # make sure CI only pick SDK components.
     SDKROOT = os.environ.get("SDKROOT", "/opt/python-wasm-sdk")
@@ -151,7 +151,7 @@ class Dependency:
             self.found = 1
         else:
 
-            if self.name in ["FONT", "IMAGE", "MIXER", "PNG", "JPEG", "FREETYPE"]:
+            if self.name in ["FONT", "IMAGE", "MIXER", "FREETYPE"]:
                 self.found = 1
                 print(
                     self.name
@@ -216,8 +216,6 @@ def main(auto_config=False):
     ]
     DEPS.extend(
         [
-            Dependency("PNG", "png.h", "libpng", ["png"]),
-            Dependency("JPEG", "jpeglib.h", "libjpeg", ["jpeg"]),
             # Dependency('SCRAP', '', 'libX11', ['X11']),
             # Dependency('GFX', 'SDL_gfxPrimitives.h', 'libSDL_gfx.a', ['SDL_gfx']),
         ]

--- a/buildconfig/config_unix.py
+++ b/buildconfig/config_unix.py
@@ -222,8 +222,6 @@ def main(auto_config=False):
         #Dependency('GFX', 'SDL_gfxPrimitives.h', 'libSDL2_gfx.so', ['SDL2_gfx']),
     ]
     DEPS.extend([
-        Dependency('PNG', 'png.h', 'libpng', ['png']),
-        Dependency('JPEG', 'jpeglib.h', 'libjpeg', ['jpeg']),
         Dependency('SCRAP', '', 'libX11', ['X11']),
         #Dependency('GFX', 'SDL_gfxPrimitives.h', 'libSDL_gfx.so', ['SDL_gfx']),
     ])

--- a/buildconfig/config_win.py
+++ b/buildconfig/config_win.py
@@ -363,9 +363,13 @@ def _add_sdl2_dll_deps(DEPS):
     DEPS.add_dll(r'(lib)?opus[-0-9]*\.dll$', 'opus', ['*opus-[0-9]*'])
     DEPS.add_dll(r'(lib)?opusfile[-0-9]*\.dll$', 'opusfile', ['*opusfile-[0-9]*'])
     # IMAGE
+    DEPS.add_dll(r'(lib)?jpeg[-0-9]*\.dll$', 'jpeg', ['*jpeg-[0-9]*'])
+    DEPS.add_dll(r'(png|libpng)[-0-9]*\.dll$', 'png', ['libpng-[1-9].*'], ['z'])
     DEPS.add_dll(r'(lib){0,1}tiff[-0-9]*\.dll$', 'tiff', ['tiff-[0-9]*'], ['jpeg', 'z'])
     DEPS.add_dll(r'(z|zlib1)\.dll$', 'z', ['zlib-[1-9].*'])
     DEPS.add_dll(r'(lib)?webp[-0-9]*\.dll$', 'webp', ['*webp-[0-9]*'])
+    DEPS.add_dll(r'(lib)?webpdemux[-0-9]*\.dll$', 'webpdemux', ['*webpdemux-[0-9]*'])
+    
 
 def setup():
     DEPS = DependencyGroup()
@@ -376,10 +380,6 @@ def setup():
     DEPS.add_placeholder('PORTTIME')
     DEPS.add('MIXER', 'SDL2_mixer', ['SDL2_mixer-[1-9].*'], r'(lib){0,1}SDL2_mixer\.dll$',
              ['SDL'])
-    DEPS.add('PNG', 'png', ['SDL2_image-[2-9].*', 'libpng-[1-9].*'], r'(png|libpng)[-0-9]*\.dll$', ['z'],
-             find_header=r'png\.h', find_lib=r'(lib)?png1[-0-9]*\.lib')
-    DEPS.add('JPEG', 'jpeg', ['SDL2_image-[2-9].*', 'jpeg-9*'], r'(lib){0,1}jpeg-9\.dll$',
-             find_header=r'jpeglib\.h', find_lib=r'(lib)?jpeg-9\.lib')
     DEPS.add('IMAGE', 'SDL2_image', ['SDL2_image-[1-9].*'], r'(lib){0,1}SDL2_image\.dll$',
              ['SDL', 'jpeg', 'png', 'tiff'], 0)
     DEPS.add('FONT', 'SDL2_ttf', ['SDL2_ttf-[2-9].*'], r'(lib){0,1}SDL2_ttf\.dll$', ['SDL', 'z', 'freetype'])
@@ -421,23 +421,13 @@ def setup_prebuilt_sdl2(prebuilt_dir):
     DEPS.add('FREETYPE', 'freetype', ['freetype'], r'freetype[-0-9]*\.dll$',
                      find_header=r'ft2build\.h', find_lib=r'freetype[-0-9]*\.lib')
 
-    png = DEPS.add('PNG', 'png', ['SDL2_image-[2-9].*', 'libpng-[1-9].*'], r'(png|libpng)[-0-9]*\.dll$', ['z'],
-                   find_header=r'png\.h', find_lib=r'(lib)?png1[-0-9]*\.lib')
-    png.path = imageDep.path
-    png.inc_dir = [os.path.join(prebuilt_dir, 'include').replace('\\', '/')]
-    png.found = True
-    jpeg = DEPS.add('JPEG', 'jpeg', ['SDL2_image-[2-9].*', 'jpeg-9*'], r'(lib){0,1}jpeg-9\.dll$',
-                   find_header=r'jpeglib\.h', find_lib=r'(lib)?jpeg-9\.lib')
-    jpeg.path = imageDep.path
-    jpeg.inc_dir = [os.path.join(prebuilt_dir, 'include').replace('\\', '/')]
-    jpeg.found = True
-
     dllPaths = {
         'png': imageDep.path,
         'jpeg': imageDep.path,
         'tiff': imageDep.path,
         'z': imageDep.path,
         'webp': imageDep.path,
+        'webpdemux': imageDep.path,
 
         'ogg': mixerDep.path,
         'modplug': mixerDep.path,

--- a/buildconfig/download_win_prebuilt.py
+++ b/buildconfig/download_win_prebuilt.py
@@ -82,8 +82,8 @@ def get_urls(x86=True, x64=True):
         '7469e9ea44d30a48b0510328cd94b25596e0aa0f',
         ],
         [
-        'https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.5-VC.zip',
-        '137f86474691f4e12e76e07d58d5920c8d844d5b',
+        'https://github.com/pygame-community/SDL_image/releases/download/2.8.0-pgce/SDL2_image-devel-2.8.0-VCpgce.zip',
+        'a576128c7c05aa4eee9b4f87ddbc488cce9bada6'
         ],
         [
         'https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.20.2/SDL2_ttf-devel-2.20.2-VC.zip',
@@ -201,12 +201,12 @@ def place_downloaded_prebuilts(temp_dir, move_to_dir, x86=True, x64=True):
         copy(
             os.path.join(
                 temp_dir,
-                'SDL2_image-devel-2.0.5-VC/SDL2_image-2.0.5'
+                'SDL2_image-devel-2.8.0-VCpgce/SDL2_image-2.8.0'
             ),
             os.path.join(
                 move_to_dir,
                 prebuilt_dir,
-                'SDL2_image-2.0.5'
+                'SDL2_image-2.8.0'
             )
         )
         copy(

--- a/buildconfig/download_win_prebuilt.py
+++ b/buildconfig/download_win_prebuilt.py
@@ -83,7 +83,7 @@ def get_urls(x86=True, x64=True):
         ],
         [
         'https://github.com/pygame-community/SDL_image/releases/download/2.8.0-pgce/SDL2_image-devel-2.8.0-VCpgce.zip',
-        'a576128c7c05aa4eee9b4f87ddbc488cce9bada6'
+        'da6b6a18f1c53baa775394e769059404925e98d7'
         ],
         [
         'https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.20.2/SDL2_ttf-devel-2.20.2-VC.zip',

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -40,10 +40,6 @@
 #undef HAVE_STDLIB_H
 #endif
 
-// PNG_SKIP_SETJMP_CHECK : non-regression on #662 (build error on old libpng)
-#define PNG_SKIP_SETJMP_CHECK
-#include <png.h>
-
 #include "pgcompat.h"
 
 #include "doc/image_doc.h"
@@ -65,15 +61,6 @@
 static SDL_mutex *_pg_img_mutex = 0;
 #endif
 */
-
-#ifdef WIN32
-#include <windows.h>
-#define pg_RWflush(rwops) \
-    (FlushFileBuffers((HANDLE)(rwops)->hidden.windowsio.h) ? 0 : -1)
-
-#else /* ~WIN32 */
-#define pg_RWflush(rwops) (fflush((rwops)->hidden.stdio.fp) ? -1 : 0)
-#endif /* ~WIN32 */
 
 static char *
 iext_find_extension(char *fullname)
@@ -150,187 +137,6 @@ image_load_ext(PyObject *self, PyObject *arg, PyObject *kwarg)
     return final;
 }
 
-/* This entire png saving code is directly copied from the SDL_image source
- * (with minor changes)
- * Eventually this should be removed, and we should start using the SDL_image
- * functions directly */
-#ifdef PNG_H
-
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN
-static const Uint32 png_format = SDL_PIXELFORMAT_ABGR8888;
-#else
-static const Uint32 png_format = SDL_PIXELFORMAT_RGBA8888;
-#endif
-
-static void
-png_write_fn(png_structp png_ptr, png_bytep data, png_size_t length)
-{
-    SDL_RWops *rwops = (SDL_RWops *)png_get_io_ptr(png_ptr);
-    if (SDL_RWwrite(rwops, data, 1, length) != length) {
-        SDL_RWclose(rwops);
-        png_error(png_ptr,
-                  "Error while writing to the PNG file (SDL_RWwrite)");
-    }
-}
-
-static void
-png_flush_fn(png_structp png_ptr)
-{
-    SDL_RWops *rwops = (SDL_RWops *)png_get_io_ptr(png_ptr);
-    if (pg_RWflush(rwops)) {
-        SDL_RWclose(rwops);
-        png_error(png_ptr, "Error while writing to PNG file (flush)");
-    }
-}
-
-static int
-pg_SavePNG_RW(SDL_Surface *surface, SDL_RWops *dst, int freedst)
-{
-    if (dst) {
-        png_structp png_ptr;
-        png_infop info_ptr;
-        png_colorp color_ptr = NULL;
-        Uint8 transparent_table[256];
-        SDL_Surface *source = surface;
-        SDL_Palette *palette;
-        int png_color_type = PNG_COLOR_TYPE_RGB_ALPHA;
-
-        png_ptr =
-            png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
-        if (png_ptr == NULL) {
-            IMG_SetError(
-                "Couldn't allocate memory for PNG file or incompatible PNG "
-                "dll");
-            return -1;
-        }
-
-        info_ptr = png_create_info_struct(png_ptr);
-        if (info_ptr == NULL) {
-            png_destroy_write_struct(&png_ptr, NULL);
-            IMG_SetError("Couldn't create image information for PNG file");
-            return -1;
-        }
-#ifdef PNG_SETJMP_SUPPORTED
-#ifndef LIBPNG_VERSION_12
-        if (setjmp(*png_set_longjmp_fn(png_ptr, longjmp, sizeof(jmp_buf))))
-#else
-        if (setjmp(png_ptr->jmpbuf))
-#endif
-#endif
-        {
-            png_destroy_write_struct(&png_ptr, &info_ptr);
-            IMG_SetError("Error writing the PNG file.");
-            return -1;
-        }
-
-        palette = surface->format->palette;
-        if (palette) {
-            const int ncolors = palette->ncolors;
-            int i;
-            int last_transparent = -1;
-
-            color_ptr = (png_colorp)SDL_malloc(sizeof(png_colorp) * ncolors);
-            if (color_ptr == NULL) {
-                png_destroy_write_struct(&png_ptr, &info_ptr);
-                IMG_SetError("Couldn't create palette for PNG file");
-                return -1;
-            }
-            for (i = 0; i < ncolors; i++) {
-                color_ptr[i].red = palette->colors[i].r;
-                color_ptr[i].green = palette->colors[i].g;
-                color_ptr[i].blue = palette->colors[i].b;
-                if (palette->colors[i].a != 255) {
-                    last_transparent = i;
-                }
-            }
-            png_set_PLTE(png_ptr, info_ptr, color_ptr, ncolors);
-            png_color_type = PNG_COLOR_TYPE_PALETTE;
-
-            if (last_transparent >= 0) {
-                for (i = 0; i <= last_transparent; ++i) {
-                    transparent_table[i] = palette->colors[i].a;
-                }
-                png_set_tRNS(png_ptr, info_ptr, transparent_table,
-                             last_transparent + 1, NULL);
-            }
-        }
-        else if (surface->format->format == SDL_PIXELFORMAT_RGB24) {
-            /* If the surface is exactly the right RGB format it is just passed
-             * through */
-            png_color_type = PNG_COLOR_TYPE_RGB;
-        }
-        else if (!SDL_ISPIXELFORMAT_ALPHA(surface->format->format)) {
-            /* If the surface is not exactly the right RGB format but does not
-               have alpha information, it should be converted to RGB24 before
-               being passed through */
-            png_color_type = PNG_COLOR_TYPE_RGB;
-            source = PG_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_RGB24);
-        }
-        else if (surface->format->format != png_format) {
-            /* Otherwise, (surface has alpha data), and it is not in the exact
-               right format , so it should be converted to that */
-            source = PG_ConvertSurfaceFormat(surface, png_format);
-        }
-
-        png_set_write_fn(png_ptr, dst, png_write_fn, png_flush_fn);
-
-        png_set_IHDR(png_ptr, info_ptr, surface->w, surface->h, 8,
-                     png_color_type, PNG_INTERLACE_NONE,
-                     PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
-
-        if (source) {
-            png_bytep *row_pointers;
-            int row;
-
-            row_pointers =
-                (png_bytep *)SDL_malloc(sizeof(png_bytep) * source->h);
-            if (!row_pointers) {
-                png_destroy_write_struct(&png_ptr, &info_ptr);
-                IMG_SetError("Out of memory");
-                return -1;
-            }
-            for (row = 0; row < (int)source->h; row++) {
-                row_pointers[row] =
-                    (png_bytep)(Uint8 *)source->pixels + row * source->pitch;
-            }
-
-            png_set_rows(png_ptr, info_ptr, row_pointers);
-            png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, NULL);
-
-            SDL_free(row_pointers);
-            if (source != surface) {
-                SDL_FreeSurface(source);
-            }
-        }
-        png_destroy_write_struct(&png_ptr, &info_ptr);
-        if (color_ptr) {
-            SDL_free(color_ptr);
-        }
-        if (freedst) {
-            SDL_RWclose(dst);
-        }
-    }
-    else {
-        IMG_SetError("Passed NULL dst");
-        return -1;
-    }
-    return 0;
-}
-
-int
-pg_SavePNG(SDL_Surface *surface, const char *file)
-{
-    SDL_RWops *dst = SDL_RWFromFile(file, "wb");
-    if (dst) {
-        return pg_SavePNG_RW(surface, dst, 1);
-    }
-    else {
-        return -1;
-    }
-}
-
-#endif /* end if PNG_H */
-
 static PyObject *
 image_save_ext(PyObject *self, PyObject *arg, PyObject *kwarg)
 {
@@ -385,19 +191,14 @@ image_save_ext(PyObject *self, PyObject *arg, PyObject *kwarg)
             }
         }
         else if (!strcasecmp(ext, "png")) {
-#ifdef PNG_H
             /*Py_BEGIN_ALLOW_THREADS; */
             if (rw != NULL) {
-                result = pg_SavePNG_RW(surf, rw, 0);
+                result = IMG_SavePNG_RW(surf, rw, 0);
             }
             else {
-                result = pg_SavePNG(surf, name);
+                result = IMG_SavePNG(surf, name);
             }
             /*Py_END_ALLOW_THREADS; */
-#else
-            PyErr_SetString(pgExc_SDLError, "No support for png compiled in.");
-            result = -2;
-#endif /* ~PNG_H */
         }
     }
 


### PR DESCRIPTION
It's a long time coming, since we've decided we need SDL_image built with libpng, and SDL_image prebuilts after 2.0.5 don't come with that.

This PR hopes to get around that using CI on a pygame-community fork of SDL_image (https://github.com/pygame-community/SDL_image/releases/tag/2.8.0-pgce) to generate release bundles with our parameters.

This allows our Windows CI and local development workflow to remain almost exactly the same through this change.