### PR TITLE
Fix linked/non linked SDL image version getter

### DIFF
--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -432,13 +432,13 @@ imageext_get_sdl_image_version(PyObject *self, PyObject *args,
     }
 
     if (linked) {
+        const SDL_version *v = IMG_Linked_Version();
+        return Py_BuildValue("iii", v->major, v->minor, v->patch);
+    }
+    else {
         SDL_version v;
         SDL_IMAGE_VERSION(&v);
         return Py_BuildValue("iii", v.major, v.minor, v.patch);
-    }
-    else {
-        const SDL_version *v = IMG_Linked_Version();
-        return Py_BuildValue("iii", v->major, v->minor, v->patch);
     }
 }
 


### PR DESCRIPTION
It was reversed from what it should be.

Checked all the other version getters, this is the only one with the problem.

Noticed this when I built a pre release SDL_image 2.9 with SDL_image 2.8 headers and it reported itself as SDL_image 2.8.