### PR TITLE
Border radius for pygame.draw.polygon (resolves #1527)

### DIFF
--- a/buildconfig/stubs/pygame/draw.pyi
+++ b/buildconfig/stubs/pygame/draw.pyi
@@ -19,6 +19,7 @@ def polygon(
     color: ColorValue,
     points: Sequence[Coordinate],
     width: int = 0,
+    border_radius: int = 0,
 ) -> Rect: ...
 def circle(
     surface: Surface,

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -103,7 +103,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
    | :sl:`draw a polygon`
    | :sg:`polygon(surface, color, points) -> Rect`
-   | :sg:`polygon(surface, color, points, width=0) -> Rect`
+   | :sg:`polygon(surface, color, points, width=0, border_radius=0) -> Rect`
 
    Draws a polygon on the given surface.
 
@@ -129,6 +129,8 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
             outside the original boundary of the polygon. For more details on
             how the thickness for edge lines grow, refer to the ``width`` notes
             of the :func:`pygame.draw.line` function.
+   :param int border_radius: (optional, default: 0) determines the radius for rounded corners of the polygon.
+      Only active when both ``width > 0`` and ``border_radius > 0``.
 
    :returns: a rect bounding the changed pixels, if nothing is drawn the
       bounding rect's position will be the position of the first point in the
@@ -136,7 +138,9 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       height will be 0
    :rtype: Rect
 
-   :raises ValueError: if ``len(points) < 3`` (must have at least 3 points)
+   :raises ValueError: if ``len(points) < 3`` (must have at least 3 points),
+      or if three of the given points provided in inputs are aligned,
+      or if the radius is very large in relation to the size of the adjacent edges.
    :raises TypeError: if ``points`` is not a sequence or ``points`` does not
       contain number pairs
 

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -1,7 +1,7 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_DRAW "pygame module for drawing shapes"
 #define DOC_DRAW_RECT "rect(surface, color, rect) -> Rect\nrect(surface, color, rect, width=0, border_radius=0, border_top_left_radius=-1, border_top_right_radius=-1, border_bottom_left_radius=-1, border_bottom_right_radius=-1) -> Rect\ndraw a rectangle"
-#define DOC_DRAW_POLYGON "polygon(surface, color, points) -> Rect\npolygon(surface, color, points, width=0) -> Rect\ndraw a polygon"
+#define DOC_DRAW_POLYGON "polygon(surface, color, points) -> Rect\npolygon(surface, color, points, width=0, border_radius=0) -> Rect\ndraw a polygon"
 #define DOC_DRAW_CIRCLE "circle(surface, color, center, radius) -> Rect\ncircle(surface, color, center, radius, width=0, draw_top_right=None, draw_top_left=None, draw_bottom_left=None, draw_bottom_right=None) -> Rect\ndraw a circle"
 #define DOC_DRAW_ELLIPSE "ellipse(surface, color, rect) -> Rect\nellipse(surface, color, rect, width=0) -> Rect\ndraw an ellipse"
 #define DOC_DRAW_ARC "arc(surface, color, rect, start_angle, stop_angle) -> Rect\narc(surface, color, rect, start_angle, stop_angle, width=1) -> Rect\ndraw an elliptical arc"

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -30,7 +30,7 @@
 #include "doc/draw_doc.h"
 
 #include <math.h>
-#define sametype(A, B) _Generic(*((A *)0), B: true, default: false)
+
 #include <float.h>
 
 #ifndef M_PI

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2848,13 +2848,18 @@ typedef struct {
 // Function to determine the side of point 'c' relative to the line formed by points 'a' and 'b'
 // Returns 1 if on the left side, -1 if on the right side, and 0 if collinear
 int side(Point a, Point b, Point c) {
+    // Calculate the determinant, a mathematical quantity used to determine the orientation of three points
     double det =
         (a.x * b.y + b.x * c.y + c.x * a.y) - (a.y * b.x + b.y * c.x + c.y * a.x);
+    // Check the sign of the determinant to determine the relative position of point 'c'   
     if (det > 0) {
         return 1;
+    // If the determinant is positive, point 'c' is on the left side of the line
     } else if (det < 0) {
+        // If the determinant is negative, point 'c' is on the right side of the line
         return -1;
     } else {
+        // If the determinant is zero, points 'a', 'b', and 'c' are collinear
         return 0;
     }
 }
@@ -2862,11 +2867,21 @@ int side(Point a, Point b, Point c) {
 // Function to find a parallel line to the line formed by 'pt1' and 'pt2' at a given distance
 // Returns a Line struct representing the parallel line
 Line find_parallel_line(Point pt1, Point pt2, Point pt3, int distance) {
+    
     // Calculate direction vector, normalize it, and find the perpendicular vector
+    
+    // Calculate direction vector from 'pt1' to 'pt2'
     Point direction_vector = {pt2.x - pt1.x, pt2.y - pt1.y};
+
+    // Calculate the magnitude of the direction vector
     float magnitude = sqrt(direction_vector.x * direction_vector.x + direction_vector.y * direction_vector.y);
+    
+    // Normalize the direction vector to get a unit vector
     Point normalized_direction = {direction_vector.x / magnitude, direction_vector.y / magnitude};
+    
+    // Calculate the perpendicular vector by swapping x and y components and negating one of them
     Point perpendicular_vector = {-normalized_direction.y, normalized_direction.x};
+    
     // Adjust the perpendicular vector based on the side of 'pt3' relative to 'pt1' and 'pt2'
     if (side(pt1, pt2, pt3) == -1) {
         perpendicular_vector.x *= -1;
@@ -2874,15 +2889,19 @@ Line find_parallel_line(Point pt1, Point pt2, Point pt3, int distance) {
     }
     // Create an offset vector and generate the parallel line.
     Point offset_vector = {perpendicular_vector.x * distance, perpendicular_vector.y * distance};
+    
+    // Generate the points for the parallel line based on the offset
     Line parallel_line = {{pt1.x + offset_vector.x, pt1.y + offset_vector.y}, {pt2.x + offset_vector.x, pt2.y + offset_vector.y}};
+    
+    // Return the Line struct representing the parallel line
     return parallel_line;
 }
+
 
 // Function to project a point onto a line segment defined by 'segment_start' and 'segment_end'
 Point project_point_onto_segment(Point point, Point segment_start,
                                  Point segment_end) {
-    // Calculate vectors, find the parameter 't' for projection, and calculate the projection.
-    // Ensure 't' is within the valid range [0, 1].
+   // Calculate vectors representing the line segment and the vector from 'segment_start' to 'point'
     Point segment_vector;
     segment_vector.x = segment_end.x - segment_start.x;
     segment_vector.y = segment_end.y - segment_start.y;
@@ -2891,18 +2910,24 @@ Point project_point_onto_segment(Point point, Point segment_start,
     point_vector.x = point.x - segment_start.x;
     point_vector.y = point.y - segment_start.y;
 
+    // Calculate the parameter 't' for the projection using the dot product
     double t =
         (point_vector.x * segment_vector.x + point_vector.y * segment_vector.y) /
         (segment_vector.x * segment_vector.x +
         segment_vector.y * segment_vector.y);
+
+    // Ensure 't' is within the valid range [0, 1] to guarantee the projection lies on the line segment    
     t = fmax(0, fmin(1, t));
 
+    // Calculate the coordinates of the projected point using the parameter 't'
     Point projection;
     projection.x = segment_start.x + t * segment_vector.x;
     projection.y = segment_start.y + t * segment_vector.y;
 
+    // Return the projected point on the line segment
     return projection;
 }
+
 
 // Function to find the intersection point of two line segments
 // Returns the intersection point as a Point struct
@@ -2919,6 +2944,7 @@ Point intersection(Point line1_start, Point line1_end, Point line2_start,
 
     // Check if the lines are parallel (det == 0) and handle the case
     double det = A1 * B2 - A2 * B1;
+    // If the lines are parallel (det == 0), they do not intersect, return a default Point
     if (det == 0) {
         return (Point){0, 0};
     } else {
@@ -2931,8 +2957,12 @@ Point intersection(Point line1_start, Point line1_end, Point line2_start,
 
 // Function to calculate the angle (in radians) between a center point and another point
 double angle(Point center, Point point) {
+    // Calculate the differences in x and y coordinates between the two points
     double x = point.x - center.x;
     double y = point.y - center.y;
+    // Use atan2 to calculate the angle formed by the vector from the center to the point
+    // The angle is measured counterclockwise from the positive x-axis
+    // Note: The negative sign is used to ensure the angle is measured clockwise, which is more common in Cartesian coordinates.
     return -atan2(y, x);
 }
 
@@ -2990,6 +3020,9 @@ draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int width, int bor
             project_point_onto_segment(circles[i].center, points[i], points[b]);
 
         // Check if the border-radius size is valid
+
+        // Compare the distance between the projected points and the corresponding endpoints
+        // If the distance is greater than or equal to half of the corresponding line segment, it is considered invalid
         if ((sqrt(pow(proj1.x - points[i].x, 2) +
             pow(proj1.y - points[i].y, 2)) >= sqrt(pow(points[a].x - points[i].x, 2) +
                                                     pow(points[a].y - points[i].y, 2)) / 2) ||  

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2865,6 +2865,7 @@ int side(Point a, Point b, Point c) {
 }
 
 // Function to find a parallel line to the line formed by 'pt1' and 'pt2' at a given distance
+// 'pt3' is used to determin in which side of the line, the parallel line should be drawn
 // Returns a Line struct representing the parallel line
 Line find_parallel_line(Point pt1, Point pt2, Point pt3, int distance) {
     
@@ -2901,7 +2902,8 @@ Line find_parallel_line(Point pt1, Point pt2, Point pt3, int distance) {
 // Function to project a point onto a line segment defined by 'segment_start' and 'segment_end'
 Point project_point_onto_segment(Point point, Point segment_start,
                                  Point segment_end) {
-   // Calculate vectors representing the line segment and the vector from 'segment_start' to 'point'
+    // t is a parameter that represents the position of the projected point along the line segment defined by segment_start and segment_end.                               
+    // Calculate vectors, find the parameter 't' for projection, and calculate the projection.
     Point segment_vector;
     segment_vector.x = segment_end.x - segment_start.x;
     segment_vector.y = segment_end.y - segment_start.y;
@@ -2916,7 +2918,8 @@ Point project_point_onto_segment(Point point, Point segment_start,
         (segment_vector.x * segment_vector.x +
         segment_vector.y * segment_vector.y);
 
-    // Ensure 't' is within the valid range [0, 1] to guarantee the projection lies on the line segment    
+    // Ensure 't' is within the valid range [0, 1] to make sure that the projection of the point onto the line segment lies specifically within the boundaries of the segment
+    // See line 2906
     t = fmax(0, fmin(1, t));
 
     // Calculate the coordinates of the projected point using the parameter 't'
@@ -2949,6 +2952,7 @@ Point intersection(Point line1_start, Point line1_end, Point line2_start,
         return (Point){0, 0};
     } else {
         // Calculate the intersection point using Cramer's rule
+        // The lines never intersect out of the range given because of the condition limiting the value of boarder radius
         double x = (B2 * C1 - B1 * C2) / det;
         double y = (A1 * C2 - A2 * C1) / det;
         return (Point){x, y};

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -30,7 +30,7 @@
 #include "doc/draw_doc.h"
 
 #include <math.h>
-
+#define sametype(A, B) _Generic(*((A *)0), B: true, default: false)
 #include <float.h>
 
 #ifndef M_PI
@@ -2841,7 +2841,7 @@ typedef struct {
 
 typedef struct {
     Point center;
-    double radius;
+    int radius;
 } Circle;
 
 typedef struct {
@@ -3107,12 +3107,19 @@ draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int width,
             end_angle = temp;
         }
 
-        draw_arc(surf, round(circle.center.x), round(circle.center.y),
-                 round(circle.radius), round(circle.radius), width,
-                 start_angle, end_angle, color, drawn_area);
+        int circle_center_x = round(circle.center.x);
+        int circle_center_y = round(circle.center.y);
+        int pt2_x = round(pt2.x);
+        int pt2_y = round(pt2.y);
+        int pt3_x = round(pt3.x);
+        int pt3_y = round(pt3.y);
 
-        draw_line_width(surf, color, round(pt2.x), round(pt2.y), round(pt3.x),
-                        round(pt3.y), width, drawn_area);
+        draw_arc(surf, circle_center_x, circle_center_y, circle.radius,
+                 circle.radius, width, start_angle, end_angle, color,
+                 drawn_area);
+
+        draw_line_width(surf, color, pt2_x, pt2_y, pt3_x, pt3_y, width,
+                        drawn_area);
     }
     free(path);
     free(circles);

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -85,6 +85,7 @@ draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
                 int width, Uint32 color, int top_left, int top_right,
                 int bottom_left, int bottom_right, int *drawn_area);
 
+
 // validation of a draw color
 #define CHECK_LOAD_COLOR(colorobj)                               \
     if (!pg_MappedColorFromObj((colorobj), surf->format, &color, \
@@ -721,19 +722,20 @@ polygon(PyObject *self, PyObject *arg, PyObject *kwargs)
     Uint32 color;
     int *xlist = NULL, *ylist = NULL;
     int width = 0; /* Default width. */
+    int border_radius = 0; /* Default border_radius. */
     int x, y, result, l, t;
     int drawn_area[4] = {INT_MAX, INT_MAX, INT_MIN,
                          INT_MIN}; /* Used to store bounding box values */
     Py_ssize_t loop, length;
-    static char *keywords[] = {"surface", "color", "points", "width", NULL};
+    static char *keywords[] = {"surface", "color", "points", "width", "border_radius", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OO|i", keywords,
+    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OO|ii", keywords,
                                      &pgSurface_Type, &surfobj, &colorobj,
-                                     &points, &width)) {
+                                     &points, &width, &border_radius)) {
         return NULL; /* Exception already set. */
     }
 
-    if (width) {
+    if (width && (border_radius==0)) {
         PyObject *ret = NULL;
         PyObject *args =
             Py_BuildValue("(OOiOi)", surfobj, colorobj, 1, points, width);
@@ -810,7 +812,11 @@ polygon(PyObject *self, PyObject *arg, PyObject *kwargs)
     }
 
     if (length != 3) {
+        if(border_radius != 0){ 
+            draw_round_polygon(surf, xlist, ylist, width, border_radius, length, color, drawn_area);
+        } else {
         draw_fillpoly(surf, xlist, ylist, length, color, drawn_area);
+        }
     }
     else {
         draw_filltri(surf, xlist, ylist, color, drawn_area);
@@ -2816,6 +2822,115 @@ draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
                              y2 - bottom_right + 1, bottom_right, width, color,
                              0, 0, 0, 1, drawn_area);
     }
+}
+
+// Define a structure representing a point with x and y coordinates
+typedef struct {
+    double x;
+    double y;
+} Point;
+
+// Define a structure representing a circle with a center (Point) and a radius
+typedef struct {
+    Point center;
+    double radius;
+} Circle;
+
+// Define a structure representing a line segment with start and end points
+typedef struct {
+    Point start;
+    Point end;
+} Line;
+
+// Function to determine the side of point 'c' relative to the line formed by points 'a' and 'b'
+// Returns 1 if on the left side, -1 if on the right side, and 0 if collinear
+int side(Point a, Point b, Point c) {
+    double det =
+        (a.x * b.y + b.x * c.y + c.x * a.y) - (a.y * b.x + b.y * c.x + c.y * a.x);
+    if (det > 0) {
+        return 1;
+    } else if (det < 0) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+// Function to find a parallel line to the line formed by 'pt1' and 'pt2' at a given distance
+// Returns a Line struct representing the parallel line
+Line find_parallel_line(Point pt1, Point pt2, Point pt3, int distance) {
+    // Calculate direction vector, normalize it, and find the perpendicular vector
+    Point direction_vector = {pt2.x - pt1.x, pt2.y - pt1.y};
+    float magnitude = sqrt(direction_vector.x * direction_vector.x + direction_vector.y * direction_vector.y);
+    Point normalized_direction = {direction_vector.x / magnitude, direction_vector.y / magnitude};
+    Point perpendicular_vector = {-normalized_direction.y, normalized_direction.x};
+    // Adjust the perpendicular vector based on the side of 'pt3' relative to 'pt1' and 'pt2'
+    if (side(pt1, pt2, pt3) == -1) {
+        perpendicular_vector.x *= -1;
+        perpendicular_vector.y *= -1;
+    }
+    // Create an offset vector and generate the parallel line.
+    Point offset_vector = {perpendicular_vector.x * distance, perpendicular_vector.y * distance};
+    Line parallel_line = {{pt1.x + offset_vector.x, pt1.y + offset_vector.y}, {pt2.x + offset_vector.x, pt2.y + offset_vector.y}};
+    return parallel_line;
+}
+
+// Function to project a point onto a line segment defined by 'segment_start' and 'segment_end'
+Point project_point_onto_segment(Point point, Point segment_start,
+                                 Point segment_end) {
+    // Calculate vectors, find the parameter 't' for projection, and calculate the projection.
+    // Ensure 't' is within the valid range [0, 1].
+    Point segment_vector;
+    segment_vector.x = segment_end.x - segment_start.x;
+    segment_vector.y = segment_end.y - segment_start.y;
+
+    Point point_vector;
+    point_vector.x = point.x - segment_start.x;
+    point_vector.y = point.y - segment_start.y;
+
+    double t =
+        (point_vector.x * segment_vector.x + point_vector.y * segment_vector.y) /
+        (segment_vector.x * segment_vector.x +
+        segment_vector.y * segment_vector.y);
+    t = fmax(0, fmin(1, t));
+
+    Point projection;
+    projection.x = segment_start.x + t * segment_vector.x;
+    projection.y = segment_start.y + t * segment_vector.y;
+
+    return projection;
+}
+
+// Function to find the intersection point of two line segments
+// Returns the intersection point as a Point struct
+Point intersection(Point line1_start, Point line1_end, Point line2_start,
+                   Point line2_end) {
+    // Calculate coefficients for each line equation
+    double A1 = line1_end.y - line1_start.y;
+    double B1 = line1_start.x - line1_end.x;
+    double C1 = A1 * line1_start.x + B1 * line1_start.y;
+
+    double A2 = line2_end.y - line2_start.y;
+    double B2 = line2_start.x - line2_end.x;
+    double C2 = A2 * line2_start.x + B2 * line2_start.y;
+
+    // Check if the lines are parallel (det == 0) and handle the case
+    double det = A1 * B2 - A2 * B1;
+    if (det == 0) {
+        return (Point){0, 0};
+    } else {
+        // Calculate the intersection point using Cramer's rule
+        double x = (B2 * C1 - B1 * C2) / det;
+        double y = (A1 * C2 - A2 * C1) / det;
+        return (Point){x, y};
+    }
+}
+
+// Function to calculate the angle (in radians) between a center point and another point
+double angle(Point center, Point point) {
+    double x = point.x - center.x;
+    double y = point.y - center.y;
+    return -atan2(y, x);
 }
 
 /* List of python functions */

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -819,7 +819,7 @@ polygon(PyObject *self, PyObject *arg, PyObject *kwargs)
         if ((border_radius > 0) && (width > 0)) {
             int err;
             err = draw_round_polygon(surf, xlist, ylist, width, border_radius,
-                                     length, color, drawn_area);
+                                     (int)length, color, drawn_area);
             if (err == -1) {
                 return NULL;
             }
@@ -2887,8 +2887,8 @@ find_parallel_line(Point pt1, Point pt2, Point pt3, int distance)
     Point direction_vector = {pt2.x - pt1.x, pt2.y - pt1.y};
 
     // Calculate the magnitude of the direction vector
-    float magnitude = sqrt(direction_vector.x * direction_vector.x +
-                           direction_vector.y * direction_vector.y);
+    double magnitude = sqrt(direction_vector.x * direction_vector.x +
+                            direction_vector.y * direction_vector.y);
 
     // Normalize the direction vector to get a unit vector
     Point normalized_direction = {direction_vector.x / magnitude,
@@ -3107,12 +3107,12 @@ draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int width,
             end_angle = temp;
         }
 
-        draw_arc(surf, circle.center.x, circle.center.y, circle.radius,
-                 circle.radius, width, start_angle, end_angle, color,
-                 drawn_area);
+        draw_arc(surf, round(circle.center.x), round(circle.center.y),
+                 round(circle.radius), round(circle.radius), width,
+                 start_angle, end_angle, color, drawn_area);
 
-        draw_line_width(surf, color, pt2.x, pt2.y, pt3.x, pt3.y, width,
-                        drawn_area);
+        draw_line_width(surf, color, round(pt2.x), round(pt2.y), round(pt3.x),
+                        round(pt3.y), width, drawn_area);
     }
     free(path);
     free(circles);

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -84,6 +84,9 @@ static void
 draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
                 int width, Uint32 color, int top_left, int top_right,
                 int bottom_left, int bottom_right, int *drawn_area);
+                static void
+draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int width, int border_radius, 
+                    int num_points, Uint32 color, int *drawn_area);
 
 
 // validation of a draw color
@@ -2931,6 +2934,124 @@ double angle(Point center, Point point) {
     double x = point.x - center.x;
     double y = point.y - center.y;
     return -atan2(y, x);
+}
+
+// Define a function to draw a rounded polygon on an SDL surface
+static void
+draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int width, int border_radius, int num_points, Uint32 color, int *drawn_area) {
+
+    // Define arrays to store path points and circle information
+    Point path[2 * num_points];
+    Circle circles[num_points];
+
+    // Define an array to store original polygon points
+    Point points[num_points];
+
+    // Convert input coordinates to Point structures
+    for (int i = 0; i < num_points; i++) {
+        points[i].x = pts_x[i];
+        points[i].y = pts_y[i];
+    }
+
+    // Iterate through each point in the polygon
+    for (int i = 0; i < num_points; i++) {
+        // Determine neighboring points for the current point
+        int a, b;
+        if (i == 0) {
+            a = num_points - 1;
+            b = 1;
+        } else if (i == (num_points - 1)) {
+            a = num_points - 2;
+            b = 0;
+        } else if (i == (num_points - 2)) {
+            a = num_points - 3;
+            b = num_points - 1;
+        } else {
+            a = i - 1;
+            b = i + 1;
+        }
+
+        // Check if the border-radius can be applied to the current angle
+        if (side(points[a], points[i], points[b]) == 0) {
+            printf("ValueError: Border-radius cannot be applied to a flat angle.\n"
+                    "Please ensure that the specified angle or curvature is within a valid range for border-radius drawing.\n");
+            return;
+        }
+
+        // Find parallel lines to the polygon sides at the current point
+        Line line1 = find_parallel_line(points[a], points[i], points[b], border_radius);
+        Line line2 = find_parallel_line(points[i], points[b], points[a], border_radius);
+        circles[i].center = intersection(line1.start, line1.end, line2.start, line2.end);
+
+        // Project points onto the parallel lines
+        Point proj1 =
+            project_point_onto_segment(circles[i].center, points[a], points[i]);
+        Point proj2 =
+            project_point_onto_segment(circles[i].center, points[i], points[b]);
+
+        // Check if the border-radius size is valid
+        if ((sqrt(pow(proj1.x - points[i].x, 2) +
+            pow(proj1.y - points[i].y, 2)) >= sqrt(pow(points[a].x - points[i].x, 2) +
+                                                    pow(points[a].y - points[i].y, 2)) / 2) ||  
+            (sqrt(pow(proj2.x - points[i].x, 2) +
+                pow(proj2.y - points[i].y, 2)) >= sqrt(pow(points[b].x - points[i].x, 2) +
+                                                        pow(points[b].y - points[i].y, 2)) / 2)) {
+            printf("ValueError: Border-radius size must be smaller\n");
+            return;
+        }
+
+        // Store projected points and circle radius in arrays
+        path[2 * i] = proj1;
+        path[2 * i + 1] = proj2;
+
+        circles[i].radius = border_radius;
+    }
+
+    // Iterate through the projected points to draw arcs and connecting lines
+    for (int i = 0; i < 2 * num_points; i += 2) {
+        Point pt1 = path[i % (2 * num_points)];
+        Point pt2 = path[(i + 1) % (2 * num_points)];
+        Point pt3 = path[(i + 2) % (2 * num_points)];
+        Circle circle = circles[i / 2];
+
+        // Calculate start and end angles for the arc
+        double start_angle = angle(circle.center, pt1);
+        double end_angle = angle(circle.center, pt2);
+
+        // Adjust angles based on the side of the polygon
+        if (side(pt1, pt2, pt3) == 1) {
+            double temp = start_angle;
+            start_angle = end_angle;
+            end_angle = temp;
+        }
+
+        // Ensure the end angle is greater than the start angle (in radians)
+        if (end_angle < start_angle) {
+            // Angle is in radians
+            end_angle += 2 * M_PI;
+        }
+
+        // Draw the arc and connecting line
+        draw_arc(surf,
+                circle.center.x,
+                circle.center.y,
+                circle.radius,
+                circle.radius,
+                width,
+                start_angle,
+                end_angle,
+                color,
+                drawn_area);
+
+        draw_line_width(surf,
+                        color,
+                        pt2.x,
+                        pt2.y,
+                        pt3.x,
+                        pt3.y,
+                        width,
+                        drawn_area);
+    }
 }
 
 /* List of python functions */

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -4229,26 +4229,42 @@ class DrawPolygonMixin:
         pygame.draw.polygon(self.surface, GREEN, RHOMBUS, 0)
         for x, y in key_polygon_points:
             self.assertEqual(self.surface.get_at((x, y)), GREEN, msg=str((x, y)))
-    
+
     def test_polygon__border_radius_args(self):
         """Ensures draw polygon accepts border_radius args."""
         bounds_rect = self.draw_polygon(
-            pygame.Surface((400, 400)), (0, 10, 0, 50), [[100,100], [300, 100], [300, 300], [100, 300]], 1, 1
+            pygame.Surface((400, 400)),
+            (0, 10, 0, 50),
+            [[100, 100], [300, 100], [300, 300], [100, 300]],
+            1,
+            1,
         )
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
-    
+
     def test_polygon__border_radius_kwarg(self):
         """Ensures draw polygon accepts border_radius kwarg
         with and without a width arg and with different orders.
         """
         surface = pygame.Surface((400, 400))
         color = pygame.Color("yellow")
-        points = [[100,100], [300, 100], [300, 300], [100, 300]]
+        points = [[100, 100], [300, 100], [300, 300], [100, 300]]
         kwargs_list = [
-            {"surface": surface, "color": color, "points": points, "width": 1, "border_radius": 1},
+            {
+                "surface": surface,
+                "color": color,
+                "points": points,
+                "width": 1,
+                "border_radius": 1,
+            },
             {"surface": surface, "color": color, "points": points, "border_radius": 1},
-            {"points": points, "surface": surface, "border_radius": 1, "color": color, "width": 1},
+            {
+                "points": points,
+                "surface": surface,
+                "border_radius": 1,
+                "color": color,
+                "width": 1,
+            },
             {"surface": surface, "color": color, "border_radius": 1, "points": points},
             {"border_radius": 1, "surface": surface, "color": color, "points": points},
         ]
@@ -4262,17 +4278,17 @@ class DrawPolygonMixin:
         """Ensures draw polygon detects invalid border_radius arg type."""
         surface = pygame.Surface((400, 400))
         color = pygame.Color("blue")
-        points = [[100,100], [300, 100], [300, 300], [100, 300]]
+        points = [[100, 100], [300, 100], [300, 300], [100, 300]]
 
         with self.assertRaises(TypeError):
             # Invalid radius.
             bounds_rect = self.draw_polygon(surface, color, points, 1, "1")
-    
+
     def test_polygon__kwarg_border_radius_invalid_type_name(self):
         """Ensures draw polygon detects invalid kwarg border_radius type and name."""
         surface = pygame.Surface((400, 400))
         color = pygame.Color("green")
-        points = [[100,100], [300, 100], [300, 300], [100, 300]]
+        points = [[100, 100], [300, 100], [300, 300], [100, 300]]
         width = 1
         kwargs_list = [
             {
@@ -4280,36 +4296,42 @@ class DrawPolygonMixin:
                 "color": color,
                 "points": points,
                 "width": width,
-                "border_radius": "1" # Invalid border_radius type
+                "border_radius": "1",  # Invalid border_radius type
             },
             {
                 "surface": surface,
                 "color": color,
                 "points": points,
                 "width": width,
-                "border_radius": 2.3 # Invalid border_radius type
+                "border_radius": 2.3,  # Invalid border_radius type
             },
             {
                 "surface": surface,
                 "color": color,
                 "points": points,
                 "width": width,
-                "Invalid": 1 # Invalid border_radius name
+                "Invalid": 1,  # Invalid border_radius name
             },
         ]
 
         for kwargs in kwargs_list:
             with self.assertRaises(TypeError):
                 bounds_rect = self.draw_polygon(**kwargs)
-    
+
     def test_polygon__args_and_kwargs_border_radius(self):
         """Ensures draw polygon accepts a combination of args/kwargs with border_radius"""
         surface = pygame.Surface((400, 400))
         color = (255, 255, 0, 0)
-        points = [[100,100], [300, 100], [300, 300], [100, 300]]
+        points = [[100, 100], [300, 100], [300, 300], [100, 300]]
         width = 1
         border_radius = 1
-        kwargs = {"surface": surface, "color": color, "points": points, "width": width, "border_radius": border_radius}
+        kwargs = {
+            "surface": surface,
+            "color": color,
+            "points": points,
+            "width": width,
+            "border_radius": border_radius,
+        }
 
         for name in ("surface", "color", "points", "width", "border_radius"):
             kwargs.pop(name)
@@ -4323,10 +4345,12 @@ class DrawPolygonMixin:
             elif "width" == name:
                 bounds_rect = self.draw_polygon(surface, color, points, width, **kwargs)
             else:
-                bounds_rect = self.draw_polygon(surface, color, points, width, border_radius, **kwargs)
+                bounds_rect = self.draw_polygon(
+                    surface, color, points, width, border_radius, **kwargs
+                )
 
             self.assertIsInstance(bounds_rect, pygame.Rect)
-            
+
     def test_polygon__valid_border_radius_values(self):
         """Ensures draw polygon accepts different border_radius values."""
         surface_color = pygame.Color("white")
@@ -4335,11 +4359,11 @@ class DrawPolygonMixin:
         kwargs = {
             "surface": surface,
             "color": color,
-            "points": [[100,100], [300, 100], [300, 300], [100, 300]],
+            "points": [[100, 100], [300, 100], [300, 300], [100, 300]],
             "width": 1,
             "border_radius": None,
         }
-        
+
         pos1 = kwargs["points"][0]
         pos2 = kwargs["points"][1]
         pos = ((pos1[0] + pos2[0]) / 2, (pos1[1] + pos2[1]) / 2)

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -3645,20 +3645,12 @@ class DrawPolygonMixin:
     def test_polygon__args(self):
         """Ensures draw polygon accepts the correct args."""
         bounds_rect = self.draw_polygon(
-            pygame.Surface((3, 3)), (0, 10, 0, 50), ((0, 0), (1, 1), (2, 2)), 1, 1
+            pygame.Surface((3, 3)), (0, 10, 0, 50), ((0, 0), (1, 1), (2, 2)), 1
         )
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
 
-    def test_polygon__args_without_radius(self):
-        """Ensures draw polygon accepts the args without a width."""
-        bounds_rect = self.draw_polygon(
-            pygame.Surface((2, 2)), (0, 0, 0, 50), ((0, 0), (1, 1), (2, 2)), 1
-        )
-
-        self.assertIsInstance(bounds_rect, pygame.Rect)
-
-    def test_polygon__args_without_width_nor_radius(self):
+    def test_polygon__args_without_width(self):
         """Ensures draw polygon accepts the args without a width."""
         bounds_rect = self.draw_polygon(
             pygame.Surface((2, 2)), (0, 0, 0, 50), ((0, 0), (1, 1), (2, 2))
@@ -3674,13 +3666,6 @@ class DrawPolygonMixin:
         color = pygame.Color("yellow")
         points = ((0, 0), (1, 1), (2, 2))
         kwargs_list = [
-            {
-                "surface": surface,
-                "color": color,
-                "points": points,
-                "width": 1,
-                "border_radius": 1,
-            },
             {"surface": surface, "color": color, "points": points, "width": 1},
             {"surface": surface, "color": color, "points": points},
         ]
@@ -3695,7 +3680,6 @@ class DrawPolygonMixin:
         bounds_rect = self.draw_polygon(
             color=(10, 20, 30),
             surface=pygame.Surface((3, 2)),
-            border_radius=1,
             width=0,
             points=((0, 1), (1, 2), (2, 3)),
         )
@@ -3723,7 +3707,6 @@ class DrawPolygonMixin:
             "color": pygame.Color("red"),
             "points": ((2, 1), (2, 2), (2, 3)),
             "width": 1,
-            "border_radius": 1,
         }
 
         for name in ("points", "color", "surface"):
@@ -3738,10 +3721,6 @@ class DrawPolygonMixin:
         surface = pygame.Surface((2, 2))
         color = pygame.Color("blue")
         points = ((0, 1), (1, 2), (1, 3))
-
-        with self.assertRaises(TypeError):
-            # Invalid border_radius.
-            bounds_rect = self.draw_polygon(surface, color, points, 1, "1")
 
         with self.assertRaises(TypeError):
             # Invalid width.
@@ -3765,44 +3744,27 @@ class DrawPolygonMixin:
         color = pygame.Color("green")
         points = ((0, 0), (1, 0), (2, 0))
         width = 1
-        border_radius = 1
         kwargs_list = [
             {
                 "surface": pygame.Surface,  # Invalid surface.
                 "color": color,
                 "points": points,
                 "width": width,
-                "border_radius": border_radius,
             },
             {
                 "surface": surface,
                 "color": 2.3,  # Invalid color.
                 "points": points,
                 "width": width,
-                "border_radius": border_radius,
             },
             {
                 "surface": surface,
                 "color": color,
                 "points": ((1,), (1,), (1,)),  # Invalid points.
                 "width": width,
-                "border_radius": border_radius,
             },
-            {
-                "surface": surface,
-                "color": color,
-                "points": points,
-                "width": 1.2,  # Invalid width.
-                "border_radius": border_radius,
-            },
-            {
-                "surface": surface,
-                "color": color,
-                "points": points,
-                "width": width,
-                "border_radius": 2.3,  # Invalid border_radius.
-            },
-        ]
+            {"surface": surface, "color": color, "points": points, "width": 1.2},
+        ]  # Invalid width.
 
         for kwargs in kwargs_list:
             with self.assertRaises(TypeError):
@@ -3819,16 +3781,9 @@ class DrawPolygonMixin:
                 "color": color,
                 "points": points,
                 "width": 1,
-                "border_radius": 1,
                 "invalid": 1,
             },
-            {
-                "surface": surface,
-                "color": color,
-                "points": points,
-                "invalid": 1,
-                "border_radius": 1,
-            },
+            {"surface": surface, "color": color, "points": points, "invalid": 1},
         ]
 
         for kwargs in kwargs_list:
@@ -3841,16 +3796,9 @@ class DrawPolygonMixin:
         color = (255, 255, 0, 0)
         points = ((0, 1), (1, 2), (2, 3))
         width = 0
-        border_radius = 0
-        kwargs = {
-            "surface": surface,
-            "color": color,
-            "points": points,
-            "width": width,
-            "border_radius": border_radius,
-        }
+        kwargs = {"surface": surface, "color": color, "points": points, "width": width}
 
-        for name in ("surface", "color", "points", "width", "border_radius"):
+        for name in ("surface", "color", "points", "width"):
             kwargs.pop(name)
 
             if "surface" == name:
@@ -3859,12 +3807,8 @@ class DrawPolygonMixin:
                 bounds_rect = self.draw_polygon(surface, color, **kwargs)
             elif "points" == name:
                 bounds_rect = self.draw_polygon(surface, color, points, **kwargs)
-            elif "width" == name:
-                bounds_rect = self.draw_polygon(surface, color, points, width, **kwargs)
             else:
-                bounds_rect = self.draw_polygon(
-                    surface, color, points, width, border_radius, **kwargs
-                )
+                bounds_rect = self.draw_polygon(surface, color, points, width, **kwargs)
 
             self.assertIsInstance(bounds_rect, pygame.Rect)
 
@@ -3878,7 +3822,6 @@ class DrawPolygonMixin:
             "color": color,
             "points": ((1, 1), (2, 1), (2, 2), (1, 2)),
             "width": None,
-            "border_radius": 0,
         }
         pos = kwargs["points"][0]
 
@@ -3902,7 +3845,6 @@ class DrawPolygonMixin:
             "color": expected_color,
             "points": None,
             "width": 0,
-            "border_radius": 0,
         }
 
         # The point type can be a tuple/list/Vector2.
@@ -3943,7 +3885,6 @@ class DrawPolygonMixin:
             "color": pygame.Color("red"),
             "points": None,
             "width": 0,
-            "border_radius": 0,
         }
 
         points_fmts = (
@@ -3969,7 +3910,6 @@ class DrawPolygonMixin:
             "color": pygame.Color("red"),
             "points": None,
             "width": 0,
-            "border_radius": 1,
         }
 
         points_fmts = (
@@ -3995,7 +3935,6 @@ class DrawPolygonMixin:
             "color": None,
             "points": ((1, 1), (2, 1), (2, 2), (1, 2)),
             "width": 0,
-            "border_radius": 0,
         }
         pos = kwargs["points"][0]
         greens = (
@@ -4026,7 +3965,6 @@ class DrawPolygonMixin:
             "color": None,
             "points": ((1, 1), (2, 1), (2, 2), (1, 2)),
             "width": 0,
-            "border_radius": 0,
         }
 
         for expected_color in (2.3, self):
@@ -4036,7 +3974,7 @@ class DrawPolygonMixin:
                 bounds_rect = self.draw_polygon(**kwargs)
 
     def test_draw_square(self):
-        self.draw_polygon(self.surface, RED, SQUARE, 0, 0)
+        self.draw_polygon(self.surface, RED, SQUARE, 0)
         # note : there is a discussion (#234) if draw.polygon should include or
         # not the right or lower border; here we stick with current behavior,
         # e.g. include those borders ...
@@ -4046,7 +3984,7 @@ class DrawPolygonMixin:
 
     def test_draw_diamond(self):
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
-        self.draw_polygon(self.surface, GREEN, DIAMOND, 0, 0)
+        self.draw_polygon(self.surface, GREEN, DIAMOND, 0)
         # this diamond shape is equivalent to its four corners, plus inner square
         for x, y in DIAMOND:
             self.assertEqual(self.surface.get_at((x, y)), GREEN, msg=str((x, y)))
@@ -4057,7 +3995,7 @@ class DrawPolygonMixin:
     def test_1_pixel_high_or_wide_shapes(self):
         # 1. one-pixel-high, filled
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
-        self.draw_polygon(self.surface, GREEN, [(x, 2) for x, _y in CROSS], 0, 0)
+        self.draw_polygon(self.surface, GREEN, [(x, 2) for x, _y in CROSS], 0)
         cross_size = 6  # the maximum x or y coordinate of the cross
         for x in range(cross_size + 1):
             self.assertEqual(self.surface.get_at((x, 1)), RED)
@@ -4065,21 +4003,21 @@ class DrawPolygonMixin:
             self.assertEqual(self.surface.get_at((x, 3)), RED)
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
         # 2. one-pixel-high, not filled
-        self.draw_polygon(self.surface, GREEN, [(x, 5) for x, _y in CROSS], 1, 0)
+        self.draw_polygon(self.surface, GREEN, [(x, 5) for x, _y in CROSS], 1)
         for x in range(cross_size + 1):
             self.assertEqual(self.surface.get_at((x, 4)), RED)
             self.assertEqual(self.surface.get_at((x, 5)), GREEN)
             self.assertEqual(self.surface.get_at((x, 6)), RED)
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
         # 3. one-pixel-wide, filled
-        self.draw_polygon(self.surface, GREEN, [(3, y) for _x, y in CROSS], 0, 0)
+        self.draw_polygon(self.surface, GREEN, [(3, y) for _x, y in CROSS], 0)
         for y in range(cross_size + 1):
             self.assertEqual(self.surface.get_at((2, y)), RED)
             self.assertEqual(self.surface.get_at((3, y)), GREEN)
             self.assertEqual(self.surface.get_at((4, y)), RED)
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
         # 4. one-pixel-wide, not filled
-        self.draw_polygon(self.surface, GREEN, [(4, y) for _x, y in CROSS], 1, 0)
+        self.draw_polygon(self.surface, GREEN, [(4, y) for _x, y in CROSS], 1)
         for y in range(cross_size + 1):
             self.assertEqual(self.surface.get_at((3, y)), RED)
             self.assertEqual(self.surface.get_at((4, y)), GREEN)
@@ -4092,7 +4030,7 @@ class DrawPolygonMixin:
         """
         # 1. case width = 1 (not filled: `polygon` calls  internally the `lines` function)
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
-        self.draw_polygon(self.surface, GREEN, CROSS, 1, 0)
+        self.draw_polygon(self.surface, GREEN, CROSS, 1)
         inside = [(x, 3) for x in range(1, 6)] + [(3, y) for y in range(1, 6)]
         for x in range(10):
             for y in range(10):
@@ -4107,7 +4045,7 @@ class DrawPolygonMixin:
 
         # 2. case width = 0 (filled; this is the example from #234)
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
-        self.draw_polygon(self.surface, GREEN, CROSS, 0, 0)
+        self.draw_polygon(self.surface, GREEN, CROSS, 0)
         inside = [(x, 3) for x in range(1, 6)] + [(3, y) for y in range(1, 6)]
         for x in range(10):
             for y in range(10):
@@ -4153,7 +4091,7 @@ class DrawPolygonMixin:
         pygame.draw.rect(self.surface, RED, (0, 0, 20, 20), 0)
 
         # 1. First without the corners 4 & 5
-        self.draw_polygon(self.surface, GREEN, path_data[:4], 0, 0)
+        self.draw_polygon(self.surface, GREEN, path_data[:4], 0)
         for x in range(20):
             self.assertEqual(self.surface.get_at((x, 0)), GREEN)  # upper border
         for x in range(4, rect.width - 5 + 1):
@@ -4161,7 +4099,7 @@ class DrawPolygonMixin:
 
         # 2. with the corners 4 & 5
         pygame.draw.rect(self.surface, RED, (0, 0, 20, 20), 0)
-        self.draw_polygon(self.surface, GREEN, path_data, 0, 0)
+        self.draw_polygon(self.surface, GREEN, path_data, 0)
         for x in range(4, rect.width - 5 + 1):
             self.assertEqual(self.surface.get_at((x, 4)), GREEN)  # upper inner
 
@@ -4186,7 +4124,6 @@ class DrawPolygonMixin:
         sizes = ((min_width, min_height), (max_width, max_height))
         surface = pygame.Surface((20, 20), 0, 32)
         surf_rect = surface.get_rect()
-        border_radius = 0
         # Make a rect that is bigger than the surface to help test drawing
         # polygons off and partially off the surface.
         big_rect = surf_rect.inflate(min_width * 2 + 1, min_height * 2 + 1)
@@ -4214,7 +4151,7 @@ class DrawPolygonMixin:
                         surface.fill(surf_color)  # Clear for each test.
 
                         bounding_rect = self.draw_polygon(
-                            surface, polygon_color, vertices, thickness, border_radius
+                            surface, polygon_color, vertices, thickness
                         )
 
                         # Calculating the expected_rect after the polygon
@@ -4239,7 +4176,6 @@ class DrawPolygonMixin:
         surface_color = pygame.Color("green")
         surface = pygame.Surface((surfw, surfh))
         surface.fill(surface_color)
-        border_radius = 0
 
         clip_rect = pygame.Rect((0, 0), (8, 10))
         clip_rect.center = surface.get_rect().center
@@ -4259,9 +4195,7 @@ class DrawPolygonMixin:
                 )
                 surface.set_clip(None)
                 surface.fill(surface_color)
-                self.draw_polygon(
-                    surface, polygon_color, vertices, width, border_radius
-                )
+                self.draw_polygon(surface, polygon_color, vertices, width)
                 expected_pts = get_color_points(surface, polygon_color, clip_rect)
 
                 # Clear the surface and set the clip area. Redraw the polygon
@@ -4269,9 +4203,7 @@ class DrawPolygonMixin:
                 surface.fill(surface_color)
                 surface.set_clip(clip_rect)
 
-                self.draw_polygon(
-                    surface, polygon_color, vertices, width, border_radius
-                )
+                self.draw_polygon(surface, polygon_color, vertices, width)
 
                 surface.lock()  # For possible speed up.
 
@@ -4294,9 +4226,133 @@ class DrawPolygonMixin:
         """
         key_polygon_points = [(2, 2), (6, 2), (2, 4), (6, 4)]
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
-        pygame.draw.polygon(self.surface, GREEN, RHOMBUS, 0, 0)
+        pygame.draw.polygon(self.surface, GREEN, RHOMBUS, 0)
         for x, y in key_polygon_points:
             self.assertEqual(self.surface.get_at((x, y)), GREEN, msg=str((x, y)))
+    
+    def test_polygon__border_radius_args(self):
+        """Ensures draw polygon accepts border_radius args."""
+        bounds_rect = self.draw_polygon(
+            pygame.Surface((400, 400)), (0, 10, 0, 50), [[100,100], [300, 100], [300, 300], [100, 300]], 1, 1
+        )
+
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+    
+    def test_polygon__border_radius_kwarg(self):
+        """Ensures draw polygon accepts border_radius kwarg
+        with and without a width arg and with different orders.
+        """
+        surface = pygame.Surface((400, 400))
+        color = pygame.Color("yellow")
+        points = [[100,100], [300, 100], [300, 300], [100, 300]]
+        kwargs_list = [
+            {"surface": surface, "color": color, "points": points, "width": 1, "border_radius": 1},
+            {"surface": surface, "color": color, "points": points, "border_radius": 1},
+            {"points": points, "surface": surface, "border_radius": 1, "color": color, "width": 1},
+            {"surface": surface, "color": color, "border_radius": 1, "points": points},
+            {"border_radius": 1, "surface": surface, "color": color, "points": points},
+        ]
+
+        for kwargs in kwargs_list:
+            bounds_rect = self.draw_polygon(**kwargs)
+
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_polygon__arg_border_radius_invalid_type(self):
+        """Ensures draw polygon detects invalid border_radius arg type."""
+        surface = pygame.Surface((400, 400))
+        color = pygame.Color("blue")
+        points = [[100,100], [300, 100], [300, 300], [100, 300]]
+
+        with self.assertRaises(TypeError):
+            # Invalid radius.
+            bounds_rect = self.draw_polygon(surface, color, points, 1, "1")
+    
+    def test_polygon__kwarg_border_radius_invalid_type_name(self):
+        """Ensures draw polygon detects invalid kwarg border_radius type and name."""
+        surface = pygame.Surface((400, 400))
+        color = pygame.Color("green")
+        points = [[100,100], [300, 100], [300, 300], [100, 300]]
+        width = 1
+        kwargs_list = [
+            {
+                "surface": surface,
+                "color": color,
+                "points": points,
+                "width": width,
+                "border_radius": "1" # Invalid border_radius type
+            },
+            {
+                "surface": surface,
+                "color": color,
+                "points": points,
+                "width": width,
+                "border_radius": 2.3 # Invalid border_radius type
+            },
+            {
+                "surface": surface,
+                "color": color,
+                "points": points,
+                "width": width,
+                "Invalid": 1 # Invalid border_radius name
+            },
+        ]
+
+        for kwargs in kwargs_list:
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_polygon(**kwargs)
+    
+    def test_polygon__args_and_kwargs_border_radius(self):
+        """Ensures draw polygon accepts a combination of args/kwargs with border_radius"""
+        surface = pygame.Surface((400, 400))
+        color = (255, 255, 0, 0)
+        points = [[100,100], [300, 100], [300, 300], [100, 300]]
+        width = 1
+        border_radius = 1
+        kwargs = {"surface": surface, "color": color, "points": points, "width": width, "border_radius": border_radius}
+
+        for name in ("surface", "color", "points", "width", "border_radius"):
+            kwargs.pop(name)
+
+            if "surface" == name:
+                bounds_rect = self.draw_polygon(surface, **kwargs)
+            elif "color" == name:
+                bounds_rect = self.draw_polygon(surface, color, **kwargs)
+            elif "points" == name:
+                bounds_rect = self.draw_polygon(surface, color, points, **kwargs)
+            elif "width" == name:
+                bounds_rect = self.draw_polygon(surface, color, points, width, **kwargs)
+            else:
+                bounds_rect = self.draw_polygon(surface, color, points, width, border_radius, **kwargs)
+
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+            
+    def test_polygon__valid_border_radius_values(self):
+        """Ensures draw polygon accepts different border_radius values."""
+        surface_color = pygame.Color("white")
+        surface = pygame.Surface((400, 400))
+        color = (10, 20, 30, 255)
+        kwargs = {
+            "surface": surface,
+            "color": color,
+            "points": [[100,100], [300, 100], [300, 300], [100, 300]],
+            "width": 1,
+            "border_radius": None,
+        }
+        
+        pos1 = kwargs["points"][0]
+        pos2 = kwargs["points"][1]
+        pos = ((pos1[0] + pos2[0]) / 2, (pos1[1] + pos2[1]) / 2)
+
+        for border_radius in (0, 1, 10, 50):
+            surface.fill(surface_color)
+            kwargs["border_radius"] = border_radius
+            expected_color = color
+
+            bounds_rect = self.draw_polygon(**kwargs)
+
+            self.assertEqual(surface.get_at(pos), expected_color)
+            self.assertIsInstance(bounds_rect, pygame.Rect)
 
 
 class DrawPolygonTest(DrawPolygonMixin, DrawTestCase):

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -3632,6 +3632,25 @@ CROSS = (
     [2, 2],
 )
 
+# Enlarged versions of the same shapes are utilized for testing purposes. This is because rounded polygons should possess sufficient size to visually demonstrate the curvature during the drawing process.
+LARGE_SQUARE = ([0, 0], [300, 0], [300, 300], [0, 300])
+LARGE_DIAMOND = [(100, 300), (300, 500), (500, 300), (300, 100)]
+LARGE_RHOMBUS = [(100, 300), (400, 500), (700, 300), (400, 100)]
+LARGE_CROSS = (
+    [200, 0],
+    [400, 0],
+    [400, 200],
+    [600, 200],
+    [600, 400],
+    [400, 400],
+    [400, 600],
+    [200, 600],
+    [200, 400],
+    [0, 400],
+    [0, 200],
+    [200, 200],
+)
+
 
 class DrawPolygonMixin:
     """Mixin tests for drawing polygons.
@@ -4377,6 +4396,103 @@ class DrawPolygonMixin:
 
             self.assertEqual(surface.get_at(pos), expected_color)
             self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_draw_round_square(self):
+        """Ensure square is drawn with rounded corner"""
+        surfw = surfh = 1000
+        polygon_color = pygame.Color("red")
+        surface_color = pygame.Color("black")
+        surface = pygame.Surface((surfw, surfh))
+        surface.fill(surface_color)
+
+        self.draw_polygon(surface, polygon_color, LARGE_SQUARE, 1, 5)
+
+        num_points = len(LARGE_SQUARE)
+
+        for i in range(num_points):
+            pos = x, y = LARGE_SQUARE[i]
+            x_next, y_next = LARGE_SQUARE[(i + 1) % num_points]
+            # Calculate the midpoint between the current point
+            # and the next point in the polygon.
+            mid = (x + x_next) / 2, (y + y_next) / 2
+            # The color at the current vertex should be equal
+            # to surface_color since the corner is rounded,
+            # while the color at the mid point of two consecutive
+            # vertices should always be equal to polygon_color
+            self.assertEqual(surface.get_at(pos), surface_color)
+            self.assertEqual(surface.get_at(mid), polygon_color)
+
+    def test_draw_round_diamond(self):
+        """Ensure diamond is drawn with rounded corner"""
+        surfw = surfh = 1000
+        polygon_color = pygame.Color("red")
+        surface_color = pygame.Color("black")
+        surface = pygame.Surface((surfw, surfh))
+        surface.fill(surface_color)
+
+        self.draw_polygon(surface, polygon_color, LARGE_DIAMOND, 1, 5)
+
+        num_points = len(LARGE_DIAMOND)
+        for i in range(num_points):
+            pos = x, y = LARGE_DIAMOND[i]
+            x_next, y_next = LARGE_DIAMOND[(i + 1) % num_points]
+            # Calculate the midpoint between the current point
+            # and the next point in the polygon.
+            mid = (x + x_next) / 2, (y + y_next) / 2
+            # The color at the current vertex should be equal
+            # to surface_color since the corner is rounded,
+            # while the color at the mid point of two consecutive
+            # vertices should always be equal to polygon_color
+            self.assertEqual(surface.get_at(pos), surface_color)
+            self.assertEqual(surface.get_at(mid), polygon_color)
+
+    def test_draw_round_rhombus(self):
+        """Ensure rhombus is drawn with rounded corner"""
+        surfw = surfh = 1000
+        polygon_color = pygame.Color("red")
+        surface_color = pygame.Color("black")
+        surface = pygame.Surface((surfw, surfh))
+        surface.fill(surface_color)
+
+        self.draw_polygon(surface, polygon_color, LARGE_RHOMBUS, 1, 5)
+
+        num_points = len(LARGE_RHOMBUS)
+        for i in range(num_points):
+            pos = x, y = LARGE_RHOMBUS[i]
+            x_next, y_next = LARGE_RHOMBUS[(i + 1) % num_points]
+            # Calculate the midpoint between the current point
+            # and the next point in the polygon.
+            mid = (x + x_next) / 2, (y + y_next) / 2
+            # The color at the current vertex should be equal
+            # to surface_color since the corner is rounded,
+            # while the color at the mid point of two consecutive
+            # vertices should always be equal to polygon_color
+            self.assertEqual(surface.get_at(pos), surface_color)
+            self.assertEqual(surface.get_at(mid), polygon_color)
+
+    def test_draw_round_cross(self):
+        """Ensure cross is drawn with rounded corner"""
+        surfw = surfh = 1000
+        polygon_color = pygame.Color("red")
+        surface_color = pygame.Color("black")
+        surface = pygame.Surface((surfw, surfh))
+        surface.fill(surface_color)
+
+        self.draw_polygon(surface, polygon_color, LARGE_CROSS, 1, 5)
+
+        num_points = len(LARGE_CROSS)
+        for i in range(num_points):
+            pos = x, y = LARGE_CROSS[i]
+            x_next, y_next = LARGE_CROSS[(i + 1) % num_points]
+            # Calculate the midpoint between the current point
+            # and the next point in the polygon.
+            mid = (x + x_next) / 2, (y + y_next) / 2
+            # The color at the current vertex should be equal
+            # to surface_color since the corner is rounded,
+            # while the color at the mid point of two consecutive
+            # vertices should always be equal to polygon_color
+            self.assertEqual(surface.get_at(pos), surface_color)
+            self.assertEqual(surface.get_at(mid), polygon_color)
 
 
 class DrawPolygonTest(DrawPolygonMixin, DrawTestCase):

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -3645,12 +3645,20 @@ class DrawPolygonMixin:
     def test_polygon__args(self):
         """Ensures draw polygon accepts the correct args."""
         bounds_rect = self.draw_polygon(
-            pygame.Surface((3, 3)), (0, 10, 0, 50), ((0, 0), (1, 1), (2, 2)), 1
+            pygame.Surface((3, 3)), (0, 10, 0, 50), ((0, 0), (1, 1), (2, 2)), 1, 1
         )
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
 
-    def test_polygon__args_without_width(self):
+    def test_polygon__args_without_radius(self):
+        """Ensures draw polygon accepts the args without a width."""
+        bounds_rect = self.draw_polygon(
+            pygame.Surface((2, 2)), (0, 0, 0, 50), ((0, 0), (1, 1), (2, 2)), 1
+        )
+
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+    
+    def test_polygon__args_without_width_nor_radius(self):
         """Ensures draw polygon accepts the args without a width."""
         bounds_rect = self.draw_polygon(
             pygame.Surface((2, 2)), (0, 0, 0, 50), ((0, 0), (1, 1), (2, 2))
@@ -3666,6 +3674,7 @@ class DrawPolygonMixin:
         color = pygame.Color("yellow")
         points = ((0, 0), (1, 1), (2, 2))
         kwargs_list = [
+            {"surface": surface, "color": color, "points": points, "width": 1, "border_radius": 1},
             {"surface": surface, "color": color, "points": points, "width": 1},
             {"surface": surface, "color": color, "points": points},
         ]
@@ -3680,6 +3689,7 @@ class DrawPolygonMixin:
         bounds_rect = self.draw_polygon(
             color=(10, 20, 30),
             surface=pygame.Surface((3, 2)),
+            border_radius=1,
             width=0,
             points=((0, 1), (1, 2), (2, 3)),
         )
@@ -3707,6 +3717,7 @@ class DrawPolygonMixin:
             "color": pygame.Color("red"),
             "points": ((2, 1), (2, 2), (2, 3)),
             "width": 1,
+            "border_radius": 1,
         }
 
         for name in ("points", "color", "surface"):
@@ -3722,6 +3733,10 @@ class DrawPolygonMixin:
         color = pygame.Color("blue")
         points = ((0, 1), (1, 2), (1, 3))
 
+        with self.assertRaises(TypeError):
+            # Invalid border_radius.
+            bounds_rect = self.draw_polygon(surface, color, points, 1, "1")
+        
         with self.assertRaises(TypeError):
             # Invalid width.
             bounds_rect = self.draw_polygon(surface, color, points, "1")
@@ -3744,27 +3759,44 @@ class DrawPolygonMixin:
         color = pygame.Color("green")
         points = ((0, 0), (1, 0), (2, 0))
         width = 1
+        border_radius = 1
         kwargs_list = [
             {
                 "surface": pygame.Surface,  # Invalid surface.
                 "color": color,
                 "points": points,
                 "width": width,
+                "border_radius": border_radius,
             },
             {
                 "surface": surface,
-                "color": 2.3,  # Invalid color.
+                "color": 2.3,   # Invalid color.
                 "points": points,
                 "width": width,
+                "border_radius": border_radius,
             },
             {
                 "surface": surface,
                 "color": color,
                 "points": ((1,), (1,), (1,)),  # Invalid points.
                 "width": width,
+                "border_radius": border_radius,
             },
-            {"surface": surface, "color": color, "points": points, "width": 1.2},
-        ]  # Invalid width.
+            {
+                "surface": surface,
+                "color": color,
+                "points": points,
+                "width": 1.2,   # Invalid width.
+                "border_radius": border_radius,
+            },
+            {
+                "surface": surface,
+                "color": color,
+                "points": points,
+                "width": width,
+                "border_radius": 2.3, # Invalid border_radius.
+            },
+        ]  
 
         for kwargs in kwargs_list:
             with self.assertRaises(TypeError):
@@ -3781,9 +3813,10 @@ class DrawPolygonMixin:
                 "color": color,
                 "points": points,
                 "width": 1,
+                "border_radius": 1,
                 "invalid": 1,
             },
-            {"surface": surface, "color": color, "points": points, "invalid": 1},
+            {"surface": surface, "color": color, "points": points, "invalid": 1, "border_radius": 1},
         ]
 
         for kwargs in kwargs_list:
@@ -3796,9 +3829,10 @@ class DrawPolygonMixin:
         color = (255, 255, 0, 0)
         points = ((0, 1), (1, 2), (2, 3))
         width = 0
-        kwargs = {"surface": surface, "color": color, "points": points, "width": width}
+        border_radius = 0
+        kwargs = {"surface": surface, "color": color, "points": points, "width": width, "border_radius": border_radius}
 
-        for name in ("surface", "color", "points", "width"):
+        for name in ("surface", "color", "points", "width", "border_radius"):
             kwargs.pop(name)
 
             if "surface" == name:
@@ -3807,11 +3841,13 @@ class DrawPolygonMixin:
                 bounds_rect = self.draw_polygon(surface, color, **kwargs)
             elif "points" == name:
                 bounds_rect = self.draw_polygon(surface, color, points, **kwargs)
-            else:
+            elif "width" == name:
                 bounds_rect = self.draw_polygon(surface, color, points, width, **kwargs)
+            else:
+                bounds_rect = self.draw_polygon(surface, color, points, width, border_radius, **kwargs)
 
             self.assertIsInstance(bounds_rect, pygame.Rect)
-
+    
     def test_polygon__valid_width_values(self):
         """Ensures draw polygon accepts different width values."""
         surface_color = pygame.Color("white")
@@ -3822,6 +3858,7 @@ class DrawPolygonMixin:
             "color": color,
             "points": ((1, 1), (2, 1), (2, 2), (1, 2)),
             "width": None,
+            "border_radius": 0,
         }
         pos = kwargs["points"][0]
 
@@ -3845,6 +3882,7 @@ class DrawPolygonMixin:
             "color": expected_color,
             "points": None,
             "width": 0,
+            "border_radius": 0,
         }
 
         # The point type can be a tuple/list/Vector2.
@@ -3885,6 +3923,7 @@ class DrawPolygonMixin:
             "color": pygame.Color("red"),
             "points": None,
             "width": 0,
+            "border_radius": 0,
         }
 
         points_fmts = (
@@ -3910,6 +3949,7 @@ class DrawPolygonMixin:
             "color": pygame.Color("red"),
             "points": None,
             "width": 0,
+            "border_radius": 1,
         }
 
         points_fmts = (
@@ -3935,6 +3975,7 @@ class DrawPolygonMixin:
             "color": None,
             "points": ((1, 1), (2, 1), (2, 2), (1, 2)),
             "width": 0,
+            "border_radius": 0,
         }
         pos = kwargs["points"][0]
         greens = (
@@ -3965,6 +4006,7 @@ class DrawPolygonMixin:
             "color": None,
             "points": ((1, 1), (2, 1), (2, 2), (1, 2)),
             "width": 0,
+            "border_radius": 0,
         }
 
         for expected_color in (2.3, self):
@@ -3974,7 +4016,7 @@ class DrawPolygonMixin:
                 bounds_rect = self.draw_polygon(**kwargs)
 
     def test_draw_square(self):
-        self.draw_polygon(self.surface, RED, SQUARE, 0)
+        self.draw_polygon(self.surface, RED, SQUARE, 0, 0)
         # note : there is a discussion (#234) if draw.polygon should include or
         # not the right or lower border; here we stick with current behavior,
         # e.g. include those borders ...
@@ -3984,7 +4026,7 @@ class DrawPolygonMixin:
 
     def test_draw_diamond(self):
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
-        self.draw_polygon(self.surface, GREEN, DIAMOND, 0)
+        self.draw_polygon(self.surface, GREEN, DIAMOND, 0, 0)
         # this diamond shape is equivalent to its four corners, plus inner square
         for x, y in DIAMOND:
             self.assertEqual(self.surface.get_at((x, y)), GREEN, msg=str((x, y)))
@@ -3995,7 +4037,7 @@ class DrawPolygonMixin:
     def test_1_pixel_high_or_wide_shapes(self):
         # 1. one-pixel-high, filled
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
-        self.draw_polygon(self.surface, GREEN, [(x, 2) for x, _y in CROSS], 0)
+        self.draw_polygon(self.surface, GREEN, [(x, 2) for x, _y in CROSS], 0, 0)
         cross_size = 6  # the maximum x or y coordinate of the cross
         for x in range(cross_size + 1):
             self.assertEqual(self.surface.get_at((x, 1)), RED)
@@ -4003,21 +4045,21 @@ class DrawPolygonMixin:
             self.assertEqual(self.surface.get_at((x, 3)), RED)
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
         # 2. one-pixel-high, not filled
-        self.draw_polygon(self.surface, GREEN, [(x, 5) for x, _y in CROSS], 1)
+        self.draw_polygon(self.surface, GREEN, [(x, 5) for x, _y in CROSS], 1, 0)
         for x in range(cross_size + 1):
             self.assertEqual(self.surface.get_at((x, 4)), RED)
             self.assertEqual(self.surface.get_at((x, 5)), GREEN)
             self.assertEqual(self.surface.get_at((x, 6)), RED)
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
         # 3. one-pixel-wide, filled
-        self.draw_polygon(self.surface, GREEN, [(3, y) for _x, y in CROSS], 0)
+        self.draw_polygon(self.surface, GREEN, [(3, y) for _x, y in CROSS], 0, 0)
         for y in range(cross_size + 1):
             self.assertEqual(self.surface.get_at((2, y)), RED)
             self.assertEqual(self.surface.get_at((3, y)), GREEN)
             self.assertEqual(self.surface.get_at((4, y)), RED)
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
         # 4. one-pixel-wide, not filled
-        self.draw_polygon(self.surface, GREEN, [(4, y) for _x, y in CROSS], 1)
+        self.draw_polygon(self.surface, GREEN, [(4, y) for _x, y in CROSS], 1, 0)
         for y in range(cross_size + 1):
             self.assertEqual(self.surface.get_at((3, y)), RED)
             self.assertEqual(self.surface.get_at((4, y)), GREEN)
@@ -4030,7 +4072,7 @@ class DrawPolygonMixin:
         """
         # 1. case width = 1 (not filled: `polygon` calls  internally the `lines` function)
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
-        self.draw_polygon(self.surface, GREEN, CROSS, 1)
+        self.draw_polygon(self.surface, GREEN, CROSS, 1, 0)
         inside = [(x, 3) for x in range(1, 6)] + [(3, y) for y in range(1, 6)]
         for x in range(10):
             for y in range(10):
@@ -4045,7 +4087,7 @@ class DrawPolygonMixin:
 
         # 2. case width = 0 (filled; this is the example from #234)
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
-        self.draw_polygon(self.surface, GREEN, CROSS, 0)
+        self.draw_polygon(self.surface, GREEN, CROSS, 0, 0)
         inside = [(x, 3) for x in range(1, 6)] + [(3, y) for y in range(1, 6)]
         for x in range(10):
             for y in range(10):
@@ -4091,7 +4133,7 @@ class DrawPolygonMixin:
         pygame.draw.rect(self.surface, RED, (0, 0, 20, 20), 0)
 
         # 1. First without the corners 4 & 5
-        self.draw_polygon(self.surface, GREEN, path_data[:4], 0)
+        self.draw_polygon(self.surface, GREEN, path_data[:4], 0, 0)
         for x in range(20):
             self.assertEqual(self.surface.get_at((x, 0)), GREEN)  # upper border
         for x in range(4, rect.width - 5 + 1):
@@ -4099,7 +4141,7 @@ class DrawPolygonMixin:
 
         # 2. with the corners 4 & 5
         pygame.draw.rect(self.surface, RED, (0, 0, 20, 20), 0)
-        self.draw_polygon(self.surface, GREEN, path_data, 0)
+        self.draw_polygon(self.surface, GREEN, path_data, 0, 0)
         for x in range(4, rect.width - 5 + 1):
             self.assertEqual(self.surface.get_at((x, 4)), GREEN)  # upper inner
 
@@ -4124,6 +4166,7 @@ class DrawPolygonMixin:
         sizes = ((min_width, min_height), (max_width, max_height))
         surface = pygame.Surface((20, 20), 0, 32)
         surf_rect = surface.get_rect()
+        border_radius = 0
         # Make a rect that is bigger than the surface to help test drawing
         # polygons off and partially off the surface.
         big_rect = surf_rect.inflate(min_width * 2 + 1, min_height * 2 + 1)
@@ -4151,7 +4194,7 @@ class DrawPolygonMixin:
                         surface.fill(surf_color)  # Clear for each test.
 
                         bounding_rect = self.draw_polygon(
-                            surface, polygon_color, vertices, thickness
+                            surface, polygon_color, vertices, thickness, border_radius
                         )
 
                         # Calculating the expected_rect after the polygon
@@ -4176,6 +4219,7 @@ class DrawPolygonMixin:
         surface_color = pygame.Color("green")
         surface = pygame.Surface((surfw, surfh))
         surface.fill(surface_color)
+        border_radius = 0
 
         clip_rect = pygame.Rect((0, 0), (8, 10))
         clip_rect.center = surface.get_rect().center
@@ -4195,7 +4239,7 @@ class DrawPolygonMixin:
                 )
                 surface.set_clip(None)
                 surface.fill(surface_color)
-                self.draw_polygon(surface, polygon_color, vertices, width)
+                self.draw_polygon(surface, polygon_color, vertices, width, border_radius)
                 expected_pts = get_color_points(surface, polygon_color, clip_rect)
 
                 # Clear the surface and set the clip area. Redraw the polygon
@@ -4203,7 +4247,7 @@ class DrawPolygonMixin:
                 surface.fill(surface_color)
                 surface.set_clip(clip_rect)
 
-                self.draw_polygon(surface, polygon_color, vertices, width)
+                self.draw_polygon(surface, polygon_color, vertices, width, border_radius)
 
                 surface.lock()  # For possible speed up.
 
@@ -4226,7 +4270,7 @@ class DrawPolygonMixin:
         """
         key_polygon_points = [(2, 2), (6, 2), (2, 4), (6, 4)]
         pygame.draw.rect(self.surface, RED, (0, 0, 10, 10), 0)
-        pygame.draw.polygon(self.surface, GREEN, RHOMBUS, 0)
+        pygame.draw.polygon(self.surface, GREEN, RHOMBUS, 0, 0)
         for x, y in key_polygon_points:
             self.assertEqual(self.surface.get_at((x, y)), GREEN, msg=str((x, y)))
 

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -3657,7 +3657,7 @@ class DrawPolygonMixin:
         )
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
-    
+
     def test_polygon__args_without_width_nor_radius(self):
         """Ensures draw polygon accepts the args without a width."""
         bounds_rect = self.draw_polygon(
@@ -3674,7 +3674,13 @@ class DrawPolygonMixin:
         color = pygame.Color("yellow")
         points = ((0, 0), (1, 1), (2, 2))
         kwargs_list = [
-            {"surface": surface, "color": color, "points": points, "width": 1, "border_radius": 1},
+            {
+                "surface": surface,
+                "color": color,
+                "points": points,
+                "width": 1,
+                "border_radius": 1,
+            },
             {"surface": surface, "color": color, "points": points, "width": 1},
             {"surface": surface, "color": color, "points": points},
         ]
@@ -3736,7 +3742,7 @@ class DrawPolygonMixin:
         with self.assertRaises(TypeError):
             # Invalid border_radius.
             bounds_rect = self.draw_polygon(surface, color, points, 1, "1")
-        
+
         with self.assertRaises(TypeError):
             # Invalid width.
             bounds_rect = self.draw_polygon(surface, color, points, "1")
@@ -3770,7 +3776,7 @@ class DrawPolygonMixin:
             },
             {
                 "surface": surface,
-                "color": 2.3,   # Invalid color.
+                "color": 2.3,  # Invalid color.
                 "points": points,
                 "width": width,
                 "border_radius": border_radius,
@@ -3786,7 +3792,7 @@ class DrawPolygonMixin:
                 "surface": surface,
                 "color": color,
                 "points": points,
-                "width": 1.2,   # Invalid width.
+                "width": 1.2,  # Invalid width.
                 "border_radius": border_radius,
             },
             {
@@ -3794,9 +3800,9 @@ class DrawPolygonMixin:
                 "color": color,
                 "points": points,
                 "width": width,
-                "border_radius": 2.3, # Invalid border_radius.
+                "border_radius": 2.3,  # Invalid border_radius.
             },
-        ]  
+        ]
 
         for kwargs in kwargs_list:
             with self.assertRaises(TypeError):
@@ -3816,7 +3822,13 @@ class DrawPolygonMixin:
                 "border_radius": 1,
                 "invalid": 1,
             },
-            {"surface": surface, "color": color, "points": points, "invalid": 1, "border_radius": 1},
+            {
+                "surface": surface,
+                "color": color,
+                "points": points,
+                "invalid": 1,
+                "border_radius": 1,
+            },
         ]
 
         for kwargs in kwargs_list:
@@ -3830,7 +3842,13 @@ class DrawPolygonMixin:
         points = ((0, 1), (1, 2), (2, 3))
         width = 0
         border_radius = 0
-        kwargs = {"surface": surface, "color": color, "points": points, "width": width, "border_radius": border_radius}
+        kwargs = {
+            "surface": surface,
+            "color": color,
+            "points": points,
+            "width": width,
+            "border_radius": border_radius,
+        }
 
         for name in ("surface", "color", "points", "width", "border_radius"):
             kwargs.pop(name)
@@ -3844,10 +3862,12 @@ class DrawPolygonMixin:
             elif "width" == name:
                 bounds_rect = self.draw_polygon(surface, color, points, width, **kwargs)
             else:
-                bounds_rect = self.draw_polygon(surface, color, points, width, border_radius, **kwargs)
+                bounds_rect = self.draw_polygon(
+                    surface, color, points, width, border_radius, **kwargs
+                )
 
             self.assertIsInstance(bounds_rect, pygame.Rect)
-    
+
     def test_polygon__valid_width_values(self):
         """Ensures draw polygon accepts different width values."""
         surface_color = pygame.Color("white")
@@ -4239,7 +4259,9 @@ class DrawPolygonMixin:
                 )
                 surface.set_clip(None)
                 surface.fill(surface_color)
-                self.draw_polygon(surface, polygon_color, vertices, width, border_radius)
+                self.draw_polygon(
+                    surface, polygon_color, vertices, width, border_radius
+                )
                 expected_pts = get_color_points(surface, polygon_color, clip_rect)
 
                 # Clear the surface and set the clip area. Redraw the polygon
@@ -4247,7 +4269,9 @@ class DrawPolygonMixin:
                 surface.fill(surface_color)
                 surface.set_clip(clip_rect)
 
-                self.draw_polygon(surface, polygon_color, vertices, width, border_radius)
+                self.draw_polygon(
+                    surface, polygon_color, vertices, width, border_radius
+                )
 
                 surface.lock()  # For possible speed up.
 


### PR DESCRIPTION
### This pull request resolves the enhancement issue #1527 (previously #3011)  about implementing the border radius for pygame.draw.polygon


# Overview
- Added a new parameter _border_radius_ to the **_pygame.draw.polygon_** function to specify the border radius of the rounded polygon corners.
- Updated the list of keywords in _**pygame.draw.polygon**_ to include _"border_radius"_ in the function signature.
- Added a new function **_draw_round_polygon_** to handle the drawing of rounded polygons. This function takes care of the logic for calculating rounded corners.
- Integrated this function as a part of _**polygon**_ in draw.c.

## Geometry Calculations:
- Implemented various geometric calculation functions, such as **_find_parallel_line_**, **_project_point_onto_segment_**, and **_intersection_**(to calculate intersections between two lines), _**angle**_, _**side**_ ….


# draw_round_polygon Function:

**static void draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int radius, int num_points, Uint32 color, int *drawn_area)**

## Purpose:
This function is responsible for drawing a rounded polygon with a specified border radius. It calculates and draws circular segments at each corner of the polygon.
Parameters:
- _surf:_ The target surface to draw on.
- _pts_x:_ Array of x-coordinates of polygon vertices.
- _pts_y:_ Array of y-coordinates of polygon vertices.
- _border_radius:_ The border radius of the rounded corners.
- _num_points_: Number of vertices in the polygon.
- _color_: Color of the polygon.
- _drawn_area_: Array to store the bounding box of the drawn area.

## Details:

### Path calculation loop:
- Coordinate Initialization: Initializes arrays and structures to store calculated points and circles.
- Parallel Line Calculation: The **_find_parallel_line_** function calculates two parallel lines given three points: the current vertex and its adjacent vertices. The function ensures that the parallel lines are on the correct side of the vertex.
- Circle and Path Calculation: The center of the circular segment is found by calculating the intersection of two parallel lines (line1 and line2) using the **_intersection_** function.
- The circular arc's starting and ending points are obtained by projecting the center onto adjacent line segments using the **_project_point_onto_segment_** function.
- Stores these points in the path array.

### Drawing loop:
- For each segment in the path array, it calculates start and end angles and draws the circular arc using the **_draw_arc_** function.
- Draws a straight line between consecutive circular arcs.


## Debugging Output:
- During the calculation loop, if three consecutive points are aligned the loop is interrupted with a return statement to abort the function.
- A condition on the border_radius is verified on each vertex, at each iteration, to avoid incorrect drawing. if the condition is not satisfied the function is aborted.
- As the draw_round_polygon function returns void (a choice made to align with the same logic of other drawing functions), it is not possible to raise an error directly from draw_round_polygon. Instead, we settle for a return statement whenever an error should be raised to abort the function, and a printf of the error message.
