### PR TITLE
Update always_on_top doc (it's not x11 only)

### DIFF
--- a/docs/reST/ref/window.rst
+++ b/docs/reST/ref/window.rst
@@ -42,8 +42,8 @@
    :param bool allow_highdpi: Create a window in high-DPI mode if supported.
    :param bool mouse_capture: Create a window that has the mouse captured
                               (unrelated to INPUT_GRABBED).
-   :param bool always_on_top: Create a window that is always on top
-                              (X11 only).
+   :param bool always_on_top: Create a window that is always presented above
+                              others.
 
    .. versionadded:: 2.4.0
 


### PR DESCRIPTION
The SDL2 docs say it is, but the SDL2 source has support for Mac/Windows/Linux. I tested it on Windows and it worked fine.

Relevant issue: #2603 