### PR TITLE
Deprecate from_display_module

### DIFF
--- a/docs/reST/ref/window.rst
+++ b/docs/reST/ref/window.rst
@@ -247,8 +247,13 @@
       | :sl:`Create a Window object using window data from display module`
       | :sg:`from_display_module() -> Window`
 
+      **DON'T USE THIS!** If you want to draw to a surface and use the window
+      API, use :func:`Window.get_surface` and :func:`Window.flip`.
+
       Create a Window object that uses the same window data from the :mod:`pygame.display` module, created upon calling
       :func:`pygame.display.set_mode`.
+
+      .. deprecated:: 2.4.0
 
    .. method:: get_surface
 

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -965,15 +965,22 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
 static PyObject *
 window_from_display_module(PyTypeObject *cls, PyObject *_null)
 {
-    SDL_Window *window;
-    pgWindowObject *self;
-    window = pg_GetDefaultWindow();
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "Please use Window.get_surface and Window.flip to use "
+                     "surface-rendering with Window. This method will be "
+                     "removed in a future version.",
+                     1) == -1) {
+        return NULL;
+    }
+
+    SDL_Window *window = pg_GetDefaultWindow();
     if (!window) {
         return RAISE(pgExc_SDLError,
                      "display.set_mode has not been called yet.");
     }
 
-    self = (pgWindowObject *)SDL_GetWindowData(window, "pg_window");
+    pgWindowObject *self =
+        (pgWindowObject *)SDL_GetWindowData(window, "pg_window");
     if (self != NULL) {
         Py_INCREF(self);
         return (PyObject *)self;


### PR DESCRIPTION
For #2603 

Making this work in an actually fool proof way would be a nightmare. Now that windows can have their own display surface management, there is no need for this function.

Why not just remove it? It's too widely used. I dislike this fact, but this "experimental api" (for this function) has enough users that I think it's worth giving it an actual deprecation and not just removing it.