### PR TITLE
Start 2.5.0

### DIFF
--- a/docs/reST/conf.py
+++ b/docs/reST/conf.py
@@ -47,9 +47,9 @@ copyright = '2000-2022, pygame developers, 2023 pygame-ce developers'
 # built documents.
 #
 # The short X.Y version.
-version = '2.4.0'
+version = '2.5.0'
 # The full version, including alpha/beta/rc tags.
-release = '2.4.0.dev5'
+release = '2.5.0.dev1'
 
 # Format strings for the version directives
 versionadded_format = 'New in pygame-ce %s'

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ EXTRAS = {}
 
 METADATA = {
     "name": "pygame-ce",
-    "version": "2.4.0.dev5",
+    "version": "2.5.0.dev1",
     "license": "LGPL",
     "url": "https://pyga.me",
     "author": "A community project.",

--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -56,11 +56,11 @@
 
 /* version macros (defined since version 1.9.5) */
 #define PG_MAJOR_VERSION 2
-#define PG_MINOR_VERSION 4
+#define PG_MINOR_VERSION 5
 #define PG_PATCH_VERSION 0
 /* The below is of the form ".devX" for dev releases, and "" (empty) for full
  * releases */
-#define PG_VERSION_TAG ".dev5"
+#define PG_VERSION_TAG ".dev1"
 #define PG_VERSIONNUM(MAJOR, MINOR, PATCH) \
     (1000 * (MAJOR) + 100 * (MINOR) + (PATCH))
 #define PG_VERSION_ATLEAST(MAJOR, MINOR, PATCH)                             \


### PR DESCRIPTION
Since this is before the release of 2.4.0 final, regression and bug fixes will need to be backported to the 2.4.x branch, and the release can happen from there.

This PR brings main up to 2.5.0 so development can continue without a merge freeze in the ~week predicted until 2.4.0 release (maybe longer if something comes up)