### PR TITLE
Improved `Window.flip` error message when no surface is associated with the `Window`

### DIFF
--- a/src_c/window.c
+++ b/src_c/window.c
@@ -183,17 +183,16 @@ window_flip(pgWindowObject *self)
 {
     int result;
 
-    VIDEO_INIT_CHECK();
+    if (!self->surf) {
+        return RAISE(pgExc_SDLError,
+                     "the Window has no surface associated with it, did "
+                     "you forget to call Window.get_surface()");
+    }
 
     Py_BEGIN_ALLOW_THREADS;
     result = SDL_UpdateWindowSurface(self->_win);
     Py_END_ALLOW_THREADS;
     if (result) {
-        if (!self->surf) {
-            return RAISE(pgExc_SDLError,
-                         "the Window has no surface associated with it, did "
-                         "you forget to call Window.get_surface()");
-        }
         return RAISE(pgExc_SDLError, SDL_GetError());
     }
     Py_RETURN_NONE;

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -183,11 +183,19 @@ window_flip(pgWindowObject *self)
 {
     int result;
 
+    VIDEO_INIT_CHECK();
+
     Py_BEGIN_ALLOW_THREADS;
     result = SDL_UpdateWindowSurface(self->_win);
     Py_END_ALLOW_THREADS;
-    if (result)
+    if (result) {
+        if (!self->surf) {
+            return RAISE(pgExc_SDLError,
+                         "the Window has no surface associated with it, did "
+                         "you forget to call Window.get_surface()");
+        }
         return RAISE(pgExc_SDLError, SDL_GetError());
+    }
     Py_RETURN_NONE;
 }
 

--- a/test/window_test.py
+++ b/test/window_test.py
@@ -360,6 +360,15 @@ class WindowTypeTest(unittest.TestCase):
         self.assertIs(win.flip(), None)
         win.destroy()
 
+        # creates a new window with no surface associated
+        win = Window(size=(640, 480))
+        self.assertRaisesRegex(
+            pygame.error,
+            "the Window has no surface associated with it, did you forget to call Window.get_surface()",
+            win.flip,
+        )
+        win.destroy()
+
     def tearDown(self):
         self.win.destroy()
 


### PR DESCRIPTION
Previously the error message would have been `"Window surface is invalid, please call SDL_GetWindowSurface() to get a new surface"`

This also adds a video init check, which is related to this issue: https://github.com/pygame-community/pygame-ce/issues/2605
But I don't know if it should stay here, because if, for instance, we implicitly init video on Window creation, this check shouldn't be needed here?