### PR TITLE
Camera: OpenCV Backend Fixed

### DIFF
--- a/src_py/_camera_opencv.py
+++ b/src_py/_camera_opencv.py
@@ -71,7 +71,11 @@ class Camera:
         self._flipy = False
         self._brightness = 1
 
+        if self._cam.get(cv2.CAP_PROP_FPS) == 0:
+            raise ZeroDivisionError("Camera returning 0 FPS. Device ID:",self._device_index)
+
         self._frametime = 1 / self._cam.get(cv2.CAP_PROP_FPS)
+
         self._last_frame_time = 0
 
         self._open = True


### PR DESCRIPTION
Fixes the issue in #2458 and #2050 where the OpenCV backend can return 0 FPS, resulting in an error.

All I've done is added exception handling to let the programmer know that there's an issue with the camera FPS. There's still an error, but the error message is more descriptive than a "ZeroDivisionError: Divide by Zero".

To test, you can use the "OpenCV" backend in any camera code, I used the "examples/camera.py" to test.