### PR TITLE
Call `PyObject_GetBuffer` directly, fix pypy fail

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -1148,12 +1148,9 @@ pgObject_GetBuffer(PyObject *obj, pg_buffer *pg_view_p, int flags)
     flags |= PyBUF_PYGAME;
 #endif
 
-    if (PyObject_CheckBuffer(obj)) {
+    if (PyObject_GetBuffer(obj, view_p, flags) == 0) {
         char *fchar_p;
 
-        if (PyObject_GetBuffer(obj, view_p, flags)) {
-            return -1;
-        }
         pg_view_p->release_buffer = PyBuffer_Release;
 
         /* Check the format is a numeric type or pad bytes
@@ -1224,6 +1221,9 @@ pgObject_GetBuffer(PyObject *obj, pg_buffer *pg_view_p, int flags)
             return -1;
         }
         success = 1;
+    }
+    else {
+        PyErr_Clear();
     }
 
     if (!success && pgGetArrayStruct(obj, &cobj, &inter_p) == 0) {


### PR DESCRIPTION
So, with the latest pypy version, we have new test fails. What's happening now on pypy is that `PyObject_CheckBuffer` passes but `PyObject_GetBuffer` fails, and the old code is forwarding the error in this case, but it's better to instead go down the array interface/struct fallback and then error if all those fail.

I have intentionally kept this PR minimal so that it is easy to review, despite my itch to refactor the whole function to make it neater :)