### PR TITLE
Remove `HAVE_NEWBUF` checks in tests

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -349,12 +349,6 @@ typedef enum {
     PGS_PREALLOC = 0x01000000
 } PygameSurfaceFlags;
 
-// TODO Implement check below in a way that does not break CI
-/* New buffer protocol (PEP 3118) implemented on all supported Py versions.
-#if !defined(Py_TPFLAGS_HAVE_NEWBUFFER)
-#error No support for PEP 3118/Py_TPFLAGS_HAVE_NEWBUFFER. Please use a
-supported Python version. #endif */
-
 #define RAISE(x, y) (PyErr_SetString((x), (y)), NULL)
 #define RAISERETURN(x, y, r)   \
     PyErr_SetString((x), (y)); \

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1005,8 +1005,7 @@ static PyTypeObject pgSound_Type = {
     .tp_basicsize = sizeof(pgSoundObject),
     .tp_dealloc = (destructor)sound_dealloc,
     .tp_as_buffer = sound_as_buffer,
-    .tp_flags =
-        (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_NEWBUFFER),
+    .tp_flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE),
     .tp_doc = DOC_MIXER_SOUND,
     .tp_weaklistoffset = offsetof(pgSoundObject, weakreflist),
     .tp_methods = sound_methods,

--- a/src_c/pgcompat.h
+++ b/src_c/pgcompat.h
@@ -17,8 +17,4 @@
 
 #define RELATIVE_MODULE(m) ("." m)
 
-#ifndef Py_TPFLAGS_HAVE_NEWBUFFER
-#define Py_TPFLAGS_HAVE_NEWBUFFER 0
-#endif
-
 #endif /* ~PGCOMPAT_INTERNAL_H */

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -193,8 +193,7 @@ class BaseModuleTest(unittest.TestCase):
             o = Exporter(shape, typechar, itemsize)
             self.assertEqual(getrefcount(o.__array_struct__), 1)
 
-    if pygame.HAVE_NEWBUF:
-        from pygame.tests.test_utils import buftools
+    from pygame.tests.test_utils import buftools
 
     def NEWBUF_assertSame(self, proxy, exp):
         buftools = self.buftools
@@ -209,7 +208,6 @@ class BaseModuleTest(unittest.TestCase):
         self.assertEqual(imp.strides, exp.strides)
         self.assertTrue(imp.suboffsets is None)
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     @unittest.skipIf(IS_PYPY, "pypy no likey")
     def test_newbuf(self):
         from pygame.bufferproxy import BufferProxy
@@ -250,7 +248,6 @@ class BaseModuleTest(unittest.TestCase):
             v = BufferProxy(o)
             self.NEWBUF_assertSame(v, o)
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     def test_bad_format(self):
         from pygame.bufferproxy import BufferProxy
         from pygame.newbuffer import BufferMixin
@@ -280,7 +277,6 @@ class BaseModuleTest(unittest.TestCase):
             b = BufferProxy(exp)
             self.assertRaises(ValueError, Importer, b, PyBUF_FORMAT)
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     @unittest.skipIf(IS_PYPY, "fails on pypy")
     def test_PgDict_AsBuffer_PyBUF_flags(self):
         from pygame.bufferproxy import BufferProxy
@@ -382,7 +378,7 @@ class BaseModuleTest(unittest.TestCase):
         self.assertEqual(b.buf, 1000000)
         self.assertRaises(BufferError, Importer, a, buftools.PyBUF_FULL)
 
-    @unittest.skipIf(IS_PYPY or (not pygame.HAVE_NEWBUF), "newbuf with ctypes")
+    @unittest.skipIf(IS_PYPY, "newbuf with ctypes")
     def test_PgObject_AsBuffer_PyBUF_flags(self):
         from pygame.bufferproxy import BufferProxy
         import ctypes

--- a/test/bufferproxy_test.py
+++ b/test/bufferproxy_test.py
@@ -255,7 +255,6 @@ class BufferProxyTest(unittest.TestCase):
         self.assertEqual(r[:2], "*<")
         self.assertEqual(r[-2:], ">*")
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     def NEWBUF_test_newbuf(self):
         from ctypes import string_at
 

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -1088,7 +1088,6 @@ class ColorTypeTest(unittest.TestCase):
             for j in range(i):
                 self.assertEqual(data[j], c[j])
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     def test_newbuf(self):
         from pygame.tests.test_utils import buftools
         from ctypes import cast, POINTER, c_uint8

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1246,7 +1246,6 @@ class FreeTypeFontTest(unittest.TestCase):
 
         self.assertRaises(AttributeError, setattr, f, "bgcolor", None)
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     @unittest.skipIf(IS_PYPY, "pypy no likey")
     def test_newbuf(self):
         from pygame.tests.test_utils import buftools

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -359,13 +359,11 @@ class MixerModuleTest(unittest.TestCase):
         self.assertEqual(d["strides"], (2,))
         self.assertEqual(d["data"], (snd._samples_address, False))
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     @unittest.skipIf(IS_PYPY, "pypy no likey")
     def test_newbuf__one_channel(self):
         mixer.init(22050, -16, 1)
         self._NEWBUF_export_check()
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     @unittest.skipIf(IS_PYPY, "pypy no likey")
     def test_newbuf__twho_channel(self):
         mixer.init(22050, -16, 2)

--- a/test/pixelarray_test.py
+++ b/test/pixelarray_test.py
@@ -1450,11 +1450,9 @@ class PixelArrayArrayInterfaceTest(unittest.TestCase, TestMixin):
             self.assert_surfaces_equal(sf3, sf2)
 
 
-@unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
 @unittest.skipIf(IS_PYPY, "pypy having issues")
 class PixelArrayNewBufferTest(unittest.TestCase, TestMixin):
-    if pygame.HAVE_NEWBUF:
-        from pygame.tests.test_utils import buftools
+    from pygame.tests.test_utils import buftools
 
     bitsize_to_format = {8: "B", 16: "=H", 24: "3x", 32: "=I"}
 

--- a/test/pixelcopy_test.py
+++ b/test/pixelcopy_test.py
@@ -593,43 +593,41 @@ class PixelCopyTestWithArrayNumpy(unittest.TestCase):
         del numpy
 
 
-@unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
 @unittest.skipIf(IS_PYPY, "pypy having illegal instruction on mac")
 class PixelCopyTestWithArrayNewBuf(unittest.TestCase):
-    if pygame.HAVE_NEWBUF:
-        from pygame.tests.test_utils import buftools
+    from pygame.tests.test_utils import buftools
 
-        class Array2D(buftools.Exporter):
-            def __init__(self, initializer):
-                from ctypes import cast, POINTER, c_uint32
+    class Array2D(buftools.Exporter):
+        def __init__(self, initializer):
+            from ctypes import cast, POINTER, c_uint32
 
-                Array2D = PixelCopyTestWithArrayNewBuf.Array2D
-                super().__init__((3, 5), format="=I", strides=(20, 4))
-                self.content = cast(self.buf, POINTER(c_uint32))
-                for i, v in enumerate(initializer):
-                    self.content[i] = v
+            Array2D = PixelCopyTestWithArrayNewBuf.Array2D
+            super().__init__((3, 5), format="=I", strides=(20, 4))
+            self.content = cast(self.buf, POINTER(c_uint32))
+            for i, v in enumerate(initializer):
+                self.content[i] = v
 
-            def __getitem__(self, key):
-                byte_index = key[0] * 5 + key[1]
-                if not (0 <= byte_index < 15):
-                    raise IndexError("%s is out of range", key)
-                return self.content[byte_index]
+        def __getitem__(self, key):
+            byte_index = key[0] * 5 + key[1]
+            if not (0 <= byte_index < 15):
+                raise IndexError("%s is out of range", key)
+            return self.content[byte_index]
 
-        class Array3D(buftools.Exporter):
-            def __init__(self, initializer):
-                from ctypes import cast, POINTER, c_uint8
+    class Array3D(buftools.Exporter):
+        def __init__(self, initializer):
+            from ctypes import cast, POINTER, c_uint8
 
-                Array3D = PixelCopyTestWithArrayNewBuf.Array3D
-                super().__init__((3, 5, 3), format="B", strides=(20, 4, 1))
-                self.content = cast(self.buf, POINTER(c_uint8))
-                for i, v in enumerate(initializer):
-                    self.content[i] = v
+            Array3D = PixelCopyTestWithArrayNewBuf.Array3D
+            super().__init__((3, 5, 3), format="B", strides=(20, 4, 1))
+            self.content = cast(self.buf, POINTER(c_uint8))
+            for i, v in enumerate(initializer):
+                self.content[i] = v
 
-            def __getitem__(self, key):
-                byte_index = key[0] * 20 + key[1] * 4 + key[2]
-                if not (0 <= byte_index < 60):
-                    raise IndexError("%s is out of range", key)
-                return self.content[byte_index]
+        def __getitem__(self, key):
+            byte_index = key[0] * 20 + key[1] * 4 + key[2]
+            if not (0 <= byte_index < 60):
+                raise IndexError("%s is out of range", key)
+            return self.content[byte_index]
 
     surface = pygame.Surface((3, 5), 0, 32)
 

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -3001,7 +3001,6 @@ class SurfaceGetBufferTest(unittest.TestCase):
                 s = pygame.Surface((4, 2), 0, 32)
                 self._check_interface_rgba(s, plane)
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     def test_newbuf_PyBUF_flags_bytes(self):
         from pygame.tests.test_utils import buftools
 
@@ -3061,7 +3060,6 @@ class SurfaceGetBufferTest(unittest.TestCase):
         self.assertEqual(b.ndim, 1)
         self.assertEqual(b.strides, (1,))
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     def test_newbuf_PyBUF_flags_0D(self):
         # This is the same handler as used by get_buffer(), so just
         # confirm that it succeeds for one case.
@@ -3081,7 +3079,6 @@ class SurfaceGetBufferTest(unittest.TestCase):
         self.assertFalse(b.readonly)
         self.assertEqual(b.buf, s._pixels_address)
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     def test_newbuf_PyBUF_flags_1D(self):
         from pygame.tests.test_utils import buftools
 
@@ -3120,7 +3117,6 @@ class SurfaceGetBufferTest(unittest.TestCase):
         self.assertTrue(b.format is None)
         self.assertEqual(b.strides, (s.get_bytesize(),))
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     def test_newbuf_PyBUF_flags_2D(self):
         from pygame.tests.test_utils import buftools
 
@@ -3191,7 +3187,6 @@ class SurfaceGetBufferTest(unittest.TestCase):
         self.assertRaises(BufferError, Importer, a, buftools.PyBUF_F_CONTIGUOUS)
         self.assertRaises(BufferError, Importer, a, buftools.PyBUF_ANY_CONTIGUOUS)
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     def test_newbuf_PyBUF_flags_3D(self):
         from pygame.tests.test_utils import buftools
 
@@ -3242,7 +3237,6 @@ class SurfaceGetBufferTest(unittest.TestCase):
         self.assertRaises(BufferError, Importer, a, buftools.PyBUF_F_CONTIGUOUS)
         self.assertRaises(BufferError, Importer, a, buftools.PyBUF_ANY_CONTIGUOUS)
 
-    @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     def test_newbuf_PyBUF_flags_rgba(self):
         # All color plane views are handled by the same routine,
         # so only one plane need be checked.

--- a/test/test_utils/buftools.py
+++ b/test/test_utils/buftools.py
@@ -21,9 +21,6 @@ python -m pygame.tests.test_utils.array
 """
 import pygame
 
-if not pygame.HAVE_NEWBUF:
-    emsg = "This Pygame build does not support the new buffer protocol"
-    raise ImportError(emsg)
 import pygame.newbuffer
 from pygame.newbuffer import (
     PyBUF_SIMPLE,


### PR DESCRIPTION
Just a minor code cleanup: `HAVE_NEWBUF` is a constant that is always defined to `1` in the source. So there's no need to check for it anymore