### PR TITLE
Add mp3 file-like object tests

### DIFF
--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -55,6 +55,9 @@ class MixerMusicModuleTest(unittest.TestCase):
     def test_load_object(self):
         """test loading music from file-like objects."""
         filenames = ["house_lo.ogg", "house_lo.wav", "surfonasinewave.xm"]
+        if pygame.mixer.get_sdl_mixer_version() >= (2, 6, 0):
+            filenames.append("house_lo.mp3")
+
         data_fname = example_path("data")
         for file in filenames:
             path = os.path.join(data_fname, file)
@@ -68,6 +71,9 @@ class MixerMusicModuleTest(unittest.TestCase):
     def test_object_namehint(self):
         """test loading & queuing music from file-like objects with namehint argument."""
         filenames = ["house_lo.ogg", "house_lo.wav", "surfonasinewave.xm"]
+        if pygame.mixer.get_sdl_mixer_version() >= (2, 6, 0):
+            filenames.append("house_lo.mp3")
+
         data_fname = example_path("data")
         for file in filenames:
             path = os.path.join(data_fname, file)


### PR DESCRIPTION
fixes #2154

Apparently, the issue here is that mp3 file-like objects are not handled properly in SDL_mixer < 2.6.0 (which is what both our ubuntu builds are on ATM). So include these tests, but only if SDL_mixer is newer than 2.6.0