### PR TITLE
Remove shuffle masks in AVX fillers

### DIFF
--- a/src_c/simd_surface_fill_avx2.c
+++ b/src_c/simd_surface_fill_avx2.c
@@ -86,31 +86,22 @@ _pg_has_avx2()
 
 /* Setup for RUN_16BIT_SHUFFLE_OUT */
 #define SETUP_SHUFFLE                                                         \
-    __m256i shuff_out_A =                                                     \
-        _mm256_set_epi8(0x80, 23, 0x80, 22, 0x80, 21, 0x80, 20, 0x80, 19,     \
-                        0x80, 18, 0x80, 17, 0x80, 16, 0x80, 7, 0x80, 6, 0x80, \
-                        5, 0x80, 4, 0x80, 3, 0x80, 2, 0x80, 1, 0x80, 0);      \
-                                                                              \
-    __m256i shuff_out_B = _mm256_set_epi8(                                    \
-        0x80, 31, 0x80, 30, 0x80, 29, 0x80, 28, 0x80, 27, 0x80, 26, 0x80, 25, \
-        0x80, 24, 0x80, 15, 0x80, 14, 0x80, 13, 0x80, 12, 0x80, 11, 0x80, 10, \
-        0x80, 9, 0x80, 8);                                                    \
-                                                                              \
-    __m256i shuff_dst, _shuff16_temp, mm256_colorA, mm256_colorB;             \
-    mm256_colorA = _mm256_shuffle_epi8(mm256_color, shuff_out_A);             \
-    mm256_colorB = _mm256_shuffle_epi8(mm256_color, shuff_out_B);
+    __m256i shuff_dst, _shuff16_temp, mm256_colorA, mm256_colorB, mm256_zero; \
+    mm256_zero = _mm256_setzero_si256();                                      \
+    mm256_colorA = _mm256_unpacklo_epi8(mm256_color, mm256_zero);             \
+    mm256_colorB = _mm256_unpackhi_epi8(mm256_color, mm256_zero);
 
 #define RUN_16BIT_SHUFFLE_OUT(FILL_CODE)                       \
     /* ==== shuffle pixels out into two registers each, src */ \
     /* and dst set up for 16 bit math, like 0A0R0G0B ==== */   \
-    shuff_dst = _mm256_shuffle_epi8(mm256_dst, shuff_out_A);   \
+    shuff_dst = _mm256_unpacklo_epi8(mm256_dst, mm256_zero);   \
     mm256_color = mm256_colorA;                                \
                                                                \
     {FILL_CODE}                                                \
                                                                \
     _shuff16_temp = shuff_dst;                                 \
                                                                \
-    shuff_dst = _mm256_shuffle_epi8(mm256_dst, shuff_out_B);   \
+    shuff_dst = _mm256_unpackhi_epi8(mm256_dst, mm256_zero);   \
     mm256_color = mm256_colorB;                                \
                                                                \
     {FILL_CODE}                                                \


### PR DESCRIPTION
This PR gets rid of some masks we used for shuffling since we can achieve the same result with simpler code all at the same performance.

new:
```
Flag: BLEND_SUB
fill: 0.023698640009388327
blit: 0.027505460020620376
--------------------
Flag: BLEND_ADD
fill: 0.02056832000380382
blit: 0.02708268000278622
--------------------
Flag: BLEND_MULT
fill: 0.03269677999196574
blit: 0.04088069999124855
--------------------
Flag: BLEND_MIN
fill: 0.01716678000520915
blit: 0.02253773999400437
--------------------
Flag: BLEND_MAX
fill: 0.01713769999332726
blit: 0.022413880005478858
--------------------
```

old:
```
Flag: BLEND_SUB
fill: 0.02369291998911649
blit: 0.0274960600072518
--------------------
Flag: BLEND_ADD
fill: 0.020125439984258264
blit: 0.027089380007237197
--------------------
Flag: BLEND_MULT
fill: 0.032841119973454624
blit: 0.04257354000583291
--------------------
Flag: BLEND_MIN
fill: 0.01882048000115901
blit: 0.022260580002330242
--------------------
Flag: BLEND_MAX
fill: 0.01668819998158142
blit: 0.022541640000417827
--------------------

```
Test Program:
```Py
from timeit import repeat

import pygame

pygame.init()

surf = pygame.Surface((500, 500))
surf.fill((132, 33, 200))

color = pygame.Surface((500, 500))
color.fill((24, 24, 24))

flags = [
    "BLEND_SUB",
    "BLEND_ADD",
    "BLEND_MULT",
    "BLEND_MIN",
    "BLEND_MAX",
]

G = globals()

for flag in flags:
    print(f"Flag: {flag}")
    teststr = "surf.fill((24, 24, 24), None, pygame." + flag + ")"
    l = [min(repeat(teststr, globals=G, number=1000, repeat=10)) for _ in range(5)]
    print(f"fill: {sum(l) / len(l)}")

    teststr = "surf.blit(color, (0, 0), None, pygame." + flag + ")"
    l = [min(repeat(teststr, globals=G, number=1000, repeat=10)) for _ in range(5)]
    print(f"blit: {sum(l) / len(l)}")
    print("-" * 20)
```