### PR TITLE
support emsdk >3.1.51

### DIFF
--- a/buildconfig/Setup.Emscripten.SDL2.in
+++ b/buildconfig/Setup.Emscripten.SDL2.in
@@ -6,7 +6,8 @@
 #MIXER = -lSDL2_mixer
 #SCRAP =
 #FREETYPE = -lfreetype -lharfbuzz
-
+PNG = -lpng
+JPEG = -ljpeg
 DEBUG =
 
 # these can build alone and object files merged with ar

--- a/buildconfig/Setup.Emscripten.SDL2.in
+++ b/buildconfig/Setup.Emscripten.SDL2.in
@@ -6,6 +6,9 @@
 #MIXER = -lSDL2_mixer
 #SCRAP =
 #FREETYPE = -lfreetype -lharfbuzz
+
+# png and jpeg are needed for decoders in SDL_image, when not using emscripten preload api because its async
+# which is the case for both pygbag or wasi (no browser, no emscripten js api emulation)
 PNG = -lpng
 JPEG = -ljpeg
 DEBUG =


### PR DESCRIPTION
since https://github.com/pygame-community/pygame-ce/pull/2596 static.c build was silently ignored (commented by setuptools) because PNG/JPEG not set anymore in Setup as emsdk is only an additional_platform_setup to config_unix

patch tested against 3.1.52 with pygbag : pygame-ce 2.5.0.dev1 (SDL 2.24.2, Python 3.11.7)