### PR TITLE
SIMD surface.fill

### DIFF
--- a/src_c/simd_fill.h
+++ b/src_c/simd_fill.h
@@ -45,6 +45,9 @@ _pg_HasSSE_NEON();
 
 // AVX2 functions
 int
+surface_fill_blend_rgba_none_avx2(SDL_Surface *surface, SDL_Rect *rect,
+                             Uint32 color);
+int
 surface_fill_blend_add_avx2(SDL_Surface *surface, SDL_Rect *rect,
                             Uint32 color);
 int
@@ -76,6 +79,9 @@ int
 surface_fill_blend_rgba_max_avx2(SDL_Surface *surface, SDL_Rect *rect,
                                  Uint32 color);
 // SSE2 functions
+int
+surface_fill_blend_rgba_none_sse2(SDL_Surface *surface, SDL_Rect *rect,
+                            Uint32 color);
 int
 surface_fill_blend_add_sse2(SDL_Surface *surface, SDL_Rect *rect,
                             Uint32 color);

--- a/src_c/simd_fill.h
+++ b/src_c/simd_fill.h
@@ -46,7 +46,7 @@ _pg_HasSSE_NEON();
 // AVX2 functions
 int
 surface_fill_blend_rgba_none_avx2(SDL_Surface *surface, SDL_Rect *rect,
-                             Uint32 color);
+                                  Uint32 color);
 int
 surface_fill_blend_add_avx2(SDL_Surface *surface, SDL_Rect *rect,
                             Uint32 color);
@@ -81,7 +81,7 @@ surface_fill_blend_rgba_max_avx2(SDL_Surface *surface, SDL_Rect *rect,
 // SSE2 functions
 int
 surface_fill_blend_rgba_none_sse2(SDL_Surface *surface, SDL_Rect *rect,
-                            Uint32 color);
+                                  Uint32 color);
 int
 surface_fill_blend_add_sse2(SDL_Surface *surface, SDL_Rect *rect,
                             Uint32 color);

--- a/src_c/simd_surface_fill_avx2.c
+++ b/src_c/simd_surface_fill_avx2.c
@@ -166,6 +166,7 @@ _pg_has_avx2()
         return -1;                                                          \
     }
 
+#define NONE_CODE mm256_dst = mm256_color;
 #define ADD_CODE mm256_dst = _mm256_adds_epu8(mm256_dst, mm256_color);
 #define SUB_CODE mm256_dst = _mm256_subs_epu8(mm256_dst, mm256_color);
 #define MIN_CODE mm256_dst = _mm256_min_epu8(mm256_dst, mm256_color);
@@ -179,12 +180,14 @@ _pg_has_avx2()
 
 #if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
     !defined(SDL_DISABLE_IMMINTRIN_H)
+FILLERS(none, color &= ~amask;, NONE_CODE)
 FILLERS(add, color &= ~amask;, ADD_CODE)
 FILLERS(sub, color &= ~amask;, SUB_CODE)
 FILLERS(min, color |= amask;, MIN_CODE)
 FILLERS(max, color &= ~amask;, MAX_CODE)
 FILLERS_SHUFF(mult, color |= amask;, MULT_CODE)
 #else
+INVALID_DEFS(none)
 INVALID_DEFS(add)
 INVALID_DEFS(sub)
 INVALID_DEFS(min)

--- a/src_c/simd_surface_fill_sse2.c
+++ b/src_c/simd_surface_fill_sse2.c
@@ -142,6 +142,7 @@ _pg_HasSSE_NEON()
         return -1;                                                          \
     }
 
+#define NONE_CODE mm128_dst = mm128_color;
 #define ADD_CODE mm128_dst = _mm_adds_epu8(mm128_dst, mm128_color);
 #define SUB_CODE mm128_dst = _mm_subs_epu8(mm128_dst, mm128_color);
 #define MIN_CODE mm128_dst = _mm_min_epu8(mm128_dst, mm128_color);
@@ -154,12 +155,14 @@ _pg_HasSSE_NEON()
     }
 
 #if defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)
+FILLERS(none, color &= ~amask;, NONE_CODE)
 FILLERS(add, color &= ~amask;, ADD_CODE)
 FILLERS(sub, color &= ~amask;, SUB_CODE)
 FILLERS(min, color |= amask;, MIN_CODE)
 FILLERS(max, color &= ~amask;, MAX_CODE)
 FILLERS_SHUFF(mult, color |= amask;, MULT_CODE)
 #else
+INVALID_DEFS(none)
 INVALID_DEFS(add)
 INVALID_DEFS(sub)
 INVALID_DEFS(min)

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1804,17 +1804,7 @@ surf_fill(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
         if (sdlrect.w <= 0 || sdlrect.h <= 0) {
             return pgRect_New(&sdlrect);
         }
-
-        if (blendargs != 0) {
-            result = surface_fill_blend(surf, &sdlrect, color, blendargs);
-        }
-        else {
-            pgSurface_Prep(self);
-            pgSurface_Lock((pgSurfaceObject *)self);
-            result = SDL_FillRect(surf, &sdlrect, color);
-            pgSurface_Unlock((pgSurfaceObject *)self);
-            pgSurface_Unprep(self);
-        }
+        result = surface_fill_blend(surf, &sdlrect, color, blendargs);
         if (result == -1)
             return RAISE(pgExc_SDLError, SDL_GetError());
     }

--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -866,6 +866,26 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
     }
 
     switch (blendargs) {
+        case SDL_BLENDMODE_NONE: {
+#if !defined(__EMSCRIPTEN__)
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+            if (surface->format->BytesPerPixel == 4) {
+                if (_pg_has_avx2()) {
+                    result = surface_fill_blend_rgba_none_avx2(surface, rect, color);
+                    break;
+                }
+#if PG_ENABLE_SSE_NEON
+                if (_pg_HasSSE_NEON()) {
+                    result = surface_fill_blend_rgba_none_sse2(surface, rect, color);
+                    break;
+                }
+#endif /* PG_ENABLE_SSE_NEON */
+            }
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
+#endif /* __EMSCRIPTEN__ */
+            result = SDL_FillRect(surface, rect, color);
+            break;
+        }
         case PYGAME_BLEND_ADD: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN

--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -871,12 +871,14 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
             if (surface->format->BytesPerPixel == 4) {
                 if (_pg_has_avx2()) {
-                    result = surface_fill_blend_rgba_none_avx2(surface, rect, color);
+                    result = surface_fill_blend_rgba_none_avx2(surface, rect,
+                                                               color);
                     break;
                 }
 #if PG_ENABLE_SSE_NEON
                 if (_pg_HasSSE_NEON()) {
-                    result = surface_fill_blend_rgba_none_sse2(surface, rect, color);
+                    result = surface_fill_blend_rgba_none_sse2(surface, rect,
+                                                               color);
                     break;
                 }
 #endif /* PG_ENABLE_SSE_NEON */


### PR DESCRIPTION
This should improve the performance of simple surface.fill

Test code:
```py
from timeit import repeat
import pygame

pygame.init()
surf = pygame.Surface((800, 600))
G = globals()

teststr = "surf.fill((24, 24, 24))"
l = [min(repeat(teststr, globals=G, number=1000, repeat=10)) for _ in range(5)]
print(f"fill: {sum(l) / len(l)}")
```

My results
```py
pygame-ce 2.5.0.dev1 (SDL 2.28.5, Python 3.11.0)
fill: 0.03824264000868425

pygame-ce 2.4.0 (SDL 2.28.5, Python 3.11.0)
fill: 0.08401216000784188
```

