### PR TITLE
Fix segfault in `surface.fblits`

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2274,7 +2274,7 @@ surf_fblits(pgSurfaceObject *self, PyObject *const *args, Py_ssize_t nargs)
 
 on_error:
     if (is_generator) {
-        Py_DECREF(item);
+        Py_XDECREF(item);
     }
     switch (error) {
         case BLITS_ERR_SEQUENCE_REQUIRED:

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2145,6 +2145,7 @@ surf_fblits(pgSurfaceObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *blit_sequence, *item, *src_surf, *blit_pos;
     int blend_flags = 0; /* Default flag is 0, opaque */
     int error = 0;
+    int is_generator = 0;
 
     if (nargs == 0 || nargs > 2) {
         error = FBLITS_ERR_INCORRECT_ARGS_NUM;
@@ -2216,11 +2217,11 @@ surf_fblits(pgSurfaceObject *self, PyObject *const *args, Py_ssize_t nargs)
     }
     /* Generator path */
     else if (PyIter_Check(blit_sequence)) {
+        is_generator = 1;
         while ((item = PyIter_Next(blit_sequence))) {
             /* Check that the item is a tuple of length 2 */
             if (!PyTuple_Check(item) || PyTuple_GET_SIZE(item) != 2) {
                 error = FBLITS_ERR_TUPLE_REQUIRED;
-                Py_DECREF(item);
                 goto on_error;
             }
 
@@ -2228,8 +2229,6 @@ surf_fblits(pgSurfaceObject *self, PyObject *const *args, Py_ssize_t nargs)
              * (Surface, dest) tuple */
             src_surf = PyTuple_GET_ITEM(item, 0);
             blit_pos = PyTuple_GET_ITEM(item, 1);
-
-            Py_DECREF(item);
 
             /* Check that the source is a Surface */
             if (!pgSurface_Check(src_surf)) {
@@ -2262,6 +2261,8 @@ surf_fblits(pgSurfaceObject *self, PyObject *const *args, Py_ssize_t nargs)
                 error = BLITS_ERR_BLIT_FAIL;
                 goto on_error;
             }
+
+            Py_DECREF(item);
         }
     }
     else {
@@ -2272,6 +2273,9 @@ surf_fblits(pgSurfaceObject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_RETURN_NONE;
 
 on_error:
+    if (is_generator) {
+        Py_DECREF(item);
+    }
     switch (error) {
         case BLITS_ERR_SEQUENCE_REQUIRED:
             return RAISE(

--- a/test/blit_test.py
+++ b/test/blit_test.py
@@ -163,6 +163,9 @@ class BlitTest(unittest.TestCase):
         self.assertEqual(dst.fblits(blit_list, 0), None)
         self.assertEqual(dst.fblits(blit_list, 1), dst.blits(blit_list, doreturn=0))
 
+        # make sure this doesn't segfault
+        dst.fblits((dst, dst.get_rect().topleft) for _ in range(1))
+
         t0 = time()
         results = blits(blit_list)
         t1 = time()


### PR DESCRIPTION
Moved reference decrementing to after the values are used for stuff (see https://docs.python.org/3/c-api/iter.html#c.PyIter_Next).
I'm not sure why this wasn't causing issues for like actual tuples like `(0, 0)` being used directly for the destination, but it appears this was related to the object being passed having to get an attribute dynamically? Not entirely sure, but the segfault seems to have gone away.

MRE:
```py
import pygame

pygame.init()
screen = pygame.display.set_mode((640, 360))
surf = pygame.Surface((10, 10))
screen.fblits((surf, surf.get_rect().topleft) for _ in range(1))
print("finished")
```