### PR TITLE
Minor changes to support pytest

### DIFF
--- a/test/display_test.py
+++ b/test/display_test.py
@@ -832,7 +832,7 @@ class DisplayInteractiveTest(unittest.TestCase):
         pygame.display.quit()
 
 
-class FullscreenToggleTests(unittest.TestCase):
+class FullscreenToggleTestsInteractive(unittest.TestCase):
     __tags__ = ["interactive"]
 
     screen = None

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -1021,7 +1021,7 @@ class FontTypeTest(unittest.TestCase):
 
 
 @unittest.skipIf(IS_PYPY, "pypy skip known failure")  # TODO
-class VisualTests(unittest.TestCase):
+class VisualTestsInteractive(unittest.TestCase):
     __tags__ = ["interactive"]
 
     screen = None

--- a/test/ftfont_test.py
+++ b/test/ftfont_test.py
@@ -1,7 +1,8 @@
 import sys
 import os
 import unittest
-from pygame.tests import font_test
+
+from . import font_test
 
 import pygame.ftfont
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -18,7 +18,7 @@ if _sdl_image_ver is not None:
     )
 
 
-def test_magic(f, magic_hexes):
+def check_magic(f, magic_hexes):
     """Tests a given file to see if the magic hex matches."""
     data = f.read(len(magic_hexes))
     if len(data) != len(magic_hexes):
@@ -325,7 +325,7 @@ class ImageModuleTest(unittest.TestCase):
                     # Test the magic numbers at the start of the file to ensure
                     # they are saved as the correct file type.
                     self.assertEqual(
-                        (1, fmt), (test_magic(handle, magic_hex[fmt.lower()]), fmt)
+                        (1, fmt), (check_magic(handle, magic_hex[fmt.lower()]), fmt)
                     )
 
                 # load the file to make sure it was saved correctly.
@@ -409,7 +409,7 @@ class ImageModuleTest(unittest.TestCase):
                         # ensure they are saved as the correct file type.
                         handle.seek(0)
                         self.assertEqual(
-                            (1, fmt), (test_magic(handle, magic_hex[fmt.lower()]), fmt)
+                            (1, fmt), (check_magic(handle, magic_hex[fmt.lower()]), fmt)
                         )
                     # load the file to make sure it was saved correctly.
                     handle.flush()
@@ -1893,7 +1893,7 @@ class ImageModuleTest(unittest.TestCase):
             with open(temp_file_name, "rb") as file:
                 # Test the magic numbers at the start of the file to ensure
                 # they are saved as the correct file type.
-                self.assertEqual(1, (test_magic(file, magic_hex[fmt.lower()])))
+                self.assertEqual(1, (check_magic(file, magic_hex[fmt.lower()])))
             # load the file to make sure it was saved correctly
             loaded_file = pygame.image.load(temp_file_name)
             self.assertEqual(loaded_file.get_at((0, 0)), surf.get_at((0, 0)))


### PR DESCRIPTION
A pleasant surprise: `pytest` seems to support `unittest` based tests out of box!

We've had occasional problems due to our custom test runner, and it seems like in the long term it's worth migrating to a tried and tested tool that handles stuff for us. The good part is that (after this PR) `pytest test -k "not interactive"` will be an alternate way of running tests that behaves like `python -m test` when running from the project directory, and the old machinery will still be default, and continue to work.

This PR is is needed because:
1. pytest does not understand our custom tags system. But pytest allows enabling/skipping tests based on patterns in the name. So interactive tests need to be explicitly marked as so in the name
2. pytest seems to run everything that begins with `test_`, so things that are not actually tests need a name changing
3. There was one package import that works better as a relative import

Future work
1. Make `python3 -m pygame.tests`/`python3 -m test` internally invoke pytest, maybe initially this should be controlled by an opt-in flag, but eventually it could be default
2. write any new tests in pytest
3. (optional) can incrementally port existing tests to pytest