### PR TITLE
Serving documentation with a simple server.

### DIFF
--- a/docs/__init__.py
+++ b/docs/__init__.py
@@ -1,0 +1,21 @@
+# python -m pygame.docs
+
+from pathlib import Path
+import webbrowser
+
+
+PKG_DIR = Path(__file__).absolute().parent / "generated"
+
+
+# for test suite to confirm pygame-ce built with local docs
+def has_local_docs():
+    return PKG_DIR.exists()
+
+
+def open_docs():
+    main_page = PKG_DIR / "index.html"
+    if main_page.exists():
+        url = main_page.as_uri()
+    else:
+        url = "https://pyga.me/docs/"
+    webbrowser.open(url)

--- a/docs/__main__.py
+++ b/docs/__main__.py
@@ -1,37 +1,8 @@
-# python -m pygame.docs
-
-import os
-import webbrowser
-from urllib.parse import quote, urlunparse
-
-
-def _iterpath(path):
-    path, last = os.path.split(path)
-    if last:
-        yield from _iterpath(path)
-        yield last
-
-
-# for test suite to confirm pygame-ce built with local docs
-def has_local_docs():
-    pkg_dir = os.path.dirname(os.path.abspath(__file__))
-    main_page = os.path.join(pkg_dir, "generated", "index.html")
-    return os.path.exists(main_page)
-
-
-def open_docs():
-    pkg_dir = os.path.dirname(os.path.abspath(__file__))
-    main_page = os.path.join(pkg_dir, "generated", "index.html")
-    if os.path.exists(main_page):
-        url_path = quote("/".join(_iterpath(main_page)))
-        drive, rest = os.path.splitdrive(__file__)
-        if drive:
-            url_path = f"{drive}/{url_path}"
-        url = urlunparse(("file", "", url_path, "", "", ""))
-    else:
-        url = "https://pyga.me/docs/"
-    webbrowser.open(url)
-
+from pygame.docs import open_docs
 
 if __name__ == "__main__":
+    print("Opening local documentation files in the browser.")
+    print(
+        "If you want to run a simple server instead, run 'python -m pygame.docs.serve'."
+    )
     open_docs()

--- a/docs/serve.py
+++ b/docs/serve.py
@@ -1,0 +1,42 @@
+# python -m pygame.docs.serve
+
+import sys
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+
+from pygame.docs import PKG_DIR, has_local_docs
+
+
+class DocsHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, directory=str(PKG_DIR))
+
+
+def serve(address: str, port: int):
+    with ThreadingHTTPServer((address, port), DocsHandler) as httpd:
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\nKeyboard interrupt received, exiting.")
+            sys.exit(0)
+
+
+if __name__ == "__main__":
+    if not has_local_docs():
+        print("ERROR: no local documentation found, cannot serve anything, exiting...")
+        sys.exit(1)
+    print("WARNING: this is not for production use!")
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "port",
+        action="store",
+        default=8000,
+        type=int,
+        nargs="?",
+        help="specify alternate port (default: 8000)",
+    )
+    parsed_args = parser.parse_args()
+    target = "localhost"
+    print(f"Serving on: http://{target}:{parsed_args.port}")
+    serve("localhost", parsed_args.port)

--- a/test/docs_test.py
+++ b/test/docs_test.py
@@ -6,11 +6,11 @@ import unittest
 
 class DocsIncludedTest(unittest.TestCase):
     def test_doc_import_works(self):
-        from pygame.docs.__main__ import has_local_docs, open_docs
+        from pygame.docs import has_local_docs, open_docs
 
     @unittest.skipIf("CI" not in os.environ, "Docs not required for local builds")
     def test_docs_included(self):
-        from pygame.docs.__main__ import has_local_docs
+        from pygame.docs import has_local_docs
 
         self.assertTrue(has_local_docs())
 


### PR DESCRIPTION
As discussed in [here](https://discord.com/channels/772505616680878080/772940667231928360/1197129403386314782) running ``python -m pygame.docs`` in some circumstances may fail - when a default browser is a non-classic snap package and ``pygame-ce`` library is installed in a ``.hidden`` folder (dotted), as those folders snaps [can't access](https://bugs.launchpad.net/snapd/+bug/1979060). This pull request solves this issue by introducing another method of opening documentation - running a simple local server for this purpose (with ``python -m pygame.docs.serve``) while not changing the original behavior.