### PR TITLE
transform.scale: softstretch SDL2/SDL3 compat

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -74,6 +74,9 @@
 
 #define PG_SurfaceHasRLE SDL_SurfaceHasRLE
 
+#define PG_SoftStretchNearest(src, srcrect, dst, dstrect) \
+    SDL_SoftStretch(src, srcrect, dst, dstrect, SDL_SCALEMODE_NEAREST)
+
 #else /* ~SDL_VERSION_ATLEAST(3, 0, 0)*/
 #define PG_ShowCursor() SDL_ShowCursor(SDL_ENABLE)
 #define PG_HideCursor() SDL_ShowCursor(SDL_DISABLE)
@@ -102,6 +105,10 @@
 #define PG_ConvertSurface(src, fmt) SDL_ConvertSurface(src, fmt, 0)
 #define PG_ConvertSurfaceFormat(src, pixel_format) \
     SDL_ConvertSurfaceFormat(src, pixel_format, 0)
+
+#define PG_SoftStretchNearest(src, srcrect, dst, dstrect) \
+    SDL_SoftStretch(src, srcrect, dst, dstrect)
+
 #if SDL_VERSION_ATLEAST(2, 0, 14)
 #define PG_SurfaceHasRLE SDL_HasSurfaceRLE
 #else

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -468,7 +468,7 @@ scale_to(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int width,
         pgSurface_Lock(srcobj);
         Py_BEGIN_ALLOW_THREADS;
 
-        stretch_result_num = SDL_SoftStretch(src, NULL, modsurf, NULL);
+        stretch_result_num = PG_SoftStretchNearest(src, NULL, modsurf, NULL);
 
         Py_END_ALLOW_THREADS;
         pgSurface_Unlock(srcobj);


### PR DESCRIPTION
In SDL3, SDL_SoftStretch takes a ScaleMode parameter. For this case, it should be "nearest neighbor" because this is our basic scaling function.

With this change, the transform module compiles with SDL3.