### PR TITLE
SDL2/SDL3 mutex support

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -77,6 +77,22 @@
 #define PG_SoftStretchNearest(src, srcrect, dst, dstrect) \
     SDL_SoftStretch(src, srcrect, dst, dstrect, SDL_SCALEMODE_NEAREST)
 
+/* Emulating SDL2 SDL_LockMutex API. In SDL3, it returns void. */
+static inline int
+PG_LockMutex(SDL_mutex *mutex)
+{
+    SDL_LockMutex(mutex);
+    return 0;
+}
+
+/* Emulating SDL2 SDL_UnlockMutex API. In SDL3, it returns void. */
+static inline int
+PG_UnlockMutex(SDL_mutex *mutex)
+{
+    SDL_UnlockMutex(mutex);
+    return 0;
+}
+
 #else /* ~SDL_VERSION_ATLEAST(3, 0, 0)*/
 #define PG_ShowCursor() SDL_ShowCursor(SDL_ENABLE)
 #define PG_HideCursor() SDL_ShowCursor(SDL_DISABLE)
@@ -108,6 +124,18 @@
 
 #define PG_SoftStretchNearest(src, srcrect, dst, dstrect) \
     SDL_SoftStretch(src, srcrect, dst, dstrect)
+
+static inline int
+PG_LockMutex(SDL_mutex *mutex)
+{
+    return SDL_LockMutex(mutex);
+}
+
+static inline int
+PG_UnlockMutex(SDL_mutex *mutex)
+{
+    return SDL_UnlockMutex(mutex);
+}
 
 #if SDL_VERSION_ATLEAST(2, 0, 14)
 #define PG_SurfaceHasRLE SDL_HasSurfaceRLE

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -104,7 +104,7 @@ static char released_keys[SDL_NUM_SCANCODES] = {0};
 
 #define PG_LOCK_EVFILTER_MUTEX                                             \
     if (pg_evfilter_mutex) {                                               \
-        if (SDL_LockMutex(pg_evfilter_mutex) < 0) {                        \
+        if (PG_LockMutex(pg_evfilter_mutex) < 0) {                         \
             /* TODO: better error handling with future error-event API */  \
             /* since this error is very rare, we can completely give up if \
              * this happens for now */                                     \
@@ -116,7 +116,7 @@ static char released_keys[SDL_NUM_SCANCODES] = {0};
 
 #define PG_UNLOCK_EVFILTER_MUTEX                                           \
     if (pg_evfilter_mutex) {                                               \
-        if (SDL_UnlockMutex(pg_evfilter_mutex) < 0) {                      \
+        if (PG_UnlockMutex(pg_evfilter_mutex) < 0) {                       \
             /* TODO: handle errors with future error-event API */          \
             /* since this error is very rare, we can completely give up if \
              * this happens for now */                                     \

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -88,7 +88,7 @@ static SDL_mutex *pg_timer_mutex = NULL;
  * easily */
 #define PG_LOCK_TIMER_MUTEX                                                \
     if (pg_timer_mutex) {                                                  \
-        if (SDL_LockMutex(pg_timer_mutex) < 0) {                           \
+        if (PG_LockMutex(pg_timer_mutex) < 0) {                            \
             /* TODO: better error handling with future error-event API */  \
             /* since this error is very rare, we can completely give up if \
              * this happens for now */                                     \
@@ -100,7 +100,7 @@ static SDL_mutex *pg_timer_mutex = NULL;
 
 #define PG_UNLOCK_TIMER_MUTEX                                              \
     if (pg_timer_mutex) {                                                  \
-        if (SDL_UnlockMutex(pg_timer_mutex) < 0) {                         \
+        if (PG_UnlockMutex(pg_timer_mutex) < 0) {                          \
             /* TODO: handle errors with future error-event API */          \
             /* since this error is very rare, we can completely give up if \
              * this happens for now */                                     \
@@ -441,7 +441,7 @@ time_set_timer(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_BEGIN_ALLOW_THREADS;
 
 #ifndef __EMSCRIPTEN__
-    if (SDL_LockMutex(pg_timer_mutex) < 0) {
+    if (PG_LockMutex(pg_timer_mutex) < 0) {
         ecode = PG_TIMER_SDL_ERROR;
         goto end_no_mutex;
     }
@@ -475,7 +475,7 @@ time_set_timer(PyObject *self, PyObject *args, PyObject *kwargs)
 
 end:
 #ifndef __EMSCRIPTEN__
-    if (SDL_UnlockMutex(pg_timer_mutex)) {
+    if (PG_UnlockMutex(pg_timer_mutex)) {
         ecode = PG_TIMER_SDL_ERROR;
     }
 


### PR DESCRIPTION
This gets the `time` module fully compiling, helps the `event` module as well (but `event` needs other patches).

Note from SDL3's readme-migration on mutexes:
> SDL_LockMutex and SDL_UnlockMutex now return void; if the mutex is valid (including being a NULL pointer, which returns immediately), these functions never fail. If the mutex is invalid or the caller does something illegal, like unlock another thread's mutex, this is considered undefined behavior.

