### PR TITLE
Adapt test runner count tweak to be 3.12.1 only

### DIFF
--- a/test/test_utils/test_runner.py
+++ b/test/test_utils/test_runner.py
@@ -285,11 +285,11 @@ def run_test(
         print(output.read())
         output.seek(0)
 
-    # change in way skipped tested counted from Python 3.12.1 onwards
+    # change in way skipped tested counted in Python 3.12.1 only (so far)
+    # This was changed and then reverted in 3.12.2
+    # https://github.com/python/cpython/pull/114994
     tests_run_and_skipped = results.testsRun
-    if sys.version_info.minor >= 13 or (
-        sys.version_info.minor == 12 and sys.version_info.micro >= 1
-    ):
+    if sys.version_info.minor == 12 and sys.version_info.micro == 1:
         tests_run_and_skipped += len(results.skipped)
 
     results = {


### PR DESCRIPTION
So when 3.12.1 released we had to add a tweak to our test running machinery because CPython stopped counting skipped tests as 'run'. Apparently this change has now been reverted for 3.12.2 (and 3.13) so we are back to how it was before.

This was causing our CircleCI runs to fail because that CI was grabbing the latest release of 3.12.2. I swear if they change this back again...

