### PR TITLE
Cleanup rwobject.c file object methods

### DIFF
--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -31,21 +31,6 @@
 
 #include "doc/pygame_doc.h"
 
-#if defined(_WIN32)
-#define PG_LSEEK _lseeki64
-#elif defined(__APPLE__)
-/* Mac does not implement lseek64 */
-#define PG_LSEEK lseek
-#elif defined(__EMSCRIPTEN__)
-/* emsdk mvp 1.0 does not implement lseek64  */
-#define PG_LSEEK lseek
-#elif defined(_LARGEFILE64_SOURCE)
-/* for glibc system that support LFS */
-#define PG_LSEEK lseek64
-#else
-#define PG_LSEEK lseek
-#endif
-
 typedef struct {
     PyObject *read;
     PyObject *write;

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -37,7 +37,6 @@ typedef struct {
     PyObject *seek;
     PyObject *tell;
     PyObject *close;
-    PyObject *file;
 } pgRWHelper;
 
 /*static const char pg_default_encoding[] = "unicode_escape";*/
@@ -412,7 +411,6 @@ _pg_rw_close(SDL_RWops *context)
     Py_XDECREF(helper->write);
     Py_XDECREF(helper->read);
     Py_XDECREF(helper->close);
-    Py_XDECREF(helper->file);
 
     PyMem_Free(helper);
     PyGILState_Release(state);
@@ -444,9 +442,6 @@ pgRWops_FromFileObject(PyObject *obj)
         PyMem_Free(helper);
         return (SDL_RWops *)PyErr_NoMemory();
     }
-
-    helper->file = obj;
-    Py_INCREF(obj);
 
     /* Adding a helper to the hidden data to support file-like object RWops */
     rw->hidden.unknown.data1 = (void *)helper;


### PR DESCRIPTION
- Simplifies the code by removing WITH_THREAD / not WITH_THREAD conditional compilation
- Removes path for file-like objects that are actually files
- Removes unused data ("file") inside pgRwHelper

I've tried before to remove WITH_THREAD blocks and got a lot of skepticism, so I've done my homework this time. See CPython https://github.com/python/cpython/issues/75551 "Remove support for threads-less builds," where WITH_THREAD becomes always defined (Python 3.7). See also [pyport.h](https://github.com/python/cpython/blob/0a6e1a4119864bec0247b04a5c99fdd9799cd8eb/Include/pyport.h#L465-L479) where it is still hardcoded as defined, and the region below references emscripten's lack of threading support, so it's not like this code hasn't taken that into account yet. Lastly, lets say we did build on a platform without threads... what's the harm in calling `PyGILState_Ensure` and `PyGILState_Release`? They're both in the stable ABI, it's not like they will be missing-- they might become no-ops but that's fine.

Secondly, my removal of the `fileno` path. The `io` protocol can only provide a fileno if it actually comes from a file, see https://docs.python.org/3/library/io.html#io.IOBase.fileno. I believe it would be very uncommon for a user to pass an `io` object into a pygame loader after loading from a file. What I've seen is str/pathlib path input, which creates a basic SDL_RWop, and io.BytesIO-style (memory) input which creates one of our custom RWops. `io.BytesIO` objects don't come from files, so they don't have a fileno. Before this PR every time they had to do anything they'd have to check if they had a fileno. If a user happens to pass in an `io` object that actually does come from a file, the code using the standard `io` APIs will work fine on it without a specialized path for that case.

Also, per the docs for PyObject_AsFileDescriptor (at https://docs.python.org/3/c-api/file.html), it is an emulation of Python 2 APIs and third party code should use `io` instead.

Some example code showing how uses of `io` can intersect with pygame-ce:

```py
import pygame
import io

pygame.init()

# Load into BytesIO somehow (through a file this time but could come from anywhere)
with open(pygame.font.match_font("Arial"), "rb") as f:
    obj = io.BytesIO(f.read())

# print(obj.fileno()) # obj doesn't have a fileno, raises exception
font = pygame.Font(obj, 20)
print(font)

# f is an io.BufferedReader
with open(pygame.font.match_font("Arial"), "rb") as f:
    print(f.fileno()) # f has a fileno
    font = pygame.Font(f, 20)
    print(font)

```