### PR TITLE
Deleted a space in geometry docs

### DIFF
--- a/docs/reST/ref/geometry.rst
+++ b/docs/reST/ref/geometry.rst
@@ -300,7 +300,7 @@
 
          .. ## Circle.rotate ##
 
-    .. method:: rotate_ip
+   .. method:: rotate_ip
 
          | :sl:`rotates the circle in place`
          | :sg:`rotate_ip(angle, rotation_point=Circle.center, /) -> None`


### PR DESCRIPTION
Fixes this weird bug (blue link to the function in the functions' docs lines and extra indent):
![image](https://github.com/pygame-community/pygame-ce/assets/103119829/59513e93-efa7-499c-9f26-dc150caf97ad)
