### PR TITLE
PixelArray raise error assigning sequence to pixel

### DIFF
--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -1318,6 +1318,12 @@ _pxarray_ass_item(pgPixelArrayObject *array, Py_ssize_t index, PyObject *value)
             if (!tmparray) {
                 return -1;
             }
+            if (!pgPixelArrayObject_Check(tmparray)) {
+                PyErr_SetString(
+                    PyExc_ValueError,
+                    "cannot assign a pixel sequence to a single pixel");
+                return -1;
+            }
             retval =
                 _array_assign_sequence(tmparray, 0, tmparray->shape[0], value);
             Py_DECREF(tmparray);

--- a/test/pixelarray_test.py
+++ b/test/pixelarray_test.py
@@ -1319,6 +1319,19 @@ class PixelArrayTypeTest(unittest.TestCase, TestMixin):
         weird_surface = pygame.Surface((0, 5))
         self.assertRaises(ValueError, lambda: pygame.PixelArray(weird_surface))
 
+    def test_assign_seq_to_single(self):
+        """
+        Regression test for https://github.com/pygame-community/pygame-ce/issues/2740
+        This usage should ValueError and not segfault (as list is to be interpreted as
+        pixel sequence, and not color)
+        """
+        test = pygame.PixelArray(pygame.Surface([800, 800]))
+        with self.assertRaises(ValueError):
+            test[400][400] = [255, 255, 0]
+
+        with self.assertRaises(ValueError):
+            test[400, 400] = [255, 255, 0]
+
 
 @unittest.skipIf(IS_PYPY, "pypy having issues")
 class PixelArrayArrayInterfaceTest(unittest.TestCase, TestMixin):


### PR DESCRIPTION
fixes https://github.com/pygame-community/pygame-ce/issues/2740

- In the pixelarray module, any sequence (except tuple and `pygame.Color`) isn't considered a "color", but rather a pixel sequence
- The segfault happens because the code expects a pixelarray upon subscripting for assignment, but receives an "integer color"

I am open to suggestions on how to improve the error message, can't think of something descriptive enough ATM.