### PR TITLE
Undeprecate draw aaline blend

### DIFF
--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -62,10 +62,10 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
          | if ``width > 0``, used for line thickness
          | if ``width < 0``, nothing will be drawn
          |
-      
+
       .. versionchangedold:: 2.1.1
-          Drawing rects with width now draws the width correctly inside the 
-          rect's area, rather than using an internal call to draw.lines(), 
+          Drawing rects with width now draws the width correctly inside the
+          rect's area, rather than using an internal call to draw.lines(),
           which had half the width spill outside the rect area.
 
    :param int border_radius: (optional) used for drawing rectangle with rounded corners.
@@ -498,6 +498,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
    .. versionchangedold:: 2.0.0 Added support for keyword arguments.
    .. versionchanged:: 2.4.0 Removed deprecated 'blend' argument
+   .. versionchanged:: 2.5.0 ``blend`` argument readded for backcompat, but will always raise a deprecation exception when used
 
    .. ## pygame.draw.aaline ##
 
@@ -536,7 +537,8 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       contain number pairs
 
    .. versionchangedold:: 2.0.0 Added support for keyword arguments.
-   .. versionchanged:: 2.4.0 Removed deprecated 'blend' argument
+   .. versionchanged:: 2.4.0 Removed deprecated ``blend`` argument
+   .. versionchanged:: 2.5.0 ``blend`` argument readded for backcompat, but will always raise a deprecation exception when used
 
    .. ## pygame.draw.aalines ##
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -105,7 +105,7 @@ aaline(PyObject *self, PyObject *arg, PyObject *kwargs)
     PyObject *colorobj, *start, *end;
     SDL_Surface *surf = NULL;
     float startx, starty, endx, endy;
-    PyObject *blend;
+    PyObject *blend = NULL;
     int drawn_area[4] = {INT_MAX, INT_MAX, INT_MIN,
                          INT_MIN}; /* Used to store bounding box values */
     Uint32 color;

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -105,16 +105,27 @@ aaline(PyObject *self, PyObject *arg, PyObject *kwargs)
     PyObject *colorobj, *start, *end;
     SDL_Surface *surf = NULL;
     float startx, starty, endx, endy;
+    PyObject *blend;
     int drawn_area[4] = {INT_MAX, INT_MAX, INT_MIN,
                          INT_MIN}; /* Used to store bounding box values */
     Uint32 color;
-    static char *keywords[] = {"surface", "color", "start_pos", "end_pos",
-                               NULL};
+    static char *keywords[] = {"surface", "color", "start_pos",
+                               "end_pos", "blend", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OOO|i", keywords,
+    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OOO|O", keywords,
                                      &pgSurface_Type, &surfobj, &colorobj,
-                                     &start, &end)) {
+                                     &start, &end, &blend)) {
         return NULL; /* Exception already set. */
+    }
+
+    if (blend != NULL) {
+        if (PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "blend argument is deprecated and has no functionality and "
+                "will be completely removed in a future version of pygame-ce",
+                1) == -1) {
+            return NULL;
+        }
     }
 
     surf = pgSurface_AsSurface(surfobj);
@@ -239,16 +250,28 @@ aalines(PyObject *self, PyObject *arg, PyObject *kwargs)
     float *xlist, *ylist;
     float x, y;
     int l, t;
+    PyObject *blend = NULL;
     int drawn_area[4] = {INT_MAX, INT_MAX, INT_MIN,
                          INT_MIN}; /* Used to store bounding box values */
     int result, closed;
     Py_ssize_t loop, length;
-    static char *keywords[] = {"surface", "color", "closed", "points", NULL};
+    static char *keywords[] = {"surface", "color", "closed",
+                               "points",  "blend", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OpO|i", keywords,
+    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OpO|O", keywords,
                                      &pgSurface_Type, &surfobj, &colorobj,
-                                     &closed, &points)) {
+                                     &closed, &points, &blend)) {
         return NULL; /* Exception already set. */
+    }
+
+    if (blend != NULL) {
+        if (PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "blend argument is deprecated and has no functionality and "
+                "will be completely removed in a future version of pygame-ce",
+                1) == -1) {
+            return NULL;
+        }
     }
 
     surf = pgSurface_AsSurface(surfobj);

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -2445,6 +2445,21 @@ class AALineMixin(BaseLineMixin):
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
 
+    def test_aaline__blend_warning(self):
+        """Using the blend argument should raise a DeprecationWarning"""
+        faulty_blend_values = [0, 1, True, False, None, "", [], type]
+        with warnings.catch_warnings(record=True) as w:
+            for count, blend in enumerate(faulty_blend_values):
+                # Cause all warnings to always be triggered.
+                warnings.simplefilter("always")
+                # Trigger DeprecationWarning.
+                self.draw_aaline(
+                    pygame.Surface((2, 2)), (0, 0, 0, 50), (0, 0), (2, 2), blend
+                )
+                # Check if there is only one warning and is a DeprecationWarning.
+                self.assertEqual(len(w), count + 1)
+                self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
     def test_aaline__kwargs(self):
         """Ensures draw aaline accepts the correct kwargs"""
         surface = pygame.Surface((4, 4))
@@ -3168,6 +3183,25 @@ class AALinesMixin(BaseLineMixin):
         )
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_aalines__blend_warning(self):
+        """Using the blend argument should raise a DeprecationWarning"""
+        faulty_blend_values = [0, 1, True, False, None, "", [], type]
+        with warnings.catch_warnings(record=True) as w:
+            for count, blend in enumerate(faulty_blend_values):
+                # Cause all warnings to always be triggered.
+                warnings.simplefilter("always")
+                # Trigger DeprecationWarning.
+                self.draw_aalines(
+                    pygame.Surface((2, 2)),
+                    (0, 0, 0, 50),
+                    False,
+                    ((0, 0), (1, 1)),
+                    blend,
+                )
+                # Check if there is only one warning and is a DeprecationWarning.
+                self.assertEqual(len(w), count + 1)
+                self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
     def test_aalines__kwargs(self):
         """Ensures draw aalines accepts the correct kwargs."""


### PR DESCRIPTION
fixes #2739 and properly deprecates the blend argument so that if it's used, a warning will always be emitted instead of just false