### PR TITLE
wasm: unify pygame-web/pyodide/static Freetype init

### DIFF
--- a/src_c/static.c
+++ b/src_c/static.c
@@ -269,6 +269,12 @@ static struct PyModuleDef mod_pygame_static = {PyModuleDef_HEAD_INIT,
 PyMODINIT_FUNC
 PyInit_pygame_static()
 {
+    // cannot fail here, and font_initialized is already set to 1 in font.c .
+    TTF_Init();
+
+    // for correct input in wasm worker
+    SDL_SetHint("SDL_EMSCRIPTEN_KEYBOARD_ELEMENT", "1");
+
     load_submodule("pygame", PyInit_base(), "base");
     load_submodule("pygame", PyInit_constants(), "constants");
     load_submodule("pygame", PyInit_surflock(), "surflock");

--- a/src_c/static.c
+++ b/src_c/static.c
@@ -14,6 +14,8 @@
 #include "pygame.h"
 #include "Python.h"
 
+#include <SDL_ttf.h>
+
 #if defined(__EMSCRIPTEN__)
 #undef WITH_THREAD
 #endif


### PR DESCRIPTION
both pygbag and pyodide benefit from that change see
https://github.com/pyodide/pyodide/pull/4602#pullrequestreview-1928005211

part of the change already was in anyway https://github.com/pygame-community/pygame-ce/blob/be55232410cb33391be23d0a279ec2632d75820e/src_c/font.c#L71 and the other part was in a patch applied by pygbag because the draft https://github.com/pygame-community/pygame-ce/pull/1967 was incomplete.
