### PR TITLE
Fix ftfont_test being run directly

### DIFF
--- a/test/font_test.py
+++ b/test/font_test.py
@@ -876,7 +876,7 @@ class FontTypeTest(unittest.TestCase):
                 ("set_underline", (True,)),
                 ("size", ("any Text",)),
             ]
-            skip_methods = set(("get_strikethrough", "set_strikethrough"))
+            skip_methods = {"get_strikethrough", "set_strikethrough"}
         else:
             methods = [
                 ("get_height", tuple()),
@@ -972,7 +972,7 @@ class FontTypeTest(unittest.TestCase):
                 ("italic", True),
                 ("resolution", None),
             ]
-            skip_properties = set(("strikethrough",))
+            skip_properties = {"strikethrough"}
         else:
             properties = [
                 ("name", None),

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -876,7 +876,7 @@ class FontTypeTest(unittest.TestCase):
                 ("set_underline", (True,)),
                 ("size", ("any Text",)),
             ]
-            version = pygame.freetype.get_version()
+            skip_methods = set(("get_strikethrough", "set_strikethrough"))
         else:
             methods = [
                 ("get_height", tuple()),
@@ -897,30 +897,23 @@ class FontTypeTest(unittest.TestCase):
                 ("set_script", ("is it other text",)),
                 ("set_direction", ("is it text",)),
             ]
+            skip_methods = set()
             version = pygame.font.get_sdl_ttf_version()
             if version >= (2, 0, 18):
                 methods.append(("get_point_size", tuple()))
                 methods.append(("set_point_size", (34,)))
+            else:
+                skip_methods.add("get_point_size")
+                skip_methods.add("set_point_size")
+                skip_methods.add("point_size")
+
+            if version < (2, 20, 0):
+                skip_methods.add("align")
 
         font = pygame_font.Font(None, 10)
         actual_names = []
         for n in sorted(dir(font)):
-            if n == "align" and version < (2, 20, 0):
-                print(f"align skipped for sld ttf version {version} < 2.20.0")
-                continue
-            if n == "point_size" and version < (2, 0, 18):
-                print(f"point_size skipped for sld ttf version {version} < 2.20.0")
-                continue
-            if n == "get_point_size" and version < (2, 0, 18):
-                print(f"get_point_size skipped for sld ttf version {version} < 2.20.0")
-                continue
-            if n == "set_point_size" and version < (2, 0, 18):
-                print(f"set_point_size skipped for sld ttf version {version} < 2.20.0")
-                continue
-            if (
-                n == "get_strikethrough" or n == "set_strikethrough"
-            ) and pygame_font.__name__ == "pygame.ftfont":
-                # this is only emulated in python
+            if n in skip_methods:
                 continue
             if n.startswith("_"):
                 continue
@@ -979,7 +972,7 @@ class FontTypeTest(unittest.TestCase):
                 ("italic", True),
                 ("resolution", None),
             ]
-            version = pygame.freetype.get_version()
+            skip_properties = set(("strikethrough",))
         else:
             properties = [
                 ("name", None),
@@ -989,24 +982,22 @@ class FontTypeTest(unittest.TestCase):
                 ("underline", True),
                 ("strikethrough", True),
             ]
+            skip_properties = set()
             version = pygame.font.get_sdl_ttf_version()
             if version >= (2, 20, 0):
                 properties.append(("align", 1))
+            else:
+                skip_properties.add("align")
             if version >= (2, 0, 18):
                 properties.append(("point_size", 1))
+            else:
+                skip_properties.add("point_size")
 
         font = pygame_font.Font(None, 10)
         actual_names = []
 
         for n in sorted(dir(font)):
-            if n == "align" and version < (2, 20, 0):
-                print(f"align skipped for sld ttf version {version} < 2.20.0")
-                continue
-            if n == "point_size" and version < (2, 0, 18):
-                print(f"point_size skipped for sld ttf version {version} < 2.0.18")
-                continue
-            if n == "strikethrough" and pygame_font.__name__ == "pygame.ftfont":
-                # this is only emulated in python
+            if n in skip_properties:
                 continue
             if n.startswith("_"):
                 continue


### PR DESCRIPTION
ftfont_test uses font_test to run, but it was trying to import pygame.freetype for a version check without an explicit import (which pygame.freetype needs). Removed the dependency on pygame.freetype for the ftfont path.

I ran into this while I was trying to get the old multithreaded test runner working, which runs each test in individual processes. This failed under those conditions. Normally something else imports pygame.freetype first so it's in working order by the time it gets here.