### PR TITLE
Fix `pygame.display.get_caption()` Docs in display.rst

### DIFF
--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -673,7 +673,7 @@ required).
    | :sl:`Get the current window caption`
    | :sg:`get_caption() -> (title, icontitle)`
 
-   Returns the title and icontitle for the display window. In pygame 2.x
+   Returns the title and icontitle of the display window. In pygame 2.x
    these will always be the same value.
 
    .. ## pygame.display.get_caption ##


### PR DESCRIPTION
Hi, this is a small grammar fix. I believe this PR could be labeled with `docs`.
using `of` instead of `for`

**from**

Returns the title and icontitle **for** the display window. In pygame 2.x these will always be the same value.

**to**

Returns the title and icontitle **of** the display window. In pygame 2.x these will always be the same value.