### PR TITLE
Minor optimizations by using comprehensions

### DIFF
--- a/buildconfig/config.py
+++ b/buildconfig/config.py
@@ -80,14 +80,12 @@ def prepdep(dep, basepath):
         if isinstance(dep.inc_dir, str):
             incs.append(IPREFIX+dep.inc_dir[startind:])
         else:
-            for dir in dep.inc_dir:
-                incs.append(IPREFIX+dir[startind:])
+            incs.extend(IPREFIX+dir[startind:] for dir in dep.inc_dir)
     if dep.lib_dir:
         if isinstance(dep.lib_dir, str):
             lids.append(LPREFIX+dep.lib_dir[startind:])
         else:
-            for dir in dep.lib_dir:
-                lids.append(LPREFIX+dir[startind:])
+            lids.extend(LPREFIX+dir[startind:] for dir in dep.lib_dir)
     libs = ''
     for lib in dep.libs:
         libs += ' -l' + lib

--- a/buildconfig/stubs/gen_stubs.py
+++ b/buildconfig/stubs/gen_stubs.py
@@ -131,7 +131,7 @@ with open(init_file, "w") as f:
     for mod, items in pygame_all_imports.items():
         if len(items) <= 4:
             # try to write imports in a single line if it can fit the line limit
-            import_items = map(lambda string: f"{string} as {string}", items)
+            import_items = (f"{string} as {string}" for string in items)
             import_line = f"\nfrom {mod} import {', '.join(import_items)}"
             if len(import_line) <= 88:
                 f.write(import_line)

--- a/examples/font_viewer.py
+++ b/examples/font_viewer.py
@@ -71,11 +71,7 @@ class FontViewer:
             path = os.path.join(sys.argv[1], "")
         fonts = []
         if os.path.exists(path):
-            # this list comprehension could replace the following loop
-            # fonts = [f in os.listdir(path) if f.endswith('.ttf')]
-            for font in os.listdir(path):
-                if font.endswith(".ttf"):
-                    fonts.append(font)
+            fonts = [font for font in os.listdir(path) if font.endswith(".ttf")]
         return fonts or pygame.font.get_fonts(), path
 
     def render_fonts(self, text="A display of font &N"):

--- a/setup.py
+++ b/setup.py
@@ -257,9 +257,9 @@ if compile_cython:
             priority = 0
         if outdated:
             print(f'Compiling {pyx_file} because it changed.')
-            queue.append((priority, dict(pyx_file=pyx_file, c_file=c_file, fingerprint=None, quiet=False,
-                                         options=c_options, full_module_name=ext.name,
-                                         embedded_metadata=pyx_meta.get(ext.name))))
+            queue.append((priority, {'pyx_file': pyx_file, 'c_file': c_file, 'fingerprint': None, 'quiet': False,
+                                         'options': c_options, 'full_module_name': ext.name,
+                                         'embedded_metadata': pyx_meta.get(ext.name)}))
 
     # compile in right order
     queue.sort(key=lambda a: a[0])
@@ -462,16 +462,16 @@ data_files = [('pygame', pygame_data_files)]
 stub_dir = os.path.join('buildconfig', 'stubs', 'pygame')
 pygame_data_files.append(os.path.join(stub_dir, 'py.typed'))
 type_files = glob.glob(os.path.join(stub_dir, '*.pyi'))
-for type_file in type_files:
-    pygame_data_files.append(type_file)
+pygame_data_files.extend(type_files)
 
 if _sdl2_data_files := glob.glob(os.path.join(stub_dir, '_sdl2', '*.pyi')):
     data_files.append(('pygame/_sdl2', _sdl2_data_files))
 
 # add non .py files in lib directory
-for f in glob.glob(os.path.join('src_py', '*')):
-    if not f[-3:] == '.py' and not f[-4:] == '.doc' and os.path.isfile(f):
-        pygame_data_files.append(f)
+pygame_data_files += [
+    file_path for file_path in glob.glob(os.path.join('src_py', '*'))
+    if not file_path.endswith(('.doc', '.py')) and os.path.isfile(file_path)
+]
 
 # We don't need to deploy tests, example code, or docs inside a game
 

--- a/src_py/cursors.py
+++ b/src_py/cursors.py
@@ -828,17 +828,10 @@ def load_xbm(curs, mask):
         if line.startswith(possible_starts):
             break
     data = " ".join(curs[i + 1 :]).replace("};", "").replace(",", " ")
-    cursdata = []
-    for x in data.split():
-        cursdata.append(bitswap(int(x, 16)))
-    cursdata = tuple(cursdata)
+    cursdata = tuple(bitswap(int(x, 16)) for x in data.split())
     for i, line in enumerate(mask):
         if line.startswith(possible_starts):
             break
     data = " ".join(mask[i + 1 :]).replace("};", "").replace(",", " ")
-    maskdata = []
-    for x in data.split():
-        maskdata.append(bitswap(int(x, 16)))
-
-    maskdata = tuple(maskdata)
+    maskdata = tuple(bitswap(int(x, 16)) for x in data.split())
     return info[:2], info[2:], cursdata, maskdata

--- a/src_py/surfarray.py
+++ b/src_py/surfarray.py
@@ -56,10 +56,11 @@ import warnings  # will be removed in the future
 
 
 # float96 not available on all numpy versions.
-numpy_floats = []
-for type_name in "float32 float64 float96".split():
-    if hasattr(numpy, type_name):
-        numpy_floats.append(getattr(numpy, type_name))
+numpy_floats = [
+    getattr(numpy, type_name)
+    for type_name in "float32 float64 float96".split()
+    if hasattr(numpy, type_name)
+]
 # Added below due to deprecation of numpy.float. See pygame-ce issue #1440
 numpy_floats.append(float)
 

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -168,9 +168,9 @@ def _font_finder_darwin():
 
     strange_root = "/System/Library/Assets/com_apple_MobileAsset_Font3"
     if exists(strange_root):
-        strange_locations = os.listdir(strange_root)
-        for loc in strange_locations:
-            locations.append(f"{strange_root}/{loc}/AssetData")
+        locations += [
+            f"{strange_root}/{loc}/AssetData" for loc in os.listdir(strange_root)
+        ]
 
     fonts = {}
 

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1419,7 +1419,7 @@ class LineMixin(BaseLineMixin):
             (2, 1, 0),  # Too many coords.
             (2, "1"),  # Wrong type.
             {2, 1},  # Wrong type.
-            dict(((2, 1),)),
+            {2: 1},
         )  # Wrong type.
 
         for start_pos in start_pos_fmts:
@@ -1443,7 +1443,7 @@ class LineMixin(BaseLineMixin):
             (2, 1, 0),  # Too many coords.
             (2, "1"),  # Wrong type.
             {2, 1},  # Wrong type.
-            dict(((2, 1),)),
+            {2: 1},
         )  # Wrong type.
 
         for end_pos in end_pos_fmts:
@@ -2137,9 +2137,9 @@ class LinesMixin(BaseLineMixin):
             ((1, 1), (2, 2, 2)),  # Too many coords.
             ((1, 1), (2, "2")),  # Wrong type.
             ((1, 1), {2, 3}),  # Wrong type.
-            ((1, 1), dict(((2, 2), (3, 3)))),  # Wrong type.
+            ((1, 1), {2: 2, 3: 3}),  # Wrong type.
             {(1, 1), (1, 2)},  # Wrong type.
-            dict(((1, 1), (4, 4))),
+            {1: 1, 4: 4},
         )  # Wrong type.
 
         for points in points_fmts:
@@ -2714,7 +2714,7 @@ class AALineMixin(BaseLineMixin):
             (2, 1, 0),  # Too many coords.
             (2, "1"),  # Wrong type.
             {2, 1},  # Wrong type.
-            dict(((2, 1),)),
+            {2: 1},
         )  # Wrong type.
 
         for start_pos in start_pos_fmts:
@@ -2737,7 +2737,7 @@ class AALineMixin(BaseLineMixin):
             (2, 1, 0),  # Too many coords.
             (2, "1"),  # Wrong type.
             {2, 1},  # Wrong type.
-            dict(((2, 1),)),
+            {2: 1},
         )  # Wrong type.
 
         for end_pos in end_pos_fmts:
@@ -3424,9 +3424,9 @@ class AALinesMixin(BaseLineMixin):
             ((1, 1), (2, 2, 2)),  # Too many coords.
             ((1, 1), (2, "2")),  # Wrong type.
             ((1, 1), {2, 3}),  # Wrong type.
-            ((1, 1), dict(((2, 2), (3, 3)))),  # Wrong type.
+            ((1, 1), {2: 2, 3: 3}),  # Wrong type.
             {(1, 1), (1, 2)},  # Wrong type.
-            dict(((1, 1), (4, 4))),
+            {1: 1, 4: 4},
         )  # Wrong type.
 
         for points in points_fmts:
@@ -3926,9 +3926,9 @@ class DrawPolygonMixin:
             ((1, 1), (2, 1), (2, 2, 2)),  # Too many coords.
             ((1, 1), (2, 1), (2, "2")),  # Wrong type.
             ((1, 1), (2, 1), {2, 3}),  # Wrong type.
-            ((1, 1), (2, 1), dict(((2, 2), (3, 3)))),  # Wrong type.
+            ((1, 1), (2, 1), {2: 2, 3: 3}),  # Wrong type.
             {(1, 1), (2, 1), (2, 2), (1, 2)},  # Wrong type.
-            dict(((1, 1), (2, 2), (3, 3), (4, 4))),
+            {1: 1, 2: 2, 3: 3, 4: 4},
         )  # Wrong type.
 
         for points in points_fmts:
@@ -3947,7 +3947,7 @@ class DrawPolygonMixin:
         }
 
         points_fmts = (
-            tuple(),  # Too few points.
+            (),  # Too few points.
             ((1, 1),),  # Too few points.
             ((1, 1), (2, 1)),
         )  # Too few points.

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -30,9 +30,9 @@ EVENT_TEST_PARAMS.update(
     {
         pygame.KEYDOWN: {"key": pygame.K_SPACE},
         pygame.KEYUP: {"key": pygame.K_SPACE},
-        pygame.MOUSEMOTION: dict(),
-        pygame.MOUSEBUTTONDOWN: dict(button=1),
-        pygame.MOUSEBUTTONUP: dict(button=1),
+        pygame.MOUSEMOTION: {},
+        pygame.MOUSEBUTTONDOWN: {"button": 1},
+        pygame.MOUSEBUTTONUP: {"button": 1},
     }
 )
 

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -839,12 +839,12 @@ class FontTypeTest(unittest.TestCase):
         if pygame_font.__name__ == "pygame.ftfont":
             surf = pygame.Surface((1, 1))
             methods = [
-                ("get_sized_height", tuple()),
-                ("get_sized_ascender", tuple()),
-                ("get_sized_glyph_height", tuple()),
+                ("get_sized_height", ()),
+                ("get_sized_ascender", ()),
+                ("get_sized_glyph_height", ()),
                 ("get_rect", ("any text",)),
                 ("get_metrics", ("any text",)),
-                ("get_sizes", tuple()),
+                ("get_sizes", ()),
                 ("render", ("any text", True, "white")),
                 (
                     "render_to",
@@ -862,14 +862,14 @@ class FontTypeTest(unittest.TestCase):
                         None,
                     ),
                 ),
-                ("get_ascent", tuple()),
-                ("get_bold", tuple()),
-                ("get_descent", tuple()),
-                ("get_height", tuple()),
-                ("get_italic", tuple()),
-                ("get_linesize", tuple()),
-                ("get_sized_descender", tuple()),
-                ("get_underline", tuple()),
+                ("get_ascent", ()),
+                ("get_bold", ()),
+                ("get_descent", ()),
+                ("get_height", ()),
+                ("get_italic", ()),
+                ("get_linesize", ()),
+                ("get_sized_descender", ()),
+                ("get_underline", ()),
                 ("metrics", ("any text",)),
                 ("set_bold", (True,)),
                 ("set_italic", (True,)),
@@ -879,17 +879,17 @@ class FontTypeTest(unittest.TestCase):
             skip_methods = {"get_strikethrough", "set_strikethrough"}
         else:
             methods = [
-                ("get_height", tuple()),
-                ("get_descent", tuple()),
-                ("get_ascent", tuple()),
-                ("get_linesize", tuple()),
-                ("get_bold", tuple()),
+                ("get_height", ()),
+                ("get_descent", ()),
+                ("get_ascent", ()),
+                ("get_linesize", ()),
+                ("get_bold", ()),
                 ("set_bold", (True,)),
-                ("get_italic", tuple()),
+                ("get_italic", ()),
                 ("set_italic", (True,)),
-                ("get_underline", tuple()),
+                ("get_underline", ()),
                 ("set_underline", (True,)),
-                ("get_strikethrough", tuple()),
+                ("get_strikethrough", ()),
                 ("set_strikethrough", (True,)),
                 ("metrics", ("any text",)),
                 ("render", ("hello", True, "white")),
@@ -900,7 +900,7 @@ class FontTypeTest(unittest.TestCase):
             skip_methods = set()
             version = pygame.font.get_sdl_ttf_version()
             if version >= (2, 0, 18):
-                methods.append(("get_point_size", tuple()))
+                methods.append(("get_point_size", ()))
                 methods.append(("set_point_size", (34,)))
             else:
                 skip_methods.add("get_point_size")

--- a/test/mouse_test.py
+++ b/test/mouse_test.py
@@ -134,7 +134,7 @@ class MouseModuleTest(MouseTests):
             # Making sure the warnings are working properly
             self.assertEqual(len(w), 6)
             self.assertTrue(
-                all([issubclass(warn.category, DeprecationWarning) for warn in w])
+                all(issubclass(warn.category, DeprecationWarning) for warn in w)
             )
 
     @unittest.skipIf(

--- a/test/test_utils/png.py
+++ b/test/test_utils/png.py
@@ -746,7 +746,7 @@ class Writer:
                 a.extend([0] * int(extra))
                 # Pack into bytes
                 l = group(a, spb)
-                l = map(lambda e: reduce(lambda x, y: (x << self.bitdepth) + y, e), l)
+                l = (reduce(lambda x, y: (x << self.bitdepth) + y, e) for e in l)
                 data.extend(l)
 
         if self.rescale:
@@ -754,7 +754,7 @@ class Writer:
             factor = float(2 ** self.rescale[1] - 1) / float(2 ** self.rescale[0] - 1)
 
             def extend(sl):
-                oldextend(map(lambda x: int(round(factor * x)), sl))
+                oldextend((int(round(factor * x)) for x in sl))
 
         # Build the first row, testing mostly to see if we need to
         # change the extend function to cope with NumPy integer types
@@ -1642,7 +1642,7 @@ class Reader:
             mask = 2**self.bitdepth - 1
             shifts = map(self.bitdepth.__mul__, reversed(range(spb)))
             for o in raw:
-                out.extend(map(lambda i: mask & (o >> i), shifts))
+                out.extend((mask & (o >> i) for i in shifts))
             return out[:width]
 
         return map(asvalues, rows)
@@ -1941,7 +1941,7 @@ class Reader:
             )
         else:
             pixels = self.iterboxed(self.iterstraight(raw))
-        meta = dict()
+        meta = {}
         for attr in "greyscale alpha planes bitdepth interlace".split():
             meta[attr] = getattr(self, attr)
         meta["size"] = (self.width, self.height)
@@ -2128,7 +2128,7 @@ class Reader:
 
         def iterscale():
             for row in pixels:
-                yield map(lambda x: int(round(x * factor)), row)
+                yield (int(round(x * factor)) for x in row)
 
         return width, height, iterscale(), meta
 
@@ -2426,7 +2426,7 @@ class Test(unittest.TestCase):
         d = d + (255,)
         e = e + (255,)
         boxed = [(e, d, c), (d, c, a), (c, a, b)]
-        flat = map(lambda row: itertools.chain(*row), boxed)
+        flat = (itertools.chain(*row) for row in boxed)
         self.assertEqual(map(list, pixels), map(list, flat))
 
     def testRGBtoRGBA(self):
@@ -2744,8 +2744,8 @@ class Test(unittest.TestCase):
         import itertools
 
         i = itertools.islice(itertools.count(10), 20)
-        i = map(lambda x: [x, x, x], i)
-        img = from_array(i, "RGB;5", dict(height=20))
+        i = ([x, x, x] for x in i)
+        img = from_array(i, "RGB;5", {"height": 20})
         f = open("testiter.png", "wb")
         img.save(f)
         f.close()
@@ -3606,7 +3606,7 @@ def read_pam_header(infile):
     """
 
     # Unlike PBM, PGM, and PPM, we can read the header a line at a time.
-    header = dict()
+    header = {}
     while True:
         l = infile.readline().strip()
         if l == strtobytes("ENDHDR"):
@@ -3960,7 +3960,7 @@ def _main(argv):
         # care about TUPLTYPE.
         greyscale = depth <= 2
         pamalpha = depth in (2, 4)
-        supported = map(lambda x: 2**x - 1, range(1, 17))
+        supported = (2**x - 1 for x in range(1, 17))
         try:
             mi = supported.index(maxval)
         except ValueError:

--- a/test/test_utils/run_tests.py
+++ b/test/test_utils/run_tests.py
@@ -232,10 +232,11 @@ def run(*args, **kwds):
         else:
             from test.test_utils.async_sub import proc_in_time_or_kill
 
-        pass_on_args = ["--exclude", ",".join(option_exclude)]
-        for field in ["randomize", "incomplete", "unbuffered", "verbosity"]:
-            if kwds.get(field, False):
-                pass_on_args.append("--" + field)
+        pass_on_args = ["--exclude", ",".join(option_exclude)] + [
+            f"--{field}"
+            for field in ("randomize", "incomplete", "unbuffered", "verbosity")
+            if kwds.get(field)
+        ]
 
         def sub_test(module):
             print(f"loading {module}")
@@ -266,15 +267,15 @@ def run(*args, **kwds):
                     results[module] = {}
 
                 results[module].update(
-                    dict(
-                        return_code=return_code,
-                        raw_return=raw_return,
-                        cmd=cmd,
-                        test_file=test_file,
-                        test_env=test_env,
-                        working_dir=working_dir,
-                        module=module,
-                    )
+                    {
+                        "return_code": return_code,
+                        "raw_return": raw_return,
+                        "cmd": cmd,
+                        "test_file": test_file,
+                        "test_env": test_env,
+                        "working_dir": working_dir,
+                        "module": module,
+                    }
                 )
 
             t = time.time() - t


### PR DESCRIPTION
% `pipx install ruff`
% `ruff check --select=C4,PERF --statistics`
```
30	C408   	[*] Unnecessary `dict` call (rewrite as a literal)
10	C406   	[*] Unnecessary `tuple` literal (rewrite as a `dict` literal)
10	C417   	[*] Unnecessary `map` usage (rewrite using a generator expression)
 9	PERF401	[ ] Use a list comprehension to create a transformed list
 2	C419   	[*] Unnecessary list comprehension
 2	PERF203	[ ] `try`-`except` within a loop incurs performance overhead
 2	PERF402	[ ] Use `list` or `list.copy` to create a copy of a list
```
% `ruff check --select=C4,PERF --fix --unsafe-fixes`
```
Found 65 errors (52 fixed, 13 remaining).
```
% `ruff rule C408`
# unnecessary-collection-call (C408)

Derived from the **flake8-comprehensions** linter.

Fix is always available.

## What it does
Checks for unnecessary `dict`, `list` or `tuple` calls that can be
rewritten as empty literals.

## Why is this bad?
It's unnecessary to call, e.g., `dict()` as opposed to using an empty
literal (`{}`). The former is slower because the name `dict` must be
looked up in the global scope in case it has been rebound.

## Examples
```python
dict()
dict(a=1, b=2)
list()
tuple()
```

Use instead:
```python
{}
{"a": 1, "b": 2}
[]
()
```

## Fix safety
This rule's fix is marked as unsafe, as it may occasionally drop comments
when rewriting the call. In most cases, though, comments will be preserved.

## Options
- `lint.flake8-comprehensions.allow-dict-calls-with-keyword-arguments`
