### PR TITLE
`python3 setup.py lint` is deprecated: Let's lint with `pre-commit`

### DIFF
--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -11,6 +11,7 @@ on:
       - '**.c'
       - '**.py'
       - '**.rst'
+      - '.pre-commit-config.yaml'
 
   pull_request:
     branches: main
@@ -19,12 +20,22 @@ on:
       - '**.c'
       - '**.py'
       - '**.rst'
+      - '.pre-commit-config.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-format-lint
   cancel-in-progress: true
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - uses: pre-commit/action@v3.0.1
+
   format-lint-code-check:
     runs-on: ubuntu-22.04
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+# Learn more about this config here: https://pre-commit.com/
+
+# To enable these pre-commit hooks run:
+# `brew install pre-commit` or `python3 -m pip install pre-commit`
+# Then in the project root directory run `pre-commit install`
+
+repos:
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.3.0
+    hooks:
+      - id: black
+        exclude: |
+            (?x)^(
+                ^buildconfig/.*$
+                | ^docs/reST/.*$
+                | setup.py
+            )$
+
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.2
+    hooks:
+      - id: clang-format
+        exclude: |
+            (?x)^(
+                ^src_c/_sdl2/.*$
+                | ^src_c/doc/.*$
+                | docs/reST/_static/script.js
+                | docs/reST/_templates/header.h
+                | src_c/include/sse2neon.h
+                | src_c/pypm.c
+            )$


### PR DESCRIPTION
Running `python3 setup.py lint` is deprecated.  https://packaging.python.org/en/latest/discussions/setup-py-deprecated

The `setup.py` logic for running `black` and `clang-format` is ~100 lines long and is skipping many Python and C files.
https://github.com/pygame-community/pygame-ce/blob/65a256d9464ae22141ac9622ca35c558d293509f/setup.py#L786-L875

This pull request proposes using [`pre-commit`](https://pre-commit.com) with ~25 lines of configuration to rapidly run these two tools locally on contributors' machines and also in our GitHub Actions to cover any contributors who do not have `pre-commit` installed.

The 15 `exclude` lines should be removed gradually as more of the codebase passes the formatting and linting process.

### How to use:
```bash
brew install pre-commit  # or `python3 -m pip install pre-commit`

pre-commit install
    > pre-commit installed at .git/hooks/pre-commit

pre-commit autoupdate
    > [https://github.com/psf/black-pre-commit-mirror] already up to date!
    > [https://github.com/pre-commit/mirrors-clang-format] already up to date!

pre-commit run --all-files
    > black....................................................................Passed
    > clang-format.............................................................Passed
```