### PR TITLE
Make error messages for using font.align clearer

### DIFF
--- a/src_c/font.c
+++ b/src_c/font.c
@@ -486,14 +486,14 @@ font_setter_align(PyObject *self, PyObject *value, void *closure)
     if (val == -1 && PyErr_Occurred()) {
         PyErr_SetString(
             PyExc_TypeError,
-            "font.align must be an integer."
-            "Must correspond with FONT_LEFT, FONT_CENTER, or FONT_RIGHT");
+            "font.align must be an integer. "
+            "Must correspond with FONT_LEFT, FONT_CENTER, or FONT_RIGHT.");
         return -1;
     }
 
     if (val < 0 || val > 2) {
         PyErr_SetString(pgExc_SDLError,
-                        "font.align must be FONT_LEFT, FONT_CENTER, or"
+                        "font.align must be FONT_LEFT, FONT_CENTER, or "
                         "FONT_RIGHT.");
         return -1;
     }

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -492,9 +492,9 @@ font_setter_align(PyObject *self, PyObject *value, void *closure)
     }
 
     if (val < 0 || val > 2) {
-        PyErr_SetString(
-            pgExc_SDLError,
-            "font.align should be FONT_LEFT, FONT_CENTER, or FONT_RIGHT, (0, 1 or 2)");
+        PyErr_SetString(pgExc_SDLError,
+                        "font.align should be FONT_LEFT, FONT_CENTER, or "
+                        "FONT_RIGHT, (0, 1 or 2)");
         return -1;
     }
 

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -486,15 +486,15 @@ font_setter_align(PyObject *self, PyObject *value, void *closure)
     if (val == -1 && PyErr_Occurred()) {
         PyErr_SetString(
             PyExc_TypeError,
-            "font.align should be an integer."
+            "font.align must be an integer."
             "Must correspond with FONT_LEFT, FONT_CENTER, or FONT_RIGHT");
         return -1;
     }
 
     if (val < 0 || val > 2) {
         PyErr_SetString(pgExc_SDLError,
-                        "font.align should be FONT_LEFT, FONT_CENTER, or "
-                        "FONT_RIGHT, (0, 1 or 2)");
+                        "font.align must be FONT_LEFT, FONT_CENTER, or"
+                        "FONT_RIGHT.");
         return -1;
     }
 

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -484,14 +484,17 @@ font_setter_align(PyObject *self, PyObject *value, void *closure)
 
     long val = PyLong_AsLong(value);
     if (val == -1 && PyErr_Occurred()) {
-        PyErr_SetString(PyExc_TypeError, "font.align should be an integer");
+        PyErr_SetString(
+            PyExc_TypeError,
+            "font.align should be an integer."
+            "Must correspond with FONT_LEFT, FONT_CENTER, or FONT_RIGHT");
         return -1;
     }
 
     if (val < 0 || val > 2) {
         PyErr_SetString(
             pgExc_SDLError,
-            "font.align should be FONT_LEFT, FONT_CENTER, or FONT_RIGHT");
+            "font.align should be FONT_LEFT, FONT_CENTER, or FONT_RIGHT, (0, 1 or 2)");
         return -1;
     }
 


### PR DESCRIPTION
Hello, while using font.align in a project, I passed it bad data, and the error message was not clear, and I had to read the source code to work out what the error message actually meant. 
The problem is when you pass something that is not FONT_LEFT, FONT_CENTER, or FONT_RIGHT it says it must be an integer, but to the end user it might appear that FONT_LEFT is not an integer, and they might be confused about what they need to parse. 

I had a function that drew some text, and it was something like this
```python
self.fontObj.align = self.textJustify
```
Then when i passed it the wrong type, the error message said it must be an integer, and I thought "I thought it was pygame.FONT_LEFT!" 

I hope that this change makes it more clear to any users in the future.