### PR TITLE
Remove apt upgrade in CI

### DIFF
--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -59,9 +59,7 @@ jobs:
       # https://github.com/actions/runner-images/issues/7192
       # https://github.com/orgs/community/discussions/47863
       run: |
-        sudo apt-mark hold grub-efi-amd64-signed
         sudo apt-get update --fix-missing
-        sudo apt-get upgrade
         sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev python3-setuptools python3-dev
         pip3 install sphinx"<7.2.0" numpy>=1.21.0
 

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -28,9 +28,7 @@ jobs:
         # https://github.com/actions/runner-images/issues/7192
         # https://github.com/orgs/community/discussions/47863
         run: |
-          sudo apt-mark hold grub-efi-amd64-signed
           sudo apt-get update --fix-missing
-          sudo apt-get upgrade
           sudo apt install cppcheck
 
       - name: Run Static Checker


### PR DESCRIPTION
I can't seem to remember why the update/upgrade was added in CI in the first place. Anyways, I'm now trying to remove it because every once in a while this step likes to break, and I don't think there's a benefit of having this extra step