### PR TITLE
Add armv6 and armv7 to multiarch CI and fix build issues

### DIFF
--- a/.github/workflows/build-debian-multiarch.yml
+++ b/.github/workflows/build-debian-multiarch.yml
@@ -35,26 +35,45 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-debian-multiarch
   cancel-in-progress: true
 
+# this command is called in two places, so save it in an env first
+env:
+  INSTALL_CMD: |
+    apt-get update --fix-missing
+    apt-get upgrade -y
+    apt-get install build-essential meson -y
+    apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev -y
+    apt-get install libfreetype6-dev libportmidi-dev fontconfig -y
+    apt-get install python3-dev python3-pip python3-wheel python3-sphinx -y
+    pip3 install meson-python --break-system-packages
+
 jobs:
   build-multiarch:
-    name: Debian (Bullseye - 11) [${{ matrix.arch }}]
+    name: Debian (Bookworm - 12) [${{ matrix.arch }}]
     runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       matrix:
         # maybe more things could be added in here in the future (if needed)
-        arch: [s390x, ppc64le]
+        include:
+          - { arch: s390x, base_image: '' }
+          - { arch: ppc64le, base_image: '' }
+          - { arch: armv6, base_image: '' }
+          # a custom base_image is specified in the armv7 case. This is done because
+          # the armv6 image is just raspbian in disguise. And the wheel built on armv7
+          # is going to be tested on armv6
+          - { arch: armv7, base_image: 'balenalib/raspberrypi3-debian:bookworm' }
 
     steps:
     - uses: actions/checkout@v4.1.2
 
     - name: Build sources and run tests
-      uses: uraimo/run-on-arch-action@v2.7.1
+      uses: uraimo/run-on-arch-action@v2.7.2
       id: build
       with:
-        arch: ${{ matrix.arch }}
-        distro: bullseye
+        arch: ${{ matrix.base_image && 'none' || matrix.arch }}
+        distro: ${{ matrix.base_image && 'none' || 'bookworm' }}
+        base_image: ${{ matrix.base_image }}
 
         # Not required, but speeds up builds
         githubToken: ${{ github.token }}
@@ -74,19 +93,61 @@ jobs:
         # builds don't have to re-install them. The image layer is cached
         # publicly in your project's package repository, so it is vital that
         # no secrets are present in the container state or logs.
-        install: |
-          apt-get update --fix-missing
-          apt-get upgrade -y
-          apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev fontconfig -y
-          apt-get install python3-setuptools python3-dev python3-pip python3-wheel python3-sphinx -y
+        install: ${{ env.INSTALL_CMD }}
 
-        # Build a wheel, install it for running unit tests
+        # Build a wheel, install it for running unit tests.
+        # --no-build-isolation is passed so that preinstalled meson-python can be used
+        # (done for optimization reasons)
         run: |
           echo "\nBuilding pygame wheel\n"
           python3 setup.py docs
-          pip3 wheel . --wheel-dir /artifacts -vvv
+          pip3 wheel . --no-build-isolation --wheel-dir /artifacts -vvv
           echo "\nInstalling wheel\n"
-          pip3 install --no-index --pre --find-links /artifacts pygame-ce
+          pip3 install --no-index --pre --break-system-packages --find-links /artifacts pygame-ce
+          echo "\nRunning tests\n"
+          export SDL_VIDEODRIVER=dummy
+          export SDL_AUDIODRIVER=disk
+          python3 -m pygame.tests -v --exclude opengl,music,timing --time_out 300
+    
+    # Upload the generated files under github actions assets section
+    - name: Upload dist
+      uses: actions/upload-artifact@v4
+      with:
+        name: pygame-multiarch-${{ matrix.arch }}-dist
+        path: ~/artifacts/*.whl
+
+  # test wheels built on armv7 on armv6. Why?
+  # because piwheels expects the same armv7 wheel to work on both armv7 and armv6
+  test-armv7-on-armv6:
+    needs: build-multiarch
+    name: Debian (Bookworm - 12) [build - armv7, test - armv6]
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Download all multiarch artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: pygame-multiarch-armv7-dist
+        path: ~/artifacts
+
+    - name: Rename arm wheel in artifacts
+      run: |
+        cd ~/artifacts
+        for f in *; do
+          mv "$f" "${f//armv7l/armv6l}"
+        done
+
+    - name: Test armv7 wheel on armv6
+      uses: uraimo/run-on-arch-action@v2.7.2
+      with:
+        arch: armv6
+        distro: bookworm
+        githubToken: ${{ github.token }}
+        dockerRunArgs: --volume ~/artifacts:/artifacts_new
+        shell: /bin/sh
+        install: ${{ env.INSTALL_CMD }}
+        run: |
+          echo "\nInstalling wheel\n"
+          pip3 install --no-index --pre --break-system-packages --find-links /artifacts_new pygame-ce
           echo "\nRunning tests\n"
           export SDL_VIDEODRIVER=dummy
           export SDL_AUDIODRIVER=disk

--- a/meson.build
+++ b/meson.build
@@ -293,8 +293,8 @@ if host_machine.cpu_family() == 'arm'
     # first check if compiler supports the flag, and use it then. Needed only
     # on 32-bit armv7.
     flag = '-mfpu=neon'
-    if cc.has_argument(flag)
-        simd_sse2_neon_flags += flag
+    if cc.has_argument(flag) and host_machine.cpu() == 'armv7l'
+        simd_sse2_neon_flags += [flag, '-march=armv7-a']
         simd_sse2_neon = true
     endif
 elif host_machine.cpu_family() == 'aarch64'

--- a/src_c/simd_fill.h
+++ b/src_c/simd_fill.h
@@ -21,11 +21,6 @@
 #endif
 #endif
 
-#if PG_ENABLE_ARM_NEON
-// sse2neon.h is from here: https://github.com/DLTcollab/sse2neon
-#include "include/sse2neon.h"
-#endif /* PG_ENABLE_ARM_NEON */
-
 #if defined(__SSE2__)
 #define PG_ENABLE_SSE_NEON 1
 #elif PG_ENABLE_ARM_NEON

--- a/src_c/simd_shared.h
+++ b/src_c/simd_shared.h
@@ -33,11 +33,6 @@ pg_has_avx2();
 #endif
 #endif
 
-#if PG_ENABLE_ARM_NEON
-// sse2neon.h is from here: https://github.com/DLTcollab/sse2neon
-#include "include/sse2neon.h"
-#endif /* PG_ENABLE_ARM_NEON */
-
 /* This defines PG_ENABLE_SSE_NEON as True if either SSE or NEON is available
  * at compile time. Since we do compile time translation of SSE2->NEON, they
  * have the same code paths, so this reduces code duplication of those paths.

--- a/src_c/simd_surface_fill_sse2.c
+++ b/src_c/simd_surface_fill_sse2.c
@@ -1,5 +1,10 @@
 #include "simd_fill.h"
 
+#if PG_ENABLE_ARM_NEON
+// sse2neon.h is from here: https://github.com/DLTcollab/sse2neon
+#include "include/sse2neon.h"
+#endif /* PG_ENABLE_ARM_NEON */
+
 #define BAD_SSE2_FUNCTION_CALL                                               \
     printf(                                                                  \
         "Fatal Error: Attempted calling an SSE2 function when both compile " \


### PR DESCRIPTION
This PR mainly does ~~3~~ 2 things
- ~~Fixes arm32 specific warnings across the codebase~~ Has been moved out to be done in a later PR
- Fixes compilation on arm32 (both armv6 and armv7) under the meson build system. As a result of the meson PR, the NEON optimizations are enabled by default on armv7 now (in the legacy buildconfig it is controlled via an opt in flag). Now that it is much easier to pass per file flags, the flags needed to build with `sse2neon.h` are only passed to the files that need it. Therefore, I made it so that only the files that require the `sse2neon.h` header include it. If any file that shouldn't be including it tries to include it, the compilation fails.
- And now coming to the good stuff, we finally have testing on CI to verify that we support both armv6 and armv7 based raspberrypi-like systems! The first level of testing tests that a wheel can be built and unit test can be run on armv6 and armv7. The second level of testing tests that an armv7 wheel can simply be renamed to lie that it's an armv6 wheel, and still pass tests on armv6 hardware. This is important because piwheels does exactly this to package `pygame-ce` wheels over at https://www.piwheels.org/project/pygame-ce/