### PR TITLE
build-ubuntu-sdist.yml: If at first you don't succeed, try again

### DIFF
--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -63,7 +63,8 @@ jobs:
       run: |
         sudo apt-mark hold grub-efi-amd64-signed
         sudo apt-get update --fix-missing
-        sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev python3-setuptools python3-dev
+        sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
+                             libfreetype6-dev libportmidi-dev python3-setuptools python3-dev
         pip3 install sphinx"<7.2.0" numpy>=1.21.0
 
     - name: Install deps retry
@@ -71,7 +72,8 @@ jobs:
       run: |
         sudo apt-mark hold grub-efi-amd64-signed
         sudo apt-get update --fix-missing
-        sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev python3-setuptools python3-dev
+        sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
+                             libfreetype6-dev libportmidi-dev python3-setuptools python3-dev
         pip3 install sphinx"<7.2.0" numpy>=1.21.0
 
     - name: Make sdist and install it

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -54,6 +54,8 @@ jobs:
     - uses: actions/checkout@v4.1.2
 
     - name: Install deps
+      id: install_deps
+      continue-on-error: true
       # install numpy from pip and not apt because the one from pip is newer,
       # and has typestubs
       # https://github.com/actions/runner-images/issues/7192
@@ -61,7 +63,14 @@ jobs:
       run: |
         sudo apt-mark hold grub-efi-amd64-signed
         sudo apt-get update --fix-missing
-        sudo apt-get upgrade
+        sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev python3-setuptools python3-dev
+        pip3 install sphinx"<7.2.0" numpy>=1.21.0
+
+    - name: Install deps retry
+      if: steps.install_deps.outcome == 'failure'
+      run: |
+        sudo apt-mark hold grub-efi-amd64-signed
+        sudo apt-get update --fix-missing
         sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev python3-setuptools python3-dev
         pip3 install sphinx"<7.2.0" numpy>=1.21.0
 


### PR DESCRIPTION
Related to:
* #2778

Our `build-ubuntu-sdist` GitHub Action often seems to fail with:
```
E: Failed to fetch https://packages.microsoft.com/ubuntu/20.04/prod/pool/main/d/dotnet-sdk-8.0/dotnet-sdk-8.0_8.0.203-1_amd64.deb  Connection failed [IP: 13.107.213.51 443]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```
Like in https://github.com/pygame-community/pygame-ce/actions/runs/8495824978

If it fails, let's try one more time.