### PR TITLE
Unify freetype init codepaths

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -748,84 +748,6 @@ _ftfont_init(pgFontObject *self, PyObject *args, PyObject *kwds)
         }
     }
 
-#if !defined(WIN32)
-    file = pg_EncodeString(file, "UTF-8", NULL, NULL);
-    if (!file) {
-        goto end;
-    }
-    if (PyBytes_Check(file)) {
-        if (PyUnicode_Check(original_file)) {
-            /* Make sure to save a pure Unicode object to prevent possible
-             * cycles from a derived class. This means no tp_traverse or
-             * tp_clear for the PyFreetypeFont type.
-             */
-            self->path = PyObject_Str(original_file);
-        }
-        else {
-            self->path = PyUnicode_FromEncodedObject(file, "UTF-8", NULL);
-        }
-        if (!self->path) {
-            goto end;
-        }
-
-        if (_PGFT_TryLoadFont_Filename(ft, self, PyBytes_AS_STRING(file),
-                                       font_index)) {
-            goto end;
-        }
-    }
-    else {
-        PyObject *str = 0;
-        PyObject *path = 0;
-#ifndef WITH_THREAD
-        goto end;
-#endif
-        source = pgRWops_FromFileObject(original_file);
-        if (!source) {
-            goto end;
-        }
-
-        if (source->size(source) <= 0) {
-            PyErr_Format(PyExc_ValueError,
-                         "Font file object has an invalid file size: %lld",
-                         source->size(source));
-            goto end;
-        }
-
-        path = PyObject_GetAttrString(original_file, "name");
-        if (!path) {
-            PyErr_Clear();
-            str = PyBytes_FromFormat("<%s instance at %p>",
-                                     Py_TYPE(file)->tp_name, (void *)file);
-            if (str) {
-                self->path =
-                    PyUnicode_FromEncodedObject(str, "ascii", "strict");
-                Py_DECREF(str);
-            }
-        }
-        else if (PyUnicode_Check(path)) {
-            /* Make sure to save a pure Unicode object to prevent possible
-             * cycles from a derived class. This means no tp_traverse or
-             * tp_clear for the PyFreetypeFont type.
-             */
-            self->path = PyObject_Str(path);
-        }
-        else if (PyBytes_Check(path)) {
-            self->path = PyUnicode_FromEncodedObject(path, "UTF-8", NULL);
-        }
-        else {
-            self->path = PyObject_Str(path);
-        }
-        Py_XDECREF(path);
-        if (!self->path) {
-            goto end;
-        }
-
-        if (_PGFT_TryLoadFont_RWops(ft, self, source, font_index)) {
-            goto end;
-        }
-    }
-#else  /* WIN32 */
-    /* FT uses fopen(); as a workaround, always use RWops */
     if (file == original_file)
         Py_INCREF(file);
     if (!PG_CHECK_THREADS())
@@ -886,7 +808,6 @@ _ftfont_init(pgFontObject *self, PyObject *args, PyObject *kwds)
     if (_PGFT_TryLoadFont_RWops(ft, self, source, font_index)) {
         goto end;
     }
-#endif /* WIN32 */
 
     if (!self->is_scalable && self->face_size.x == 0) {
         if (_PGFT_Font_GetAvailableSize(ft, self, 0, &size, &height, &width,


### PR DESCRIPTION
The freetype.Font init code has a windows codepath and an "everything else" codepath. I think that the windows codepath would work everywhere, so let's try using it everywhere.

Why am I mucking around with this? Because SDL3 changes rwops stuff and freetype looks like it might be the most complex use of rwops we have. If we can make it simpler that will help the transition. This is similar to #2717 in that regard.