### PR TITLE
(Freetype) use calloc where possible

### DIFF
--- a/src_c/freetype/ft_cache.c
+++ b/src_c/freetype/ft_cache.c
@@ -134,7 +134,6 @@ int
 _PGFT_Cache_Init(FreeTypeInstance *ft, FontCache *cache)
 {
     int cache_size = MAX(ft->cache_size - 1, PGFT_MIN_CACHE_SIZE - 1);
-    int i;
 
     /*
      * Make sure this is a power of 2.
@@ -147,18 +146,15 @@ _PGFT_Cache_Init(FreeTypeInstance *ft, FontCache *cache)
 
     cache_size = cache_size + 1;
 
-    cache->nodes = _PGFT_malloc((size_t)cache_size * sizeof(FontGlyph *));
+    cache->nodes = _PGFT_calloc((size_t)cache_size, sizeof(FontGlyph *));
     if (!cache->nodes)
         return -1;
-    for (i = 0; i < cache_size; ++i)
-        cache->nodes[i] = 0;
-    cache->depths = _PGFT_malloc((size_t)cache_size);
+    cache->depths = _PGFT_calloc((size_t)cache_size, sizeof(FT_Byte));
     if (!cache->depths) {
         _PGFT_free(cache->nodes);
         cache->nodes = 0;
         return -1;
     }
-    memset(cache->depths, 0, cache_size);
     cache->free_nodes = 0;
     cache->size_mask = (FT_UInt32)(cache_size - 1);
 
@@ -307,13 +303,12 @@ static CacheNode *
 allocate_node(FontCache *cache, const FontRenderMode *render, GlyphIndex_t id,
               void *internal)
 {
-    CacheNode *node = _PGFT_malloc(sizeof(CacheNode));
+    CacheNode *node = _PGFT_calloc(1, sizeof(CacheNode));
     FT_UInt32 bucket;
 
     if (!node) {
         return 0;
     }
-    memset(node, 0, sizeof(CacheNode));
 
     if (_PGFT_LoadGlyph(&node->glyph, id, render, internal)) {
         goto cleanup;

--- a/src_c/freetype/ft_wrap.c
+++ b/src_c/freetype/ft_wrap.c
@@ -401,12 +401,11 @@ ft_wrap_init(FreeTypeInstance *ft, pgFontObject *fontobj)
     }
     fontobj->is_scalable = FT_IS_SCALABLE(font) ? ~0 : 0;
 
-    fontobj->_internals = _PGFT_malloc(sizeof(FontInternals));
+    fontobj->_internals = _PGFT_calloc(1, sizeof(FontInternals));
     if (!fontobj->_internals) {
         PyErr_NoMemory();
         return -1;
     }
-    memset(fontobj->_internals, 0x0, sizeof(FontInternals));
 
     if (_PGFT_LayoutInit(ft, fontobj)) {
         _PGFT_free(fontobj->_internals);
@@ -493,12 +492,11 @@ _PGFT_TryLoadFont_RWops(FreeTypeInstance *ft, pgFontObject *fontobj,
         return -1;
     }
 
-    stream = _PGFT_malloc(sizeof(*stream));
+    stream = _PGFT_calloc(1, sizeof(*stream));
     if (!stream) {
         PyErr_NoMemory();
         return -1;
     }
-    memset(stream, 0, sizeof(*stream));
     stream->read = RWops_read;
     stream->descriptor.pointer = src;
     stream->pos = (unsigned long)position;

--- a/src_c/freetype/ft_wrap.h
+++ b/src_c/freetype/ft_wrap.h
@@ -432,6 +432,7 @@ _PGFT_GetFontSized(FreeTypeInstance *, pgFontObject *, Scale_t);
 void
 _PGFT_BuildScaler(pgFontObject *, FTC_Scaler, Scale_t);
 #define _PGFT_malloc PyMem_Malloc
+#define _PGFT_calloc PyMem_Calloc
 #define _PGFT_free PyMem_Free
 
 #endif


### PR DESCRIPTION
I was poking around freetype and saw some malloc+memset pairs, which could instead be expressed as a calloc.

This is slightly simpler code to do, and might be faster. *Not that perf really matters for these calls, they are infrequent.