### PR TITLE
Fix sdist to include meson stuff and minor updates

### DIFF
--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -61,6 +61,7 @@ jobs:
       run: |
         sudo apt-get update --fix-missing
         sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev python3-setuptools python3-dev
+        pip3 install --upgrade pip
         pip3 install sphinx"<7.2.0" numpy>=1.21.0
 
     - name: Make sdist and install it

--- a/buildconfig/MANIFEST.in
+++ b/buildconfig/MANIFEST.in
@@ -7,8 +7,12 @@ recursive-include test *
 
 recursive-exclude buildconfig/ci *
 recursive-exclude buildconfig/manylinux-build *
+recursive-exclude buildconfig/macdependencies *
+recursive-exclude buildconfig/stubs/.mypy_cache *
 
 include README.rst
+include meson_options.txt
+include meson.build
+include pyproject.toml
 
-exclude buildconfig/appveyor.yml
-exclude .travis.yml
+global-exclude *.pyc


### PR DESCRIPTION
This PR ensures three files are bundled in our sdist wheels: `pyproject.toml`, `meson.build` and `meson_options.txt`.

With this change, anyone attempting an sdist install will be making use of the new buildconfig by default (though the old one can still be used with some flags or workarounds)

I also added excludes of files unneeded in sdist builds: pyc files, mypy cache files and mac ci files.