### PR TITLE
Use macros for (Bytes|Bits)PerPixel compat in SDL3

### DIFF
--- a/src_c/SDL_gfx/SDL_gfxPrimitives.c
+++ b/src_c/SDL_gfx/SDL_gfxPrimitives.c
@@ -79,7 +79,7 @@ fastPixelColorNolock(SDL_Surface *dst, Sint16 x, Sint16 y, Uint32 color)
         /*
          * Get destination format
          */
-        bpp = dst->format->BytesPerPixel;
+        bpp = GFX_SURF_BytesPerPixel(dst);
         p = (Uint8 *)dst->pixels + y * dst->pitch + x * bpp;
         switch (bpp) {
             case 1:
@@ -131,7 +131,7 @@ int fastPixelColorNolockNoclip(SDL_Surface * dst, Sint16 x, Sint16 y, Uint32 col
 	/*
 	* Get destination format
 	*/
-	bpp = dst->format->BytesPerPixel;
+	bpp = GFX_SURF_BytesPerPixel(dst);
 	p = (Uint8 *) dst->pixels + y * dst->pitch + x * bpp;
 	switch (bpp) {
 	case 1:
@@ -287,7 +287,7 @@ _putPixelAlpha(SDL_Surface *dst, Sint16 x, Sint16 y, Uint32 color, Uint8 alpha)
         y <= clip_ymax(dst)) {
         format = dst->format;
 
-        switch (format->BytesPerPixel) {
+        switch (GFX_FORMAT_BytesPerPixel(format)) {
             case 1: { /* Assuming 8-bpp */
                 if (alpha == 255) {
                     *((Uint8 *)dst->pixels + y * dst->pitch + x) = color;
@@ -602,7 +602,7 @@ _filledRectAlpha(SDL_Surface *dst, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2,
     Sint16 x, y;
 
     format = dst->format;
-    switch (format->BytesPerPixel) {
+    switch (GFX_FORMAT_BytesPerPixel(format)) {
         case 1: { /* Assuming 8-bpp */
             Uint8 *row, *pixel;
             Uint8 dR, dG, dB;
@@ -1098,14 +1098,14 @@ hlineColorStore(SDL_Surface *dst, Sint16 x1, Sint16 x2, Sint16 y, Uint32 color)
      * More variable setup
      */
     dx = w;
-    pixx = dst->format->BytesPerPixel;
+    pixx = GFX_SURF_BytesPerPixel(dst);
     pixy = dst->pitch;
     pixel = ((Uint8 *)dst->pixels) + pixx * (int)x1 + pixy * (int)y;
 
     /*
      * Draw
      */
-    switch (dst->format->BytesPerPixel) {
+    switch (GFX_SURF_BytesPerPixel(dst)) {
         case 1:
             memset(pixel, color, dx + 1);
             break;
@@ -1288,14 +1288,14 @@ hlineColor(SDL_Surface *dst, Sint16 x1, Sint16 x2, Sint16 y, Uint32 color)
         /*
          * More variable setup
          */
-        pixx = dst->format->BytesPerPixel;
+        pixx = GFX_SURF_BytesPerPixel(dst);
         pixy = dst->pitch;
         pixel = ((Uint8 *)dst->pixels) + pixx * (int)x1 + pixy * (int)y;
 
         /*
          * Draw
          */
-        switch (dst->format->BytesPerPixel) {
+        switch (GFX_SURF_BytesPerPixel(dst)) {
             case 1:
                 memset(pixel, color, dx + 1);
                 break;
@@ -1484,7 +1484,7 @@ vlineColor(SDL_Surface *dst, Sint16 x, Sint16 y1, Sint16 y2, Uint32 color)
          * More variable setup
          */
         dy = h;
-        pixx = dst->format->BytesPerPixel;
+        pixx = GFX_SURF_BytesPerPixel(dst);
         pixy = dst->pitch;
         pixel = ((Uint8 *)dst->pixels) + pixx * (int)x + pixy * (int)y1;
         pixellast = pixel + pixy * dy;
@@ -1492,7 +1492,7 @@ vlineColor(SDL_Surface *dst, Sint16 x, Sint16 y1, Sint16 y2, Uint32 color)
         /*
          * Draw
          */
-        switch (dst->format->BytesPerPixel) {
+        switch (GFX_SURF_BytesPerPixel(dst)) {
             case 1:
                 for (; pixel <= pixellast; pixel += pixy) {
                     *(Uint8 *)pixel = color;
@@ -2265,7 +2265,7 @@ boxColor(SDL_Surface *dst, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2,
          */
         dx = w;
         dy = h;
-        pixx = dst->format->BytesPerPixel;
+        pixx = GFX_SURF_BytesPerPixel(dst);
         pixy = dst->pitch;
         pixel = ((Uint8 *)dst->pixels) + pixx * (int)x1 + pixy * (int)y1;
         pixellast = pixel + pixx * dx + pixy * dy;
@@ -2274,7 +2274,7 @@ boxColor(SDL_Surface *dst, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2,
         /*
          * Draw
          */
-        switch (dst->format->BytesPerPixel) {
+        switch (GFX_SURF_BytesPerPixel(dst)) {
             case 1:
                 for (; pixel <= pixellast; pixel += pixy) {
                     memset(pixel, (Uint8)color, dx);
@@ -2463,7 +2463,7 @@ lineColor(SDL_Surface *dst, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2,
          */
         dx = sx * dx + 1;
         dy = sy * dy + 1;
-        pixx = dst->format->BytesPerPixel;
+        pixx = GFX_SURF_BytesPerPixel(dst);
         pixy = dst->pitch;
         pixel = ((Uint8 *)dst->pixels) + pixx * (int)x1 + pixy * (int)y1;
         pixx *= sx;
@@ -2482,7 +2482,7 @@ lineColor(SDL_Surface *dst, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2,
          */
         x = 0;
         y = 0;
-        switch (dst->format->BytesPerPixel) {
+        switch (GFX_SURF_BytesPerPixel(dst)) {
             case 1:
                 for (; x < dx; x++, pixel += pixx) {
                     *pixel = color;

--- a/src_c/SDL_gfx/SDL_gfxPrimitives.h
+++ b/src_c/SDL_gfx/SDL_gfxPrimitives.h
@@ -27,6 +27,20 @@ extern "C" {
 #define SDL_GFXPRIMITIVES_MINOR 0
 #define SDL_GFXPRIMITIVES_MICRO 23
 
+/* ---- Compatibility */
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+#define GFX_SURF_BitsPerPixel(surf) surf->format->bits_per_pixel
+#define GFX_SURF_BytesPerPixel(surf) surf->format->bytes_per_pixel
+#define GFX_FORMAT_BitsPerPixel(format) format->bits_per_pixel
+#define GFX_FORMAT_BytesPerPixel(format) format->bytes_per_pixel
+#else
+#define GFX_SURF_BitsPerPixel(surf) surf->format->BitsPerPixel
+#define GFX_SURF_BytesPerPixel(surf) surf->format->BytesPerPixel
+#define GFX_FORMAT_BitsPerPixel(format) format->BitsPerPixel
+#define GFX_FORMAT_BytesPerPixel(format) format->BytesPerPixel
+#endif
+
 /* ---- Function Prototypes */
 
 #ifdef _MSC_VER

--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -124,7 +124,7 @@ surf_colorspace(PyObject *self, PyObject *arg)
                      "Surfaces not the same width and height.");
 
     /* check to see if the format of the surface is the same. */
-    if (surf->format->BitsPerPixel != newsurf->format->BitsPerPixel)
+    if (PG_SURF_BitsPerPixel(surf) != PG_SURF_BitsPerPixel(newsurf))
         return RAISE(PyExc_ValueError, "Surfaces not the same depth");
 
     SDL_LockSurface(newsurf);
@@ -505,7 +505,7 @@ rgb24_to_rgb(const void *src, void *dst, int length, SDL_PixelFormat *format)
     gloss = format->Gloss;
     bloss = format->Bloss;
 
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             d8 = (Uint8 *)dst;
             while (length--) {
@@ -567,7 +567,7 @@ bgr32_to_rgb(const void *src, void *dst, int length, SDL_PixelFormat *format)
     gloss = format->Gloss;
     bloss = format->Bloss;
 
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             d8 = (Uint8 *)dst;
             while (length--) {
@@ -681,7 +681,7 @@ rgb_to_hsv(const void *src, void *dst, int length, unsigned long source,
                     h = 170 + 43 * (r - g) / delta;
                 }
             }
-            switch (format->BytesPerPixel) {
+            switch (PG_FORMAT_BytesPerPixel(format)) {
                 case 1:
                     *d8++ = ((h >> rloss) << rshift) |
                             ((s >> gloss) << gshift) |
@@ -707,7 +707,7 @@ rgb_to_hsv(const void *src, void *dst, int length, unsigned long source,
     }
     else { /* for use as stage 2 in yuv or bayer to hsv, r and b switched */
         while (length--) {
-            switch (format->BytesPerPixel) {
+            switch (PG_FORMAT_BytesPerPixel(format)) {
                 case 1:
                     r = *s8 >> rshift << rloss;
                     g = *s8 >> gshift << gloss;
@@ -749,7 +749,7 @@ rgb_to_hsv(const void *src, void *dst, int length, unsigned long source,
                     h = 170 + 43 * (r - g) / delta;
                 }
             }
-            switch (format->BytesPerPixel) {
+            switch (PG_FORMAT_BytesPerPixel(format)) {
                 case 1:
                     *d8++ = ((h >> rloss) << rshift) |
                             ((s >> gloss) << gshift) |
@@ -826,7 +826,7 @@ rgb_to_yuv(const void *src, void *dst, int length, unsigned long source,
             v = ((112 * r - 94 * g - 18 * b + 128) >> 8) + 128;  /* V */
             u = ((-38 * r - 74 * g + 112 * b + 128) >> 8) + 128; /* U */
             y = (77 * r + 150 * g + 29 * b + 128) >> 8;          /* Y */
-            switch (format->BytesPerPixel) {
+            switch (PG_FORMAT_BytesPerPixel(format)) {
                 case 1:
                     *d8++ = ((y >> rloss) << rshift) |
                             ((u >> gloss) << gshift) |
@@ -851,7 +851,7 @@ rgb_to_yuv(const void *src, void *dst, int length, unsigned long source,
         }
     }
     else { /* for use as stage 2 in bayer to yuv, r and b switched */
-        switch (format->BytesPerPixel) {
+        switch (PG_FORMAT_BytesPerPixel(format)) {
             case 1:
                 while (length--) {
                     r = *s8 >> rshift << rloss;
@@ -932,7 +932,7 @@ rgb444_to_rgb(const void *src, void *dst, int length, SDL_PixelFormat *format)
     gloss = format->Gloss;
     bloss = format->Bloss;
 
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             d8 = (Uint8 *)dst;
             while (length--) {
@@ -1026,7 +1026,7 @@ yuyv_to_rgb(const void *src, void *dst, int length, SDL_PixelFormat *format)
         b2 = SAT2(y2 + u1);
 
         /* choose the right pixel packing for the destination surface depth */
-        switch (format->BytesPerPixel) {
+        switch (PG_FORMAT_BytesPerPixel(format)) {
             case 1:
                 *d8++ = ((r1 >> rloss) << rshift) | ((g1 >> gloss) << gshift) |
                         ((b1 >> bloss) << bshift);
@@ -1076,7 +1076,7 @@ yuyv_to_yuv(const void *src, void *dst, int length, SDL_PixelFormat *format)
     bloss = format->Bloss;
     s = (Uint8 *)src;
 
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             d8 = (Uint8 *)dst;
             while (i--) {
@@ -1180,7 +1180,7 @@ uyvy_to_rgb(const void *src, void *dst, int length, SDL_PixelFormat *format)
         b2 = SAT2(y2 + u1);
 
         /* choose the right pixel packing for the destination surface depth */
-        switch (format->BytesPerPixel) {
+        switch (PG_FORMAT_BytesPerPixel(format)) {
             case 1:
                 *d8++ = ((r1 >> rloss) << rshift) | ((g1 >> gloss) << gshift) |
                         ((b1 >> bloss) << bshift);
@@ -1229,7 +1229,7 @@ uyvy_to_yuv(const void *src, void *dst, int length, SDL_PixelFormat *format)
     bloss = format->Bloss;
     s = (Uint8 *)src;
 
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             d8 = (Uint8 *)dst;
             while (i--) {
@@ -1405,7 +1405,7 @@ sbggr8_to_rgb(const void *src, void *dst, int width, int height,
             }
         }
         rawpt++;
-        switch (format->BytesPerPixel) {
+        switch (PG_FORMAT_BytesPerPixel(format)) {
             case 1:
                 *d8++ = ((r >> rloss) << rshift) | ((g >> gloss) << gshift) |
                         ((b >> bloss) << bshift);
@@ -1456,7 +1456,7 @@ yuv420_to_rgb(const void *src, void *dst, int width, int height,
     /* prepare the destination pointers for different surface depths. */
     d8_1 = (Uint8 *)dst;
     /* the following is because d8 used for both 8 and 24 bit surfaces */
-    d8_2 = d8_1 + (format->BytesPerPixel == 3 ? width * 3 : 3);
+    d8_2 = d8_1 + (PG_FORMAT_BytesPerPixel(format) == 3 ? width * 3 : 3);
     d16_1 = (Uint16 *)dst;
     d16_2 = d16_1 + width;
     d32_1 = (Uint32 *)dst;
@@ -1464,7 +1464,7 @@ yuv420_to_rgb(const void *src, void *dst, int width, int height,
 
     /* for the sake of speed, the nested while loops are inside of the switch
       statement for the different surface bit depths */
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             while (j--) {
                 i = width / 2;
@@ -1648,7 +1648,7 @@ yuv420_to_yuv(const void *src, void *dst, int width, int height,
     bloss = format->Bloss;
 
     d8_1 = (Uint8 *)dst;
-    d8_2 = d8_1 + (format->BytesPerPixel == 3 ? width * 3 : 3);
+    d8_2 = d8_1 + (PG_FORMAT_BytesPerPixel(format) == 3 ? width * 3 : 3);
     d16_1 = (Uint16 *)dst;
     d16_2 = d16_1 + width;
     d32_1 = (Uint32 *)dst;
@@ -1659,7 +1659,7 @@ yuv420_to_yuv(const void *src, void *dst, int width, int height,
     v = u + (width * height) / 4;
     j = height / 2;
 
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             while (j--) {
                 i = width / 2;

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -93,6 +93,11 @@ PG_UnlockMutex(SDL_mutex *mutex)
     return 0;
 }
 
+#define PG_SURF_BitsPerPixel(surf) surf->format->bits_per_pixel
+#define PG_SURF_BytesPerPixel(surf) surf->format->bytes_per_pixel
+#define PG_FORMAT_BitsPerPixel(format) format->bits_per_pixel
+#define PG_FORMAT_BytesPerPixel(format) format->bytes_per_pixel
+
 #else /* ~SDL_VERSION_ATLEAST(3, 0, 0)*/
 #define PG_ShowCursor() SDL_ShowCursor(SDL_ENABLE)
 #define PG_HideCursor() SDL_ShowCursor(SDL_DISABLE)
@@ -136,6 +141,11 @@ PG_UnlockMutex(SDL_mutex *mutex)
 {
     return SDL_UnlockMutex(mutex);
 }
+
+#define PG_SURF_BitsPerPixel(surf) surf->format->BitsPerPixel
+#define PG_SURF_BytesPerPixel(surf) surf->format->BytesPerPixel
+#define PG_FORMAT_BitsPerPixel(format) format->BitsPerPixel
+#define PG_FORMAT_BytesPerPixel(format) format->BytesPerPixel
 
 #if SDL_VERSION_ATLEAST(2, 0, 14)
 #define PG_SurfaceHasRLE SDL_HasSurfaceRLE

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -103,14 +103,14 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
         info.height = srcrect->h;
         info.s_pixels = (Uint8 *)src->pixels +
                         (Uint16)srcrect->y * src->pitch +
-                        (Uint16)srcrect->x * src->format->BytesPerPixel;
-        info.s_pxskip = src->format->BytesPerPixel;
-        info.s_skip = src->pitch - info.width * src->format->BytesPerPixel;
+                        (Uint16)srcrect->x * PG_SURF_BytesPerPixel(src);
+        info.s_pxskip = PG_SURF_BytesPerPixel(src);
+        info.s_skip = src->pitch - info.width * PG_SURF_BytesPerPixel(src);
         info.d_pixels = (Uint8 *)dst->pixels +
                         (Uint16)dstrect->y * dst->pitch +
-                        (Uint16)dstrect->x * dst->format->BytesPerPixel;
-        info.d_pxskip = dst->format->BytesPerPixel;
-        info.d_skip = dst->pitch - info.width * dst->format->BytesPerPixel;
+                        (Uint16)dstrect->x * PG_SURF_BytesPerPixel(dst);
+        info.d_pxskip = PG_SURF_BytesPerPixel(dst);
+        info.d_skip = dst->pitch - info.width * PG_SURF_BytesPerPixel(dst);
         info.src = src->format;
         info.dst = dst->format;
         SDL_GetSurfaceAlphaMod(src, &info.src_blanket_alpha);
@@ -121,7 +121,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
         }
         if (okay) {
             if (info.d_pixels > info.s_pixels) {
-                int span = info.width * info.src->BytesPerPixel;
+                int span = info.width * PG_FORMAT_BytesPerPixel(info.src);
                 Uint8 *srcpixend =
                     info.s_pixels + (info.height - 1) * src->pitch + span;
 
@@ -158,8 +158,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         src->format->Amask) {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                        if (src->format->BytesPerPixel == 4 &&
-                            dst->format->BytesPerPixel == 4 &&
+                        if (PG_SURF_BytesPerPixel(src) == 4 &&
+                            PG_SURF_BytesPerPixel(dst) == 4 &&
                             src->format->Rmask == dst->format->Rmask &&
                             src->format->Gmask == dst->format->Gmask &&
                             src->format->Bmask == dst->format->Bmask) {
@@ -220,8 +220,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 case PYGAME_BLEND_ADD: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -232,8 +232,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         break;
                     }
 #if PG_ENABLE_SSE_NEON
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -252,8 +252,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 case PYGAME_BLEND_SUB: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -264,8 +264,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         break;
                     }
 #if PG_ENABLE_SSE_NEON
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -284,8 +284,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 case PYGAME_BLEND_MULT: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -296,8 +296,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         break;
                     }
 #if PG_ENABLE_SSE_NEON
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -316,8 +316,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 case PYGAME_BLEND_MIN: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -328,8 +328,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         break;
                     }
 #if PG_ENABLE_SSE_NEON
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -348,8 +348,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 case PYGAME_BLEND_MAX: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -360,8 +360,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         break;
                     }
 #if PG_ENABLE_SSE_NEON
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -381,8 +381,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 case PYGAME_BLEND_RGBA_ADD: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -392,8 +392,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         break;
                     }
 #if PG_ENABLE_SSE_NEON
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -411,8 +411,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 case PYGAME_BLEND_RGBA_SUB: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -422,8 +422,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         break;
                     }
 #if PG_ENABLE_SSE_NEON
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -441,8 +441,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 case PYGAME_BLEND_RGBA_MULT: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -452,8 +452,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         break;
                     }
 #if PG_ENABLE_SSE_NEON
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -471,8 +471,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 case PYGAME_BLEND_RGBA_MIN: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -482,8 +482,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         break;
                     }
 #if PG_ENABLE_SSE_NEON
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -501,8 +501,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 case PYGAME_BLEND_RGBA_MAX: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -512,8 +512,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         break;
                     }
 #if PG_ENABLE_SSE_NEON
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -531,8 +531,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 case PYGAME_BLEND_PREMULTIPLIED: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -542,8 +542,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         break;
                     }
 #if PG_ENABLE_SSE_NEON
-                    if (src->format->BytesPerPixel == 4 &&
-                        dst->format->BytesPerPixel == 4 &&
+                    if (PG_SURF_BytesPerPixel(src) == 4 &&
+                        PG_SURF_BytesPerPixel(dst) == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
@@ -594,8 +594,8 @@ blit_blend_rgba_add(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     Uint32 pixel;
     Uint32 tmp;
@@ -724,8 +724,8 @@ blit_blend_rgba_sub(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     Uint32 pixel;
     Sint32 tmp2;
@@ -854,8 +854,8 @@ blit_blend_rgba_mul(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     Uint32 pixel;
     Uint32 tmp;
@@ -986,8 +986,8 @@ blit_blend_rgba_min(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     Uint32 pixel;
     int srcppa = info->src_blend != SDL_BLENDMODE_NONE && srcfmt->Amask;
@@ -1115,8 +1115,8 @@ blit_blend_rgba_max(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     Uint32 pixel;
     int srcppa = info->src_blend != SDL_BLENDMODE_NONE && srcfmt->Amask;
@@ -1244,8 +1244,8 @@ blit_blend_premultiplied(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     Uint32 pixel;
     int srcppa = info->src_blend != SDL_BLENDMODE_NONE && srcfmt->Amask;
@@ -1447,8 +1447,8 @@ blit_blend_add(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     Uint32 pixel;
     Uint32 tmp;
@@ -1623,8 +1623,8 @@ blit_blend_sub(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     Uint32 pixel;
     Sint32 tmp2;
@@ -1799,8 +1799,8 @@ blit_blend_mul(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     Uint32 pixel;
     Uint32 tmp;
@@ -1985,8 +1985,8 @@ blit_blend_min(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     Uint32 pixel;
     int srcppa = info->src_blend != SDL_BLENDMODE_NONE && srcfmt->Amask;
@@ -2163,8 +2163,8 @@ blit_blend_max(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     Uint32 pixel;
     int srcppa = info->src_blend != SDL_BLENDMODE_NONE && srcfmt->Amask;
@@ -2343,8 +2343,8 @@ alphablit_alpha(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     int dRi, dGi, dBi, dAi, sRi, sGi, sBi, sAi;
     Uint32 modulateA = info->src_blanket_alpha;
@@ -2456,8 +2456,8 @@ alphablit_colorkey(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     int dRi, dGi, dBi, dAi, sRi, sGi, sBi, sAi;
     int alpha = info->src_blanket_alpha;
@@ -2602,8 +2602,8 @@ alphablit_solid(SDL_BlitInfo *info)
     int dstskip = info->d_skip;
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
     int dRi, dGi, dBi, dAi, sRi, sGi, sBi;
     int alpha = info->src_blanket_alpha;
@@ -2839,18 +2839,18 @@ premul_surf_color_by_alpha(SDL_Surface *src, SDL_Surface *dst)
         // since we know dst is a copy of src we can simplify the normal checks
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-    if ((src->format->BytesPerPixel == 4) && pg_has_avx2()) {
+    if ((PG_SURF_BytesPerPixel(src) == 4) && pg_has_avx2()) {
         premul_surf_color_by_alpha_avx2(src, dst);
         return 0;
     }
 #if defined(__SSE2__)
-    if ((src->format->BytesPerPixel == 4) && SDL_HasSSE2()) {
+    if ((PG_SURF_BytesPerPixel(src) == 4) && SDL_HasSSE2()) {
         premul_surf_color_by_alpha_sse2(src, dst);
         return 0;
     }
 #endif /* __SSE2__*/
 #if PG_ENABLE_ARM_NEON
-    if ((src->format->BytesPerPixel == 4) && SDL_HasNEON()) {
+    if ((PG_SURF_BytesPerPixel(src) == 4) && SDL_HasNEON()) {
         premul_surf_color_by_alpha_sse2(src, dst);
         return 0;
     }
@@ -2868,13 +2868,13 @@ premul_surf_color_by_alpha_non_simd(SDL_Surface *src, SDL_Surface *dst)
     SDL_PixelFormat *dstfmt = dst->format;
     int width = src->w;
     int height = src->h;
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 *src_pixels = (Uint8 *)src->pixels;
     Uint8 *dst_pixels = (Uint8 *)dst->pixels;
 
-    int srcpxskip = src->format->BytesPerPixel;
-    int dstpxskip = dst->format->BytesPerPixel;
+    int srcpxskip = PG_SURF_BytesPerPixel(src);
+    int dstpxskip = PG_SURF_BytesPerPixel(dst);
 
     int srcppa = SDL_TRUE;
 

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -317,9 +317,9 @@ pg_vidinfo_getattr(PyObject *self, char *name)
     else if (!strcmp(name, "video_mem"))
         return PyLong_FromLong(info->video_mem);
     else if (!strcmp(name, "bitsize"))
-        return PyLong_FromLong(info->vfmt->BitsPerPixel);
+        return PyLong_FromLong(PG_FORMAT_BitsPerPixel(info->vfmt));
     else if (!strcmp(name, "bytesize"))
-        return PyLong_FromLong(info->vfmt->BytesPerPixel);
+        return PyLong_FromLong(PG_FORMAT_BytesPerPixel(info->vfmt));
     else if (!strcmp(name, "masks"))
         return Py_BuildValue("(iiii)", info->vfmt->Rmask, info->vfmt->Gmask,
                              info->vfmt->Bmask, info->vfmt->Amask);
@@ -378,12 +378,13 @@ pg_vidinfo_str(PyObject *self)
         ">",
         info->hw_available, info->wm_available, info->video_mem, info->blit_hw,
         info->blit_hw_CC, info->blit_hw_A, info->blit_sw, info->blit_sw_CC,
-        info->blit_sw_A, info->vfmt->BitsPerPixel, info->vfmt->BytesPerPixel,
-        info->vfmt->Rmask, info->vfmt->Gmask, info->vfmt->Bmask,
-        info->vfmt->Amask, info->vfmt->Rshift, info->vfmt->Gshift,
-        info->vfmt->Bshift, info->vfmt->Ashift, info->vfmt->Rloss,
-        info->vfmt->Gloss, info->vfmt->Bloss, info->vfmt->Aloss, current_w,
-        current_h, pixel_format_name);
+        info->blit_sw_A, PG_FORMAT_BitsPerPixel(info->vfmt),
+        PG_FORMAT_BytesPerPixel(info->vfmt), info->vfmt->Rmask,
+        info->vfmt->Gmask, info->vfmt->Bmask, info->vfmt->Amask,
+        info->vfmt->Rshift, info->vfmt->Gshift, info->vfmt->Bshift,
+        info->vfmt->Ashift, info->vfmt->Rloss, info->vfmt->Gloss,
+        info->vfmt->Bloss, info->vfmt->Aloss, current_w, current_h,
+        pixel_format_name);
 }
 
 static PyTypeObject pgVidInfo_Type = {
@@ -1373,7 +1374,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
         }
     }
 
-    if (depth != 0 && surface->surf->format->BitsPerPixel != depth) {
+    if (depth != 0 && PG_SURF_BitsPerPixel(surface->surf) != depth) {
         if (PyErr_WarnEx(PyExc_DeprecationWarning,
                          "The depth argument is deprecated, and is ignored",
                          1)) {
@@ -1780,7 +1781,7 @@ pg_set_palette(PyObject *self, PyObject *args)
     Py_INCREF(surface);
     surf = pgSurface_AsSurface(surface);
     pal = surf->format->palette;
-    if (surf->format->BytesPerPixel != 1 || !pal) {
+    if (PG_SURF_BytesPerPixel(surf) != 1 || !pal) {
         Py_DECREF(surface);
         return RAISE(pgExc_SDLError, "Display mode is not colormapped");
     }

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -131,10 +131,10 @@ aaline(PyObject *self, PyObject *arg, PyObject *kwargs)
     surf = pgSurface_AsSurface(surfobj);
     SURF_INIT_CHECK(surf)
 
-    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+    if (PG_SURF_BytesPerPixel(surf) <= 0 || PG_SURF_BytesPerPixel(surf) > 4) {
         return PyErr_Format(PyExc_ValueError,
                             "unsupported surface bit depth (%d) for drawing",
-                            surf->format->BytesPerPixel);
+                            PG_SURF_BytesPerPixel(surf));
     }
 
     CHECK_LOAD_COLOR(colorobj)
@@ -193,10 +193,10 @@ line(PyObject *self, PyObject *arg, PyObject *kwargs)
     surf = pgSurface_AsSurface(surfobj);
     SURF_INIT_CHECK(surf)
 
-    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+    if (PG_SURF_BytesPerPixel(surf) <= 0 || PG_SURF_BytesPerPixel(surf) > 4) {
         return PyErr_Format(PyExc_ValueError,
                             "unsupported surface bit depth (%d) for drawing",
-                            surf->format->BytesPerPixel);
+                            PG_SURF_BytesPerPixel(surf));
     }
 
     CHECK_LOAD_COLOR(colorobj)
@@ -277,10 +277,10 @@ aalines(PyObject *self, PyObject *arg, PyObject *kwargs)
     surf = pgSurface_AsSurface(surfobj);
     SURF_INIT_CHECK(surf)
 
-    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+    if (PG_SURF_BytesPerPixel(surf) <= 0 || PG_SURF_BytesPerPixel(surf) > 4) {
         return PyErr_Format(PyExc_ValueError,
                             "unsupported surface bit depth (%d) for drawing",
-                            surf->format->BytesPerPixel);
+                            PG_SURF_BytesPerPixel(surf));
     }
 
     CHECK_LOAD_COLOR(colorobj)
@@ -398,10 +398,10 @@ lines(PyObject *self, PyObject *arg, PyObject *kwargs)
     surf = pgSurface_AsSurface(surfobj);
     SURF_INIT_CHECK(surf)
 
-    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+    if (PG_SURF_BytesPerPixel(surf) <= 0 || PG_SURF_BytesPerPixel(surf) > 4) {
         return PyErr_Format(PyExc_ValueError,
                             "unsupported surface bit depth (%d) for drawing",
-                            surf->format->BytesPerPixel);
+                            PG_SURF_BytesPerPixel(surf));
     }
 
     CHECK_LOAD_COLOR(colorobj)
@@ -519,10 +519,10 @@ arc(PyObject *self, PyObject *arg, PyObject *kwargs)
     surf = pgSurface_AsSurface(surfobj);
     SURF_INIT_CHECK(surf)
 
-    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+    if (PG_SURF_BytesPerPixel(surf) <= 0 || PG_SURF_BytesPerPixel(surf) > 4) {
         return PyErr_Format(PyExc_ValueError,
                             "unsupported surface bit depth (%d) for drawing",
-                            surf->format->BytesPerPixel);
+                            PG_SURF_BytesPerPixel(surf));
     }
 
     CHECK_LOAD_COLOR(colorobj)
@@ -591,10 +591,10 @@ ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
     surf = pgSurface_AsSurface(surfobj);
     SURF_INIT_CHECK(surf)
 
-    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+    if (PG_SURF_BytesPerPixel(surf) <= 0 || PG_SURF_BytesPerPixel(surf) > 4) {
         return PyErr_Format(PyExc_ValueError,
                             "unsupported surface bit depth (%d) for drawing",
-                            surf->format->BytesPerPixel);
+                            PG_SURF_BytesPerPixel(surf));
     }
 
     CHECK_LOAD_COLOR(colorobj)
@@ -675,10 +675,10 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
     surf = pgSurface_AsSurface(surfobj);
     SURF_INIT_CHECK(surf)
 
-    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+    if (PG_SURF_BytesPerPixel(surf) <= 0 || PG_SURF_BytesPerPixel(surf) > 4) {
         return PyErr_Format(PyExc_ValueError,
                             "unsupported surface bit depth (%d) for drawing",
-                            surf->format->BytesPerPixel);
+                            PG_SURF_BytesPerPixel(surf));
     }
 
     CHECK_LOAD_COLOR(colorobj)
@@ -773,10 +773,10 @@ polygon(PyObject *self, PyObject *arg, PyObject *kwargs)
     surf = pgSurface_AsSurface(surfobj);
     SURF_INIT_CHECK(surf)
 
-    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+    if (PG_SURF_BytesPerPixel(surf) <= 0 || PG_SURF_BytesPerPixel(surf) > 4) {
         return PyErr_Format(PyExc_ValueError,
                             "unsupported surface bit depth (%d) for drawing",
-                            surf->format->BytesPerPixel);
+                            PG_SURF_BytesPerPixel(surf));
     }
 
     CHECK_LOAD_COLOR(colorobj)
@@ -895,10 +895,10 @@ rect(PyObject *self, PyObject *args, PyObject *kwargs)
     surf = pgSurface_AsSurface(surfobj);
     SURF_INIT_CHECK(surf)
 
-    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+    if (PG_SURF_BytesPerPixel(surf) <= 0 || PG_SURF_BytesPerPixel(surf) > 4) {
         return PyErr_Format(PyExc_ValueError,
                             "unsupported surface bit depth (%d) for drawing",
-                            surf->format->BytesPerPixel);
+                            PG_SURF_BytesPerPixel(surf));
     }
 
     CHECK_LOAD_COLOR(colorobj)
@@ -1092,7 +1092,7 @@ set_at(SDL_Surface *surf, int x, int y, Uint32 color)
         y < surf->clip_rect.y || y >= surf->clip_rect.y + surf->clip_rect.h)
         return 0;
 
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             *((Uint8 *)pixels + y * surf->pitch + x) = (Uint8)color;
             break;
@@ -1333,9 +1333,9 @@ drawhorzline(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2)
     Uint8 *pixel, *end;
 
     pixel = ((Uint8 *)surf->pixels) + surf->pitch * y1;
-    end = pixel + x2 * surf->format->BytesPerPixel;
-    pixel += x1 * surf->format->BytesPerPixel;
-    switch (surf->format->BytesPerPixel) {
+    end = pixel + x2 * PG_SURF_BytesPerPixel(surf);
+    pixel += x1 * PG_SURF_BytesPerPixel(surf);
+    switch (PG_SURF_BytesPerPixel(surf)) {
         case 1:
             for (; pixel <= end; ++pixel) {
                 *pixel = (Uint8)color;
@@ -1369,9 +1369,9 @@ drawvertline(SDL_Surface *surf, Uint32 color, int y1, int x1, int y2)
 
     pixel = ((Uint8 *)surf->pixels) + surf->pitch * y1;
     end = ((Uint8 *)surf->pixels) + surf->pitch * y2 +
-          x1 * surf->format->BytesPerPixel;
-    pixel += x1 * surf->format->BytesPerPixel;
-    switch (surf->format->BytesPerPixel) {
+          x1 * PG_SURF_BytesPerPixel(surf);
+    pixel += x1 * PG_SURF_BytesPerPixel(surf);
+    switch (PG_SURF_BytesPerPixel(surf)) {
         case 1:
             for (; pixel <= end; pixel += surf->pitch) {
                 *pixel = (Uint8)color;
@@ -1680,7 +1680,7 @@ unsafe_set_at(SDL_Surface *surf, int x, int y, Uint32 color)
     Uint8 *pixels = (Uint8 *)surf->pixels;
     Uint8 *byte_buf, rgb[4];
 
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             *((Uint8 *)pixels + y * surf->pitch + x) = (Uint8)color;
             break;

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -335,7 +335,7 @@ _PGFT_Render_ExistingSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
         surf_offset.y += offset.y;
     }
 
-    if (!surface->format->BytesPerPixel) {
+    if (!PG_SURF_BytesPerPixel(surface)) {
         // This should never happen, error to make static analyzer happy
         PyErr_SetString(pgExc_SDLError, "Got surface of invalid format");
         return -1;
@@ -349,9 +349,9 @@ _PGFT_Render_ExistingSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
     font_surf.height = surface->h;
     font_surf.pitch = surface->pitch;
     font_surf.format = surface->format;
-    font_surf.render_gray = __SDLrenderFuncs[surface->format->BytesPerPixel];
-    font_surf.render_mono = __MONOrenderFuncs[surface->format->BytesPerPixel];
-    font_surf.fill = __RGBfillFuncs[surface->format->BytesPerPixel];
+    font_surf.render_gray = __SDLrenderFuncs[PG_SURF_BytesPerPixel(surface)];
+    font_surf.render_mono = __MONOrenderFuncs[PG_SURF_BytesPerPixel(surface)];
+    font_surf.fill = __RGBfillFuncs[PG_SURF_BytesPerPixel(surface)];
 
     /*
      * if bg color exists, paint background

--- a/src_c/freetype/ft_render_cb.c
+++ b/src_c/freetype/ft_render_cb.c
@@ -220,7 +220,7 @@ __render_glyph_INT(int x, int y, FontSurface *surface, const FT_Bitmap *bitmap,
 {
     FT_Byte *dst = ((FT_Byte *)surface->buffer + x * surface->item_stride +
                     y * surface->pitch);
-    int item_size = surface->format->BytesPerPixel;
+    int item_size = PG_SURF_BytesPerPixel(surface);
     int item_stride = surface->item_stride;
     FT_Byte *dst_cpy;
 
@@ -301,7 +301,7 @@ __render_glyph_MONO_as_INT(int x, int y, FontSurface *surface,
 
     int i, j, shift;
     int item_stride = surface->item_stride;
-    int item_size = surface->format->BytesPerPixel;
+    int item_size = PG_SURF_BytesPerPixel(surface);
     unsigned char *src;
     unsigned char *dst;
     unsigned char *src_cpy;
@@ -380,7 +380,7 @@ __fill_glyph_INT(FT_Fixed x, FT_Fixed y, FT_Fixed w, FT_Fixed h,
 {
     int i, j;
     FT_Byte *dst;
-    int itemsize = surface->format->BytesPerPixel;
+    int itemsize = PG_SURF_BytesPerPixel(surface);
     int item_stride = surface->item_stride;
     int byteoffset = surface->format->Ashift / 8;
     FT_Byte *dst_cpy;

--- a/src_c/gfxdraw.c
+++ b/src_c/gfxdraw.c
@@ -875,7 +875,7 @@ _gfx_texturedpolygon(PyObject *self, PyObject *args)
     if (!PySequence_Check(points)) {
         return RAISE(PyExc_TypeError, "points must be a sequence");
     }
-    if (s_surface->format->BytesPerPixel == 1 &&
+    if (PG_SURF_BytesPerPixel(s_surface) == 1 &&
         (s_texture->format->Amask || s_texture->flags & SDL_SRCALPHA)) {
         return RAISE(PyExc_ValueError,
                      "Per-byte alpha texture unsupported "

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -538,7 +538,7 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
     Aloss = surf->format->Aloss;
 
     if (!strcmp(format, "P")) {
-        if (surf->format->BytesPerPixel != 1)
+        if (PG_SURF_BytesPerPixel(surf) != 1)
             return RAISE(
                 PyExc_ValueError,
                 "Can only create \"P\" format data with 8bit Surfaces");
@@ -557,7 +557,7 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
     }
     else if (!strcmp(format, "RGBA_PREMULT") ||
              !strcmp(format, "ARGB_PREMULT")) {
-        if (surf->format->BytesPerPixel == 1 || surf->format->Amask == 0)
+        if (PG_SURF_BytesPerPixel(surf) == 1 || surf->format->Amask == 0)
             return RAISE(PyExc_ValueError,
                          "Can only create pre-multiplied alpha bytes if "
                          "the surface has per-pixel alpha");
@@ -598,7 +598,7 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
     else if (!strcmp(format, "RGB")) {
         pgSurface_Lock(surfobj);
 
-        switch (surf->format->BytesPerPixel) {
+        switch (PG_SURF_BytesPerPixel(surf)) {
             case 1:
                 for (h = 0; h < surf->h; ++h) {
                     Uint8 *ptr = (Uint8 *)DATAROW(surf->pixels, h, surf->pitch,
@@ -666,7 +666,7 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
     }
     else if (!strcmp(format, "RGBX") || !strcmp(format, "RGBA")) {
         pgSurface_Lock(surfobj);
-        switch (surf->format->BytesPerPixel) {
+        switch (PG_SURF_BytesPerPixel(surf)) {
             case 1:
                 for (h = 0; h < surf->h; ++h) {
                     Uint8 *ptr = (Uint8 *)DATAROW(surf->pixels, h, surf->pitch,
@@ -737,7 +737,7 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
     }
     else if (!strcmp(format, "ARGB")) {
         pgSurface_Lock(surfobj);
-        switch (surf->format->BytesPerPixel) {
+        switch (PG_SURF_BytesPerPixel(surf)) {
             case 1:
                 for (h = 0; h < surf->h; ++h) {
                     Uint8 *ptr = (Uint8 *)DATAROW(surf->pixels, h, surf->pitch,
@@ -801,7 +801,7 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
     }
     else if (!strcmp(format, "BGRA")) {
         pgSurface_Lock(surfobj);
-        switch (surf->format->BytesPerPixel) {
+        switch (PG_SURF_BytesPerPixel(surf)) {
             case 1:
                 for (h = 0; h < surf->h; ++h) {
                     Uint8 *ptr = (Uint8 *)DATAROW(surf->pixels, h, surf->pitch,
@@ -878,7 +878,7 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
     }
     else if (!strcmp(format, "RGBA_PREMULT")) {
         pgSurface_Lock(surfobj);
-        switch (surf->format->BytesPerPixel) {
+        switch (PG_SURF_BytesPerPixel(surf)) {
             case 2:
                 for (h = 0; h < surf->h; ++h) {
                     Uint16 *ptr = (Uint16 *)DATAROW(
@@ -960,7 +960,7 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
     }
     else if (!strcmp(format, "ARGB_PREMULT")) {
         pgSurface_Lock(surfobj);
-        switch (surf->format->BytesPerPixel) {
+        switch (PG_SURF_BytesPerPixel(surf)) {
             case 2:
                 for (h = 0; h < surf->h; ++h) {
                     Uint16 *ptr = (Uint16 *)DATAROW(
@@ -1535,7 +1535,7 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
     h.infolen = 0;
     SETLE16(h.cmap_start, 0);
 
-    srcbpp = surface->format->BitsPerPixel;
+    srcbpp = PG_SURF_BitsPerPixel(surface);
     if (srcbpp < 8) {
         SDL_SetError("cannot save <8bpp images as TGA");
         return -1;

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -770,7 +770,7 @@ static void
 set_from_threshold(SDL_Surface *surf, bitmask_t *bitmask, int threshold)
 {
     SDL_PixelFormat *format = surf->format;
-    Uint8 bpp = format->BytesPerPixel;
+    Uint8 bpp = PG_FORMAT_BytesPerPixel(format);
     Uint8 *pixel = NULL;
     Uint8 rgba[4];
     int x, y;
@@ -802,7 +802,7 @@ set_from_threshold(SDL_Surface *surf, bitmask_t *bitmask, int threshold)
 static void
 set_from_colorkey(SDL_Surface *surf, bitmask_t *bitmask, Uint32 colorkey)
 {
-    Uint8 bpp = surf->format->BytesPerPixel;
+    Uint8 bpp = PG_SURF_BytesPerPixel(surf);
     Uint8 *pixel = NULL;
     int x, y;
 
@@ -915,7 +915,7 @@ bitmask_threshold(bitmask_t *m, SDL_Surface *surf, SDL_Surface *surf2,
     rloss = format->Rloss;
     gloss = format->Gloss;
     bloss = format->Bloss;
-    bpp1 = surf->format->BytesPerPixel;
+    bpp1 = PG_SURF_BytesPerPixel(surf);
 
     if (surf2) {
         format2 = surf2->format;
@@ -929,7 +929,7 @@ bitmask_threshold(bitmask_t *m, SDL_Surface *surf, SDL_Surface *surf2,
         gloss2 = format2->Gloss;
         bloss2 = format2->Bloss;
         pixels2 = (Uint8 *)surf2->pixels;
-        bpp2 = surf->format->BytesPerPixel;
+        bpp2 = PG_SURF_BytesPerPixel(surf);
     }
     else { /* make gcc stop complaining */
         rmask2 = gmask2 = bmask2 = 0;
@@ -1919,7 +1919,7 @@ draw_to_surface(SDL_Surface *surf, bitmask_t *bitmask, int x_dest, int y_dest,
         return;
     }
 
-    bpp = surf->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(surf);
 
     xm_start = (x_dest < 0) ? -x_dest : 0;
     x_start = (x_dest > 0) ? x_dest : 0;
@@ -2055,8 +2055,8 @@ draw_to_surface(SDL_Surface *surf, bitmask_t *bitmask, int x_dest, int y_dest,
 static int
 check_surface_pixel_format(SDL_Surface *surf, SDL_Surface *check_surf)
 {
-    if ((surf->format->BytesPerPixel != check_surf->format->BytesPerPixel) ||
-        (surf->format->BitsPerPixel != check_surf->format->BitsPerPixel) ||
+    if ((PG_SURF_BytesPerPixel(surf) != PG_SURF_BytesPerPixel(check_surf)) ||
+        (PG_SURF_BitsPerPixel(surf) != PG_SURF_BitsPerPixel(check_surf)) ||
         (surf->format->format != check_surf->format->format)) {
         return 0;
     }

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -145,7 +145,7 @@ static PyTypeObject pgPixelArray_Type;
 static int
 array_is_contiguous(pgPixelArrayObject *ap, char fortran)
 {
-    int itemsize = pgSurface_AsSurface(ap->surface)->format->BytesPerPixel;
+    int itemsize = PG_SURF_BytesPerPixel(pgSurface_AsSurface(ap->surface));
 
     if (ap->strides[0] == itemsize) {
         if (ap->shape[1] == 0) {
@@ -351,7 +351,7 @@ _pxarray_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     surf = pgSurface_AsSurface(surfobj);
     dim0 = (Py_ssize_t)surf->w;
     dim1 = (Py_ssize_t)surf->h;
-    stride0 = (Py_ssize_t)surf->format->BytesPerPixel;
+    stride0 = (Py_ssize_t)PG_SURF_BytesPerPixel(surf);
     stride1 = (Py_ssize_t)surf->pitch;
     pixels = surf->pixels;
     if (pixels == NULL) {
@@ -445,7 +445,7 @@ _pxarray_get_itemsize(pgPixelArrayObject *self, void *closure)
 
     SDL_Surface *surf = pgSurface_AsSurface(self->surface);
 
-    return PyLong_FromLong((long)surf->format->BytesPerPixel);
+    return PyLong_FromLong((long)PG_SURF_BytesPerPixel(surf));
 }
 
 /**
@@ -543,7 +543,7 @@ _pxarray_getbuffer(pgPixelArrayObject *self, Py_buffer *view_p, int flags)
         return -1;
     }
 
-    itemsize = pgSurface_AsSurface(self->surface)->format->BytesPerPixel;
+    itemsize = PG_SURF_BytesPerPixel(pgSurface_AsSurface(self->surface));
 
     len = self->shape[0] * (ndim == 2 ? self->shape[1] : 1) * itemsize;
     view_p->obj = 0;
@@ -661,7 +661,7 @@ _pxarray_repr(pgPixelArrayObject *array)
     }
 
     surf = pgSurface_AsSurface(array->surface);
-    bpp = surf->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(surf);
 
     string = PyUnicode_FromString("PixelArray(");
     if (!string) {
@@ -962,8 +962,8 @@ _array_assign_array(pgPixelArrayObject *array, Py_ssize_t low, Py_ssize_t high,
         return -1;
     }
 
-    bpp = surf->format->BytesPerPixel;
-    val_bpp = val_surf->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(surf);
+    val_bpp = PG_SURF_BytesPerPixel(val_surf);
     if (val_bpp != bpp) {
         /* bpp do not match. We cannot guarantee that the padding and columns
          * would be set correctly. */
@@ -1098,7 +1098,7 @@ _array_assign_sequence(pgPixelArrayObject *array, Py_ssize_t low,
     }
 
     format = surf->format;
-    bpp = format->BytesPerPixel;
+    bpp = PG_FORMAT_BytesPerPixel(format);
 
     if (!dim1) {
         dim1 = 1;
@@ -1206,7 +1206,7 @@ _array_assign_slice(pgPixelArrayObject *array, Py_ssize_t low, Py_ssize_t high,
     Py_ssize_t x;
     Py_ssize_t y;
 
-    bpp = surf->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(surf);
 
     if (!dim1) {
         dim1 = 1;
@@ -1297,7 +1297,7 @@ _pxarray_ass_item(pgPixelArrayObject *array, Py_ssize_t index, PyObject *value)
     Py_ssize_t stride0 = array->strides[0];
     Py_ssize_t stride1 = array->strides[1];
 
-    bpp = surf->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(surf);
 
     if (!_get_color_from_object(value, surf->format, &color)) {
         if (PyTuple_Check(value)) {
@@ -1452,7 +1452,7 @@ _pxarray_contains(pgPixelArrayObject *array, PyObject *value)
     Py_ssize_t y;
     int found = 0;
 
-    bpp = surf->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(surf);
 
     if (!_get_color_from_object(value, surf->format, &color)) {
         return -1;
@@ -1860,7 +1860,7 @@ pgPixelArray_New(PyObject *surfobj)
     surf = pgSurface_AsSurface(surfobj);
     dim0 = (Py_ssize_t)surf->w;
     dim1 = (Py_ssize_t)surf->h;
-    stride0 = (Py_ssize_t)surf->format->BytesPerPixel;
+    stride0 = (Py_ssize_t)PG_SURF_BytesPerPixel(surf);
     stride1 = (Py_ssize_t)surf->pitch;
     pixels = surf->pixels;
     if (stride0 < 1 || stride0 > 4) {

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -65,7 +65,7 @@ _get_single_pixel(pgPixelArrayObject *array, Py_ssize_t x, Py_ssize_t y)
     pixel_p = (array->pixels + x * array->strides[0] + y * array->strides[1]);
     surf = pgSurface_AsSurface(array->surface);
 
-    bpp = surf->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(surf);
 
     /* Find the start of the pixel */
     switch (bpp) {
@@ -124,7 +124,7 @@ _make_surface(pgPixelArrayObject *array, PyObject *args)
     }
 
     surf = pgSurface_AsSurface(array->surface);
-    bpp = surf->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(surf);
 
     /* Create the second surface. */
 
@@ -152,7 +152,7 @@ _make_surface(pgPixelArrayObject *array, PyObject *args)
     }
 
     new_pixels = (Uint8 *)new_surf->pixels;
-    new_stride0 = new_surf->format->BytesPerPixel;
+    new_stride0 = PG_SURF_BytesPerPixel(new_surf);
     new_stride1 = new_surf->pitch;
     pixelrow = pixels;
     new_pixelrow = new_pixels;
@@ -352,7 +352,7 @@ _replace_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
     }
 
     format = surf->format;
-    bpp = surf->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(surf);
 
     if (!_get_color_from_object(delcolor, format, &dcolor) ||
         !_get_color_from_object(replcolor, format, &rcolor)) {
@@ -550,7 +550,7 @@ _extract_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
 
     surf = pgSurface_AsSurface(surface);
     format = surf->format;
-    bpp = surf->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(surf);
     dim0 = new_array->shape[0];
     dim1 = new_array->shape[1];
     stride0 = new_array->strides[0];
@@ -780,11 +780,11 @@ _compare(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
     }
 
     format = surf->format;
-    bpp = surf->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(surf);
     other_surf = pgSurface_AsSurface(other_array->surface);
     other_format = other_surf->format;
 
-    if (other_format->BytesPerPixel != bpp) {
+    if (PG_FORMAT_BytesPerPixel(other_format) != bpp) {
         /* bpp do not match. We cannot guarantee that the padding and co
          * would be set correctly. */
         PyErr_SetString(PyExc_ValueError, "bit depths do not match");
@@ -1015,7 +1015,7 @@ _transpose(pgPixelArrayObject *array, PyObject *args)
     Py_ssize_t stride1 = array->strides[0];
 
     stride0 = array->shape[1] ? array->strides[1]
-                              : array->shape[0] * surf->format->BytesPerPixel;
+                              : array->shape[0] * PG_SURF_BytesPerPixel(surf);
 
     return (PyObject *)_pxarray_new_internal(&pgPixelArray_Type, 0, array,
                                              array->pixels, dim0, dim1,

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -191,7 +191,7 @@ typedef union {
 static int
 _copy_mapped(Py_buffer *view_p, SDL_Surface *surf)
 {
-    Uint8 pixelsize = surf->format->BytesPerPixel;
+    Uint8 pixelsize = PG_SURF_BytesPerPixel(surf);
     Py_ssize_t intsize = view_p->itemsize;
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
     char *src = (char *)surf->pixels;
@@ -201,7 +201,7 @@ _copy_mapped(Py_buffer *view_p, SDL_Surface *surf)
     char *dst = (char *)view_p->buf;
     int w = surf->w;
     int h = surf->h;
-    Py_intptr_t dx_src = surf->format->BytesPerPixel;
+    Py_intptr_t dx_src = PG_SURF_BytesPerPixel(surf);
     Py_intptr_t dy_src = surf->pitch;
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
     Py_intptr_t dz_src = 1;
@@ -257,14 +257,14 @@ _copy_colorplane(Py_buffer *view_p, SDL_Surface *surf,
                  _pc_view_kind_t view_kind, Uint8 opaque, Uint8 clear)
 {
     SDL_PixelFormat *format = surf->format;
-    int pixelsize = surf->format->BytesPerPixel;
+    int pixelsize = PG_SURF_BytesPerPixel(surf);
     SDL_BlendMode mode;
     int intsize = (int)view_p->itemsize;
     char *src = (char *)surf->pixels;
     char *dst = (char *)view_p->buf;
     int w = surf->w;
     int h = surf->h;
-    Py_intptr_t dx_src = surf->format->BytesPerPixel;
+    Py_intptr_t dx_src = PG_SURF_BytesPerPixel(surf);
     Py_intptr_t dy_src = surf->pitch;
     Py_intptr_t dx_dst = view_p->strides[0];
     Py_intptr_t dy_dst = view_p->strides[1];
@@ -370,13 +370,13 @@ static int
 _copy_unmapped(Py_buffer *view_p, SDL_Surface *surf)
 {
     SDL_PixelFormat *format = surf->format;
-    int pixelsize = surf->format->BytesPerPixel;
+    int pixelsize = PG_SURF_BytesPerPixel(surf);
     int intsize = (int)view_p->itemsize;
     char *src = (char *)surf->pixels;
     char *dst = (char *)view_p->buf;
     int w = surf->w;
     int h = surf->h;
-    Py_intptr_t dx_src = surf->format->BytesPerPixel;
+    Py_intptr_t dx_src = PG_SURF_BytesPerPixel(surf);
     Py_intptr_t dy_src = surf->pitch;
     Py_intptr_t dx_dst = view_p->strides[0];
     Py_intptr_t dy_dst = view_p->strides[1];
@@ -492,7 +492,7 @@ array_to_surface(PyObject *self, PyObject *arg)
         return RAISE(PyExc_ValueError, "must be a valid 2d or 3d array\n");
     }
 
-    if (surf->format->BytesPerPixel == 0 || surf->format->BytesPerPixel > 4)
+    if (PG_SURF_BytesPerPixel(surf) == 0 || PG_SURF_BytesPerPixel(surf) > 4)
         return RAISE(PyExc_ValueError, "unsupported bit depth for surface");
 
     stridex = view_p->strides[0];
@@ -535,7 +535,7 @@ array_to_surface(PyObject *self, PyObject *arg)
 
     array_data = (char *)view_p->buf;
 
-    switch (surf->format->BytesPerPixel) {
+    switch (PG_SURF_BytesPerPixel(surf)) {
         case 1:
             if (view_p->ndim == 2) {
                 switch (view_p->itemsize) {
@@ -963,7 +963,7 @@ map_array(PyObject *self, PyObject *args)
     /* Determine source and destination pixel formats
      */
     format = pgSurface_AsSurface(format_surf)->format;
-    pix_bytesize = format->BytesPerPixel;
+    pix_bytesize = PG_FORMAT_BytesPerPixel(format);
     if (tar_itemsize < pix_bytesize) {
         PyErr_SetString(PyExc_ValueError,
                         "target array itemsize is too small for pixel format");

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -540,8 +540,8 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
     /*
      * Determine if source surface is 32bit or 8bit
      */
-    is32bit = (src->format->BitsPerPixel == 32);
-    if ((is32bit) || (src->format->BitsPerPixel == 8)) {
+    is32bit = (PG_SURF_BitsPerPixel(src) == 32);
+    if ((is32bit) || (PG_SURF_BitsPerPixel(src) == 8)) {
         /*
          * Use source surface 'as is'
          */

--- a/src_c/scale2x.c
+++ b/src_c/scale2x.c
@@ -61,7 +61,11 @@ scale2x(SDL_Surface *src, SDL_Surface *dst)
     const int width = src->w;
     const int height = src->h;
 
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    switch (src->format->bytes_per_pixel) {
+#else
     switch (src->format->BytesPerPixel) {
+#endif
         case 1: {
             Uint8 E0, E1, E2, E3, B, D, E, F, H;
             for (looph = 0; looph < height; ++looph) {

--- a/src_c/simd_blitters_sse2.c
+++ b/src_c/simd_blitters_sse2.c
@@ -154,8 +154,8 @@ alphablit_alpha_sse2_argb_surf_alpha(SDL_BlitInfo *info)
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
 
-    // int srcbpp = srcfmt->BytesPerPixel;
-    // int dstbpp = dstfmt->BytesPerPixel;
+    // int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
+    // int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
 
     Uint32 dst_amask = dstfmt->Amask;
     Uint32 src_amask = srcfmt->Amask;

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -494,7 +494,7 @@ surface_str(PyObject *self)
     // but alpha, we can "move up" the global alpha to this spot No need to do
     // this vice-versa, as it ignores extra args
     PyObject *formatted_str = PyUnicode_FromFormat(
-        format, surf->w, surf->h, surf->format->BitsPerPixel,
+        format, surf->w, surf->h, PG_SURF_BitsPerPixel(surf),
         PyObject_IsTrue(colorkey) ? colorkey : global_alpha, global_alpha);
 
     Py_DECREF(colorkey);
@@ -646,7 +646,7 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
             pix->Gmask = 0xFF00;
             pix->Bmask = 0xFF;
         }
-        bpp = pix->BitsPerPixel;
+        bpp = PG_FORMAT_BitsPerPixel(pix);
 
         if (flags & PGS_SRCALPHA) {
             switch (bpp) {
@@ -758,7 +758,8 @@ surf_get_at(PyObject *self, PyObject *position)
 
     format = surf->format;
 
-    if (format->BytesPerPixel < 1 || format->BytesPerPixel > 4)
+    if (PG_FORMAT_BytesPerPixel(format) < 1 ||
+        PG_FORMAT_BytesPerPixel(format) > 4)
         return RAISE(PyExc_RuntimeError, "invalid color depth for surface");
 
     if (!pgSurface_Lock((pgSurfaceObject *)self))
@@ -766,7 +767,7 @@ surf_get_at(PyObject *self, PyObject *position)
 
     pixels = (Uint8 *)surf->pixels;
 
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             color = (Uint32) * ((Uint8 *)pixels + y * surf->pitch + x);
             SDL_GetRGB(color, format, rgba, rgba + 1, rgba + 2);
@@ -785,7 +786,7 @@ surf_get_at(PyObject *self, PyObject *position)
             SDL_GetRGB(color, format, rgba, rgba + 1, rgba + 2);
             break;
         default: /* case 4: */
-            assert(format->BytesPerPixel == 4);
+            assert(PG_FORMAT_BytesPerPixel(format) == 4);
             color = *((Uint32 *)(pixels + y * surf->pitch) + x);
             SDL_GetRGBA(color, format, rgba, rgba + 1, rgba + 2, rgba + 3);
             break;
@@ -822,7 +823,8 @@ surf_set_at(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     rgba_obj = args[1];
 
     format = surf->format;
-    if (format->BytesPerPixel < 1 || format->BytesPerPixel > 4)
+    if (PG_FORMAT_BytesPerPixel(format) < 1 ||
+        PG_FORMAT_BytesPerPixel(format) > 4)
         return RAISE(PyExc_RuntimeError, "invalid color depth for surface");
 
     if (x < surf->clip_rect.x || x >= surf->clip_rect.x + surf->clip_rect.w ||
@@ -840,7 +842,7 @@ surf_set_at(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
         return NULL;
     pixels = (Uint8 *)surf->pixels;
 
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             *((Uint8 *)pixels + y * surf->pitch + x) = (Uint8)color;
             break;
@@ -898,7 +900,8 @@ surf_get_at_mapped(PyObject *self, PyObject *position)
 
     format = surf->format;
 
-    if (format->BytesPerPixel < 1 || format->BytesPerPixel > 4)
+    if (PG_FORMAT_BytesPerPixel(format) < 1 ||
+        PG_FORMAT_BytesPerPixel(format) > 4)
         return RAISE(PyExc_RuntimeError, "invalid color depth for surface");
 
     if (!pgSurface_Lock((pgSurfaceObject *)self))
@@ -906,7 +909,7 @@ surf_get_at_mapped(PyObject *self, PyObject *position)
 
     pixels = (Uint8 *)surf->pixels;
 
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             color = (Uint32) * ((Uint8 *)pixels + y * surf->pitch + x);
             break;
@@ -1229,7 +1232,7 @@ surf_set_colorkey(pgSurfaceObject *self, PyObject *args)
 
     pgSurface_Prep(self);
     result = 0;
-    if (hascolor && surf->format->BytesPerPixel == 1) {
+    if (hascolor && PG_SURF_BytesPerPixel(surf) == 1) {
         /* For an indexed surface, remove the previous colorkey first.
          */
         result = SDL_SetColorKey(surf, SDL_FALSE, color);
@@ -1312,7 +1315,7 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
     else
         alpha = (Uint8)alphaval;
 
-    if (alpha == 255 && (surf->format->BytesPerPixel == 1)) {
+    if (alpha == 255 && (PG_SURF_BytesPerPixel(surf) == 1)) {
         /* Can't blend with a surface alpha of 255 and 8bit surfaces */
         if (SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE) != 0)
             return RAISE(pgExc_SDLError, SDL_GetError());
@@ -1619,7 +1622,7 @@ pg_DisplayFormatAlpha(SDL_Surface *surface)
         return NULL;
     }
 
-    switch (dformat->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(dformat)) {
         case 2:
             /* same behavior as SDL1 */
             if ((dformat->Rmask == 0x1f) &&
@@ -2329,7 +2332,7 @@ surf_scroll(PyObject *self, PyObject *args, PyObject *keywds)
         return NULL;
     }
 
-    bpp = surf->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(surf);
     pitch = surf->pitch;
     src = dst =
         (Uint8 *)surf->pixels + clip_rect->y * pitch + clip_rect->x * bpp;
@@ -2537,7 +2540,7 @@ surf_get_bitsize(PyObject *self, PyObject *_null)
     SDL_Surface *surf = pgSurface_AsSurface(self);
     SURF_INIT_CHECK(surf)
 
-    return PyLong_FromLong(surf->format->BitsPerPixel);
+    return PyLong_FromLong(PG_SURF_BitsPerPixel(surf));
 }
 
 static PyObject *
@@ -2546,7 +2549,7 @@ surf_get_bytesize(PyObject *self, PyObject *_null)
     SDL_Surface *surf = pgSurface_AsSurface(self);
     SURF_INIT_CHECK(surf)
 
-    return PyLong_FromLong(surf->format->BytesPerPixel);
+    return PyLong_FromLong(PG_SURF_BytesPerPixel(surf));
 }
 
 static PyObject *
@@ -2618,7 +2621,8 @@ surf_subsurface(PyObject *self, PyObject *args)
 
     pgSurface_Lock((pgSurfaceObject *)self);
 
-    pixeloffset = rect->x * format->BytesPerPixel + rect->y * surf->pitch;
+    pixeloffset =
+        rect->x * PG_FORMAT_BytesPerPixel(format) + rect->y * surf->pitch;
     startpixel = ((char *)surf->pixels) + pixeloffset;
 
     sub = PG_CreateSurfaceFrom(startpixel, rect->w, rect->h, surf->pitch,
@@ -2841,8 +2845,9 @@ surf_get_bounding_rect(PyObject *self, PyObject *args, PyObject *kwargs)
     found_alpha = 0;
     for (y = max_y - 1; y >= min_y; --y) {
         for (x = min_x; x < max_x; ++x) {
-            pixel = (pixels + y * surf->pitch) + x * format->BytesPerPixel;
-            switch (format->BytesPerPixel) {
+            pixel = (pixels + y * surf->pitch) +
+                    x * PG_FORMAT_BytesPerPixel(format);
+            switch (PG_FORMAT_BytesPerPixel(format)) {
                 case 1:
                     value = *pixel;
                     break;
@@ -2855,7 +2860,7 @@ surf_get_bounding_rect(PyObject *self, PyObject *args, PyObject *kwargs)
                     value |= pixel[BYTE2] << 16;
                     break;
                 default:
-                    assert(format->BytesPerPixel == 4);
+                    assert(PG_FORMAT_BytesPerPixel(format) == 4);
                     value = *(Uint32 *)pixel;
             }
             SDL_GetRGBA(value, surf->format, &r, &g, &b, &a);
@@ -2873,8 +2878,9 @@ surf_get_bounding_rect(PyObject *self, PyObject *args, PyObject *kwargs)
     found_alpha = 0;
     for (x = max_x - 1; x >= min_x; --x) {
         for (y = min_y; y < max_y; ++y) {
-            pixel = (pixels + y * surf->pitch) + x * format->BytesPerPixel;
-            switch (format->BytesPerPixel) {
+            pixel = (pixels + y * surf->pitch) +
+                    x * PG_FORMAT_BytesPerPixel(format);
+            switch (PG_FORMAT_BytesPerPixel(format)) {
                 case 1:
                     value = *pixel;
                     break;
@@ -2887,7 +2893,7 @@ surf_get_bounding_rect(PyObject *self, PyObject *args, PyObject *kwargs)
                     value |= pixel[BYTE2] << 16;
                     break;
                 default:
-                    assert(format->BytesPerPixel == 4);
+                    assert(PG_FORMAT_BytesPerPixel(format) == 4);
                     value = *(Uint32 *)pixel;
             }
             SDL_GetRGBA(value, surf->format, &r, &g, &b, &a);
@@ -2906,8 +2912,9 @@ surf_get_bounding_rect(PyObject *self, PyObject *args, PyObject *kwargs)
     for (y = min_y; y < max_y; ++y) {
         min_y = y;
         for (x = min_x; x < max_x; ++x) {
-            pixel = (pixels + y * surf->pitch) + x * format->BytesPerPixel;
-            switch (format->BytesPerPixel) {
+            pixel = (pixels + y * surf->pitch) +
+                    x * PG_FORMAT_BytesPerPixel(format);
+            switch (PG_FORMAT_BytesPerPixel(format)) {
                 case 1:
                     value = *pixel;
                     break;
@@ -2920,7 +2927,7 @@ surf_get_bounding_rect(PyObject *self, PyObject *args, PyObject *kwargs)
                     value |= pixel[BYTE2] << 16;
                     break;
                 default:
-                    assert(format->BytesPerPixel == 4);
+                    assert(PG_FORMAT_BytesPerPixel(format) == 4);
                     value = *(Uint32 *)pixel;
             }
             SDL_GetRGBA(value, surf->format, &r, &g, &b, &a);
@@ -2938,8 +2945,9 @@ surf_get_bounding_rect(PyObject *self, PyObject *args, PyObject *kwargs)
     for (x = min_x; x < max_x; ++x) {
         min_x = x;
         for (y = min_y; y < max_y; ++y) {
-            pixel = (pixels + y * surf->pitch) + x * format->BytesPerPixel;
-            switch (format->BytesPerPixel) {
+            pixel = (pixels + y * surf->pitch) +
+                    x * PG_FORMAT_BytesPerPixel(format);
+            switch (PG_FORMAT_BytesPerPixel(format)) {
                 case 1:
                     value = *pixel;
                     break;
@@ -2952,7 +2960,7 @@ surf_get_bounding_rect(PyObject *self, PyObject *args, PyObject *kwargs)
                     value |= pixel[BYTE2] << 16;
                     break;
                 default:
-                    assert(format->BytesPerPixel == 4);
+                    assert(PG_FORMAT_BytesPerPixel(format) == 4);
                     value = *(Uint32 *)pixel;
             }
             SDL_GetRGBA(value, surf->format, &r, &g, &b, &a);
@@ -3046,7 +3054,8 @@ surf_get_view(PyObject *self, PyObject *args)
              */
 
         case VIEWKIND_0D:
-            if (surface->pitch != format->BytesPerPixel * surface->w) {
+            if (surface->pitch !=
+                PG_FORMAT_BytesPerPixel(format) * surface->w) {
                 PyErr_SetString(PyExc_ValueError,
                                 "Surface data is not contiguous");
                 return 0;
@@ -3054,7 +3063,8 @@ surf_get_view(PyObject *self, PyObject *args)
             get_buffer = _get_buffer_0D;
             break;
         case VIEWKIND_1D:
-            if (surface->pitch != format->BytesPerPixel * surface->w) {
+            if (surface->pitch !=
+                PG_FORMAT_BytesPerPixel(format) * surface->w) {
                 PyErr_SetString(PyExc_ValueError,
                                 "Surface data is not contiguous");
                 return 0;
@@ -3065,12 +3075,13 @@ surf_get_view(PyObject *self, PyObject *args)
             get_buffer = _get_buffer_2D;
             break;
         case VIEWKIND_3D:
-            if (format->BytesPerPixel < 3) {
-                return _raise_get_view_ndim_error(format->BytesPerPixel * 8,
-                                                  view_kind);
+            if (PG_FORMAT_BytesPerPixel(format) < 3) {
+                return _raise_get_view_ndim_error(
+                    PG_FORMAT_BytesPerPixel(format) * 8, view_kind);
             }
             if (format->Gmask != 0x00ff00 &&
-                (format->BytesPerPixel != 4 || format->Gmask != 0xff0000)) {
+                (PG_FORMAT_BytesPerPixel(format) != 4 ||
+                 format->Gmask != 0xff0000)) {
                 return RAISE(PyExc_ValueError,
                              "unsupported colormasks for 3D reference array");
             }
@@ -3211,7 +3222,7 @@ static int
 _get_buffer_1D(PyObject *obj, Py_buffer *view_p, int flags)
 {
     SDL_Surface *surface = pgSurface_AsSurface(obj);
-    Py_ssize_t itemsize = surface->format->BytesPerPixel;
+    Py_ssize_t itemsize = PG_SURF_BytesPerPixel(surface);
 
     view_p->obj = 0;
     if (itemsize == 1) {
@@ -3269,7 +3280,7 @@ static int
 _get_buffer_2D(PyObject *obj, Py_buffer *view_p, int flags)
 {
     SDL_Surface *surface = pgSurface_AsSurface(obj);
-    int itemsize = surface->format->BytesPerPixel;
+    int itemsize = PG_SURF_BytesPerPixel(surface);
 
     view_p->obj = 0;
     if (!PyBUF_HAS_FLAG(flags, PyBUF_ND)) {
@@ -3355,7 +3366,7 @@ static int
 _get_buffer_3D(PyObject *obj, Py_buffer *view_p, int flags)
 {
     SDL_Surface *surface = pgSurface_AsSurface(obj);
-    int pixelsize = surface->format->BytesPerPixel;
+    int pixelsize = PG_SURF_BytesPerPixel(surface);
     char *startpixel = (char *)surface->pixels;
 
     view_p->obj = 0;
@@ -3462,7 +3473,7 @@ _get_buffer_colorplane(PyObject *obj, Py_buffer *view_p, int flags, char *name,
                        Uint32 mask)
 {
     SDL_Surface *surface = pgSurface_AsSurface(obj);
-    int pixelsize = surface->format->BytesPerPixel;
+    int pixelsize = PG_SURF_BytesPerPixel(surface);
     char *startpixel = (char *)surface->pixels;
 
     view_p->obj = 0;
@@ -3781,15 +3792,15 @@ surface_do_overlap(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
     }
 
     srcpixels = ((Uint8 *)src->pixels + srcy * src->pitch +
-                 srcx * src->format->BytesPerPixel);
+                 srcx * PG_SURF_BytesPerPixel(src));
     dstpixels = ((Uint8 *)dst->pixels + dsty * dst->pitch +
-                 dstx * dst->format->BytesPerPixel);
+                 dstx * PG_SURF_BytesPerPixel(dst));
 
     if (dstpixels <= srcpixels) {
         return 0;
     }
 
-    span = w * src->format->BytesPerPixel;
+    span = w * PG_SURF_BytesPerPixel(src);
 
     if (dstpixels >= srcpixels + (h - 1) * src->pitch + span) {
         return 0;
@@ -3862,11 +3873,11 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
         /* Py_END_ALLOW_THREADS */
     }
     /* can't blit alpha to 8bit, crashes SDL */
-    else if (dst->format->BytesPerPixel == 1 &&
+    else if (PG_SURF_BytesPerPixel(dst) == 1 &&
              (SDL_ISPIXELFORMAT_ALPHA(src->format->format) ||
               ((SDL_GetSurfaceAlphaMod(src, &alpha) == 0 && alpha != 255)))) {
         /* Py_BEGIN_ALLOW_THREADS */
-        if (src->format->BytesPerPixel == 1) {
+        if (PG_SURF_BytesPerPixel(src) == 1) {
             result = pygame_Blit(src, srcrect, dst, dstrect, 0);
         }
         else {
@@ -3874,8 +3885,13 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
             SDL_PixelFormat newfmt;
 
             newfmt.palette = 0; /* Set NULL (or SDL gets confused) */
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+            newfmt.bits_per_pixel = fmt->bits_per_pixel;
+            newfmt.bytes_per_pixel = fmt->bytes_per_pixel;
+#else
             newfmt.BitsPerPixel = fmt->BitsPerPixel;
             newfmt.BytesPerPixel = fmt->BytesPerPixel;
+#endif
             newfmt.Amask = 0;
             newfmt.Rmask = fmt->Rmask;
             newfmt.Gmask = fmt->Gmask;
@@ -3902,8 +3918,8 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
     else if (blend_flags != PYGAME_BLEND_ALPHA_SDL2 &&
              !(pg_EnvShouldBlendAlphaSDL2()) &&
              SDL_GetColorKey(src, &key) != 0 &&
-             (dst->format->BytesPerPixel == 4 ||
-              dst->format->BytesPerPixel == 2) &&
+             (PG_SURF_BytesPerPixel(dst) == 4 ||
+              PG_SURF_BytesPerPixel(dst) == 2) &&
              _PgSurface_SrcAlpha(src) &&
              (SDL_ISPIXELFORMAT_ALPHA(src->format->format)) &&
              !pg_HasSurfaceRLE(src) && !pg_HasSurfaceRLE(dst) &&

--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -84,7 +84,7 @@ surface_fill_blend_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int width = rect->w;
     int height = rect->h;
     int skip;
-    int bpp = surface->format->BytesPerPixel;
+    int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
@@ -170,7 +170,7 @@ surface_fill_blend_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int width = rect->w;
     int height = rect->h;
     int skip;
-    int bpp = surface->format->BytesPerPixel;
+    int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
@@ -256,7 +256,7 @@ surface_fill_blend_mult(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int width = rect->w;
     int height = rect->h;
     int skip;
-    int bpp = surface->format->BytesPerPixel;
+    int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
@@ -341,7 +341,7 @@ surface_fill_blend_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int width = rect->w;
     int height = rect->h;
     int skip;
-    int bpp = surface->format->BytesPerPixel;
+    int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
@@ -426,7 +426,7 @@ surface_fill_blend_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int width = rect->w;
     int height = rect->h;
     int skip;
-    int bpp = surface->format->BytesPerPixel;
+    int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
@@ -513,7 +513,7 @@ surface_fill_blend_rgba_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int width = rect->w;
     int height = rect->h;
     int skip;
-    int bpp = surface->format->BytesPerPixel;
+    int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
@@ -582,7 +582,7 @@ surface_fill_blend_rgba_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int width = rect->w;
     int height = rect->h;
     int skip;
-    int bpp = surface->format->BytesPerPixel;
+    int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
@@ -652,7 +652,7 @@ surface_fill_blend_rgba_mult(SDL_Surface *surface, SDL_Rect *rect,
     int width = rect->w;
     int height = rect->h;
     int skip;
-    int bpp = surface->format->BytesPerPixel;
+    int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
@@ -720,7 +720,7 @@ surface_fill_blend_rgba_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int width = rect->w;
     int height = rect->h;
     int skip;
-    int bpp = surface->format->BytesPerPixel;
+    int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
@@ -788,7 +788,7 @@ surface_fill_blend_rgba_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int width = rect->w;
     int height = rect->h;
     int skip;
-    int bpp = surface->format->BytesPerPixel;
+    int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
@@ -869,7 +869,7 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
         case PYGAME_BLEND_ADD: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-            if (surface->format->BytesPerPixel == 4) {
+            if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
                     result = surface_fill_blend_add_avx2(surface, rect, color);
                     break;
@@ -889,7 +889,7 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
         case PYGAME_BLEND_SUB: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-            if (surface->format->BytesPerPixel == 4) {
+            if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
                     result = surface_fill_blend_sub_avx2(surface, rect, color);
                     break;
@@ -909,7 +909,7 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
         case PYGAME_BLEND_MULT: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-            if (surface->format->BytesPerPixel == 4) {
+            if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
                     result =
                         surface_fill_blend_mult_avx2(surface, rect, color);
@@ -931,7 +931,7 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
         case PYGAME_BLEND_MIN: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-            if (surface->format->BytesPerPixel == 4) {
+            if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
                     result = surface_fill_blend_min_avx2(surface, rect, color);
                     break;
@@ -951,7 +951,7 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
         case PYGAME_BLEND_MAX: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-            if (surface->format->BytesPerPixel == 4) {
+            if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
                     result = surface_fill_blend_max_avx2(surface, rect, color);
                     break;
@@ -972,7 +972,7 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
         case PYGAME_BLEND_RGBA_ADD: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-            if (surface->format->BytesPerPixel == 4) {
+            if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
                     result =
                         surface_fill_blend_rgba_add_avx2(surface, rect, color);
@@ -994,7 +994,7 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
         case PYGAME_BLEND_RGBA_SUB: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-            if (surface->format->BytesPerPixel == 4) {
+            if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
                     result =
                         surface_fill_blend_rgba_sub_avx2(surface, rect, color);
@@ -1016,7 +1016,7 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
         case PYGAME_BLEND_RGBA_MULT: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-            if (surface->format->BytesPerPixel == 4) {
+            if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
                     result = surface_fill_blend_rgba_mult_avx2(surface, rect,
                                                                color);
@@ -1038,7 +1038,7 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
         case PYGAME_BLEND_RGBA_MIN: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-            if (surface->format->BytesPerPixel == 4) {
+            if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
                     result =
                         surface_fill_blend_rgba_min_avx2(surface, rect, color);
@@ -1060,7 +1060,7 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
         case PYGAME_BLEND_RGBA_MAX: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-            if (surface->format->BytesPerPixel == 4) {
+            if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
                     result =
                         surface_fill_blend_rgba_max_avx2(surface, rect, color);

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -125,7 +125,7 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
     Uint8 alpha;
     int isalpha;
 
-    if (surf->format->BytesPerPixel == 0 || surf->format->BytesPerPixel > 4)
+    if (PG_SURF_BytesPerPixel(surf) == 0 || PG_SURF_BytesPerPixel(surf) > 4)
         return (SDL_Surface *)(RAISE(
             PyExc_ValueError, "unsupported Surface bit depth for transform"));
 
@@ -224,7 +224,7 @@ rotate90(SDL_Surface *src, int angle)
     SDL_LockSurface(dst);
     srcrow = (char *)src->pixels;
     dstrow = (char *)dst->pixels;
-    srcstepx = dststepx = src->format->BytesPerPixel;
+    srcstepx = dststepx = PG_SURF_BytesPerPixel(src);
     srcstepy = src->pitch;
     dststepy = dst->pitch;
 
@@ -243,11 +243,11 @@ rotate90(SDL_Surface *src, int angle)
         case 3:
             srcrow += ((src->h - 1) * srcstepy);
             srcstepx = -srcstepy;
-            srcstepy = src->format->BytesPerPixel;
+            srcstepy = PG_SURF_BytesPerPixel(src);
             break;
     }
 
-    switch (src->format->BytesPerPixel) {
+    switch (PG_SURF_BytesPerPixel(src)) {
         case 1:
             for (loopy = 0; loopy < dstheight; ++loopy) {
                 dstpix = dstrow;
@@ -332,7 +332,7 @@ rotate(SDL_Surface *src, SDL_Surface *dst, Uint32 bgcolor, double sangle,
     int xmaxval = ((src->w) << 16) - 1;
     int ymaxval = ((src->h) << 16) - 1;
 
-    switch (src->format->BytesPerPixel) {
+    switch (PG_SURF_BytesPerPixel(src)) {
         case 1:
             for (y = 0; y < dst->h; y++) {
                 Uint8 *dstpos = (Uint8 *)dstrow;
@@ -434,7 +434,7 @@ scale_to(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int width,
     }
     else {
         modsurf = retsurf = pgSurface_AsSurface(dstobj);
-        if (retsurf->format->BytesPerPixel != src->format->BytesPerPixel ||
+        if (PG_SURF_BytesPerPixel(retsurf) != PG_SURF_BytesPerPixel(src) ||
             retsurf->format->Rmask != src->format->Rmask ||
             retsurf->format->Gmask != src->format->Gmask ||
             retsurf->format->Bmask != src->format->Bmask) {
@@ -590,7 +590,7 @@ surf_scale2x(PyObject *self, PyObject *args, PyObject *kwargs)
         return RAISE(PyExc_ValueError, "Destination surface not 2x bigger.");
 
     /* check to see if the format of the surface is the same. */
-    if (surf->format->BytesPerPixel != newsurf->format->BytesPerPixel)
+    if (PG_SURF_BytesPerPixel(surf) != PG_SURF_BytesPerPixel(newsurf))
         return RAISE(PyExc_ValueError,
                      "Source and destination surfaces need the same format.");
 
@@ -636,7 +636,7 @@ surf_rotate(PyObject *self, PyObject *args, PyObject *kwargs)
         return (PyObject *)surfobj;
     }
 
-    if (surf->format->BytesPerPixel == 0 || surf->format->BytesPerPixel > 4)
+    if (PG_SURF_BytesPerPixel(surf) == 0 || PG_SURF_BytesPerPixel(surf) > 4)
         return RAISE(PyExc_ValueError,
                      "unsupported Surface bit depth for transform");
 
@@ -674,7 +674,7 @@ surf_rotate(PyObject *self, PyObject *args, PyObject *kwargs)
     /* get the background color */
     if (SDL_GetColorKey(surf, &bgcolor) != 0) {
         SDL_LockSurface(surf);
-        switch (surf->format->BytesPerPixel) {
+        switch (PG_SURF_BytesPerPixel(surf)) {
             case 1:
                 bgcolor = *(Uint8 *)surf->pixels;
                 break;
@@ -749,19 +749,19 @@ surf_flip(PyObject *self, PyObject *args, PyObject *kwargs)
         if (!yaxis) {
             for (loopy = 0; loopy < surf->h; ++loopy)
                 memcpy(dstpix + loopy * dstpitch, srcpix + loopy * srcpitch,
-                       surf->w * surf->format->BytesPerPixel);
+                       surf->w * PG_SURF_BytesPerPixel(surf));
         }
         else {
             for (loopy = 0; loopy < surf->h; ++loopy)
                 memcpy(dstpix + loopy * dstpitch,
                        srcpix + (surf->h - 1 - loopy) * srcpitch,
-                       surf->w * surf->format->BytesPerPixel);
+                       surf->w * PG_SURF_BytesPerPixel(surf));
         }
     }
     else /*if (xaxis)*/
     {
         if (yaxis) {
-            switch (surf->format->BytesPerPixel) {
+            switch (PG_SURF_BytesPerPixel(surf)) {
                 case 1:
                     for (loopy = 0; loopy < surf->h; ++loopy) {
                         Uint8 *dst = (Uint8 *)(dstpix + loopy * dstpitch);
@@ -812,7 +812,7 @@ surf_flip(PyObject *self, PyObject *args, PyObject *kwargs)
             }
         }
         else {
-            switch (surf->format->BytesPerPixel) {
+            switch (PG_SURF_BytesPerPixel(surf)) {
                 case 1:
                     for (loopy = 0; loopy < surf->h; ++loopy) {
                         Uint8 *dst = (Uint8 *)(dstpix + loopy * dstpitch);
@@ -882,7 +882,7 @@ surf_rotozoom(PyObject *self, PyObject *args, PyObject *kwargs)
         return (PyObject *)pgSurface_New(newsurf);
     }
 
-    if (surf->format->BitsPerPixel == 32) {
+    if (PG_SURF_BitsPerPixel(surf) == 32) {
         surf32 = surf;
         pgSurface_Lock(surfobj);
     }
@@ -941,7 +941,7 @@ chop(SDL_Surface *src, int x, int y, int width, int height)
     SDL_LockSurface(dst);
     srcrow = (char *)src->pixels;
     dstrow = (char *)dst->pixels;
-    srcstepx = dststepx = src->format->BytesPerPixel;
+    srcstepx = dststepx = PG_SURF_BytesPerPixel(src);
     srcstepy = src->pitch;
     dststepy = dst->pitch;
 
@@ -951,7 +951,7 @@ chop(SDL_Surface *src, int x, int y, int width, int height)
             srcpix = srcrow;
             for (loopx = 0; loopx < src->w; loopx++) {
                 if ((loopx < x) || (loopx >= (x + width))) {
-                    switch (src->format->BytesPerPixel) {
+                    switch (PG_SURF_BytesPerPixel(src)) {
                         case 1:
                             *dstpix = *srcpix;
                             break;
@@ -1327,7 +1327,7 @@ scalesmooth(SDL_Surface *src, SDL_Surface *dst, struct _module_state *st)
     int dstwidth = dst->w;
     int dstheight = dst->h;
 
-    int bpp = src->format->BytesPerPixel;
+    int bpp = PG_SURF_BytesPerPixel(src);
 
     Uint8 *temppix = NULL;
     int tempwidth = 0, temppitch = 0;
@@ -1432,7 +1432,7 @@ smoothscale_to(PyObject *self, pgSurfaceObject *srcobj,
 
     src = pgSurface_AsSurface(srcobj);
 
-    bpp = src->format->BytesPerPixel;
+    bpp = PG_SURF_BytesPerPixel(src);
     if (bpp < 3 || bpp > 4)
         return (SDL_Surface *)(RAISE(
             PyExc_ValueError,
@@ -1707,7 +1707,7 @@ _set_at_pixels(int x, int y, Uint8 *pixels, SDL_PixelFormat *format,
 {
     Uint8 *byte_buf;
 
-    switch (format->BytesPerPixel) {
+    switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
             *((Uint8 *)pixels + y * surf_pitch + x) = (Uint8)the_color;
             break;
@@ -1770,14 +1770,14 @@ get_threshold(SDL_Surface *dest_surf, SDL_Surface *surf,
             pixels2 = (Uint8 *)search_surf->pixels + y * search_surf->pitch;
 
         for (x = 0; x < surf->w; x++) {
-            pixels = _get_color_move_pixels(surf->format->BytesPerPixel,
+            pixels = _get_color_move_pixels(PG_SURF_BytesPerPixel(surf),
                                             pixels, &the_color);
             SDL_GetRGB(the_color, surf->format, &surf_r, &surf_g, &surf_b);
 
             if (search_surf) {
                 /* Get search_surf.color */
                 pixels2 = _get_color_move_pixels(
-                    search_surf->format->BytesPerPixel, pixels2, &the_color2);
+                    PG_SURF_BytesPerPixel(search_surf), pixels2, &the_color2);
                 SDL_GetRGB(the_color2, search_surf->format, &search_surf_r,
                            &search_surf_g, &search_surf_b);
 
@@ -2013,7 +2013,7 @@ clamp_4
 */
 
 #define SURF_GET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format, p_pix)    \
-    switch (p_format->BytesPerPixel) {                                       \
+    switch (PG_FORMAT_BytesPerPixel(p_format)) {                             \
         case 1:                                                              \
             p_color = (Uint32) *                                             \
                       ((Uint8 *)(p_pixels) + (p_y) * p_surf->pitch + (p_x)); \
@@ -2040,7 +2040,7 @@ clamp_4
 
 #define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,       \
                     p_byte_buf)                                          \
-    switch (p_format->BytesPerPixel) {                                   \
+    switch (PG_FORMAT_BytesPerPixel(p_format)) {                         \
         case 1:                                                          \
             *((Uint8 *)p_pixels + (p_y) * p_surf->pitch + (p_x)) =       \
                 (Uint8)p_color;                                          \
@@ -2069,7 +2069,7 @@ clamp_4
 
 #define SURF_SET_AT(p_color, p_surf, p_x, p_y, p_pixels, p_format,       \
                     p_byte_buf)                                          \
-    switch (p_format->BytesPerPixel) {                                   \
+    switch (PG_FORMAT_BytesPerPixel(p_format)) {                         \
         case 1:                                                          \
             *((Uint8 *)p_pixels + (p_y) * p_surf->pitch + (p_x)) =       \
                 (Uint8)p_color;                                          \
@@ -2147,7 +2147,7 @@ grayscale(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj)
             "Destination surface must be the same size as source surface."));
     }
 
-    if (src->format->BytesPerPixel != newsurf->format->BytesPerPixel) {
+    if (PG_SURF_BytesPerPixel(src) != PG_SURF_BytesPerPixel(newsurf)) {
         return (SDL_Surface *)(RAISE(
             PyExc_ValueError,
             "Source and destination surfaces need the same format."));
@@ -2155,7 +2155,7 @@ grayscale(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj)
 #if defined(__EMSCRIPTEN__)
     grayscale_non_simd(src, newsurf);
 #else  // !defined(__EMSCRIPTEN__)
-    if (src->format->BytesPerPixel == 4 &&
+    if (PG_SURF_BytesPerPixel(src) == 4 &&
         src->format->Rmask == newsurf->format->Rmask &&
         src->format->Gmask == newsurf->format->Gmask &&
         src->format->Bmask == newsurf->format->Bmask &&
@@ -2371,7 +2371,7 @@ laplacian(SDL_Surface *surf, SDL_Surface *destsurf)
 
             // set_at(destsurf, color, x,y);
 
-            switch (destformat->BytesPerPixel) {
+            switch (PG_FORMAT_BytesPerPixel(destformat)) {
                 case 1:
                     *((Uint8 *)destpixels + y * destsurf->pitch + x) =
                         (Uint8)the_color;
@@ -2444,7 +2444,7 @@ surf_laplacian(PyObject *self, PyObject *args, PyObject *kwargs)
                      "Destination surface not the same size.");
 
     /* check to see if the format of the surface is the same. */
-    if (surf->format->BytesPerPixel != newsurf->format->BytesPerPixel)
+    if (PG_SURF_BytesPerPixel(surf) != PG_SURF_BytesPerPixel(newsurf))
         return RAISE(PyExc_ValueError,
                      "Source and destination surfaces need the same format.");
 
@@ -2514,7 +2514,7 @@ average_surfaces(SDL_Surface **surfaces, size_t num_surfaces,
     If we're using 1 byte per pixel, then only need to average on that much.
     */
 
-    if ((destformat->BytesPerPixel == 1) && (destformat->palette) &&
+    if ((PG_FORMAT_BytesPerPixel(destformat) == 1) && (destformat->palette) &&
         (!palette_colors)) {
         num_elements = 1;
     }
@@ -2549,7 +2549,8 @@ average_surfaces(SDL_Surface **surfaces, size_t num_surfaces,
         the_idx = accumulate;
         /* If palette surface, we use a different code path... */
 
-        if ((format->BytesPerPixel == 1 && destformat->BytesPerPixel == 1) &&
+        if ((PG_FORMAT_BytesPerPixel(format) == 1 &&
+             PG_FORMAT_BytesPerPixel(destformat) == 1) &&
             (format->palette) && (destformat->palette) && (!palette_colors)) {
             /*
             This is useful if the surface is actually greyscale colors,
@@ -2746,8 +2747,8 @@ surf_average_surfaces(PyObject *self, PyObject *args, PyObject *kwargs)
             }
 
             /* check to see if the format of the surface is the same. */
-            if (surf->format->BytesPerPixel !=
-                newsurf->format->BytesPerPixel) {
+            if (PG_SURF_BytesPerPixel(surf) !=
+                PG_SURF_BytesPerPixel(newsurf)) {
                 Py_XDECREF(obj);
                 ret = RAISE(
                     PyExc_ValueError,
@@ -2863,7 +2864,7 @@ average_color(SDL_Surface *surf, int x, int y, int width, int height, Uint8 *r,
     height_and_y = height + y;
 
     if (consider_alpha) {
-        switch (format->BytesPerPixel) {
+        switch (PG_FORMAT_BytesPerPixel(format)) {
             case 1: {
                 Uint8 color8;
                 for (row = y; row < height_and_y; row++) {
@@ -2947,7 +2948,7 @@ average_color(SDL_Surface *surf, int x, int y, int width, int height, Uint8 *r,
         *b = btot / size;
     }
     else {
-        switch (format->BytesPerPixel) {
+        switch (PG_FORMAT_BytesPerPixel(format)) {
             case 1: {
                 Uint8 color8;
                 for (row = y; row < height_and_y; row++) {
@@ -3075,7 +3076,7 @@ box_blur(SDL_Surface *src, SDL_Surface *dst, int radius, SDL_bool repeat)
 
     Uint8 *srcpx = (Uint8 *)src->pixels;
     Uint8 *dstpx = (Uint8 *)dst->pixels;
-    Uint8 nb = src->format->BytesPerPixel;
+    Uint8 nb = PG_SURF_BytesPerPixel(src);
     int w = dst->w, h = dst->h;
     int dst_pitch = dst->pitch;
     int src_pitch = src->pitch;
@@ -3157,7 +3158,7 @@ gaussian_blur(SDL_Surface *src, SDL_Surface *dst, int sigma, SDL_bool repeat)
 {
     Uint8 *srcpx = (Uint8 *)src->pixels;
     Uint8 *dstpx = (Uint8 *)dst->pixels;
-    Uint8 nb = src->format->BytesPerPixel;
+    Uint8 nb = PG_SURF_BytesPerPixel(src);
     int w = dst->w, h = dst->h;
     int dst_pitch = dst->pitch;
     int src_pitch = src->pitch;
@@ -3279,7 +3280,7 @@ blur(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int radius,
                      "Destination surface not the same size.");
     }
 
-    if (src->format->BytesPerPixel != retsurf->format->BytesPerPixel) {
+    if (PG_SURF_BytesPerPixel(src) != PG_SURF_BytesPerPixel(retsurf)) {
         return (SDL_Surface *)(RAISE(
             PyExc_ValueError,
             "Source and destination surfaces need the same format."));
@@ -3413,7 +3414,7 @@ invert(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj)
             "Destination surface must be the same size as source surface."));
     }
 
-    if (src->format->BytesPerPixel != newsurf->format->BytesPerPixel) {
+    if (PG_SURF_BytesPerPixel(src) != PG_SURF_BytesPerPixel(newsurf)) {
         return (SDL_Surface *)(RAISE(
             PyExc_ValueError,
             "Source and destination surfaces need the same format."));
@@ -3421,7 +3422,7 @@ invert(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj)
 #if defined(__EMSCRIPTEN__)
     invert_non_simd(src, newsurf);
 #else  // !defined(__EMSCRIPTEN__)
-    if (src->format->BytesPerPixel == 4 &&
+    if (PG_SURF_BytesPerPixel(src) == 4 &&
         src->format->Rmask == newsurf->format->Rmask &&
         src->format->Gmask == newsurf->format->Gmask &&
         src->format->Bmask == newsurf->format->Bmask &&


### PR DESCRIPTION
This doesn't fix every read/write of these struct members, but it gets 99% of them. And this is hard to test (SDL3wise) without everything else compiling on SDL3, which it doesn't without a lot more patches.

For SDL2, this doesn't change how it compiles at all.