### PR TITLE
Remove use of Py_BuildValue("(ii)")

### DIFF
--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -338,7 +338,7 @@ PyObject *
 camera_get_size(pgCameraObject *self, PyObject *_null)
 {
 #if defined(__unix__) || defined(PYGAME_WINDOWS_CAMERA)
-    return Py_BuildValue("(ii)", self->width, self->height);
+    return pg_tuple_couple_from_values_int( self->width, self->height);
 #endif
     Py_RETURN_NONE;
 }

--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -338,7 +338,7 @@ PyObject *
 camera_get_size(pgCameraObject *self, PyObject *_null)
 {
 #if defined(__unix__) || defined(PYGAME_WINDOWS_CAMERA)
-    return pg_tuple_couple_from_values_int( self->width, self->height);
+    return pg_tuple_couple_from_values_int(self->width, self->height);
 #endif
     Py_RETURN_NONE;
 }

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -353,7 +353,7 @@ pg_init(PyObject *self, PyObject *_null)
     }
 
     pg_is_init = 1;
-    return Py_BuildValue("(ii)", success, fail);
+    return pg_tuple_couple_from_values_int( success, fail);
 }
 
 static void

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -353,7 +353,7 @@ pg_init(PyObject *self, PyObject *_null)
     }
 
     pg_is_init = 1;
-    return pg_tuple_couple_from_values_int( success, fail);
+    return pg_tuple_couple_from_values_int(success, fail);
 }
 
 static void

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -1924,7 +1924,7 @@ _color_slice(register pgColorObject *a, register Py_ssize_t ilow,
         return Py_BuildValue("(iii)", c1, c2, c3);
     }
     else if (len == 2) {
-        return pg_tuple_couple_from_values_int( c1, c2);
+        return pg_tuple_couple_from_values_int(c1, c2);
     }
     else if (len == 1) {
         return Py_BuildValue("(i)", c1);

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -1924,7 +1924,7 @@ _color_slice(register pgColorObject *a, register Py_ssize_t ilow,
         return Py_BuildValue("(iii)", c1, c2, c3);
     }
     else if (len == 2) {
-        return Py_BuildValue("(ii)", c1, c2);
+        return pg_tuple_couple_from_values_int( c1, c2);
     }
     else if (len == 1) {
         return Py_BuildValue("(i)", c1);

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -1924,7 +1924,7 @@ _color_slice(register pgColorObject *a, register Py_ssize_t ilow,
         return Py_BuildValue("(iii)", c1, c2, c3);
     }
     else if (len == 2) {
-        return pg_tuple_couple_from_values_int(c1, c2);
+        return pg_tuple_couple_from_values_int((int)c1, (int)c2);
     }
     else if (len == 1) {
         return Py_BuildValue("(i)", c1);

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1444,7 +1444,7 @@ pg_window_size(PyObject *self, PyObject *_null)
     if (!win)
         return RAISE(pgExc_SDLError, "No open window");
     SDL_GetWindowSize(win, &w, &h);
-    return pg_tuple_couple_from_values_int( w, h);
+    return pg_tuple_couple_from_values_int(w, h);
 }
 
 static PyObject *
@@ -1557,7 +1557,7 @@ pg_list_modes(PyObject *self, PyObject *args, PyObject *kwds)
             last_width != -1) {
             continue;
         }
-        if (!(size = pg_tuple_couple_from_values_int( mode.w, mode.h))) {
+        if (!(size = pg_tuple_couple_from_values_int(mode.w, mode.h))) {
             Py_DECREF(list);
             return NULL;
         }
@@ -2117,7 +2117,7 @@ pg_get_desktop_screen_sizes(PyObject *self, PyObject *_null)
             return RAISE(pgExc_SDLError, SDL_GetError());
         }
 
-        size_tuple = pg_tuple_couple_from_values_int( dm.w, dm.h);
+        size_tuple = pg_tuple_couple_from_values_int(dm.w, dm.h);
         if (!size_tuple) {
             Py_DECREF(result);
             return NULL;

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1444,7 +1444,7 @@ pg_window_size(PyObject *self, PyObject *_null)
     if (!win)
         return RAISE(pgExc_SDLError, "No open window");
     SDL_GetWindowSize(win, &w, &h);
-    return Py_BuildValue("(ii)", w, h);
+    return pg_tuple_couple_from_values_int( w, h);
 }
 
 static PyObject *
@@ -1557,7 +1557,7 @@ pg_list_modes(PyObject *self, PyObject *args, PyObject *kwds)
             last_width != -1) {
             continue;
         }
-        if (!(size = Py_BuildValue("(ii)", mode.w, mode.h))) {
+        if (!(size = pg_tuple_couple_from_values_int( mode.w, mode.h))) {
             Py_DECREF(list);
             return NULL;
         }
@@ -2117,7 +2117,7 @@ pg_get_desktop_screen_sizes(PyObject *self, PyObject *_null)
             return RAISE(pgExc_SDLError, SDL_GetError());
         }
 
-        size_tuple = Py_BuildValue("(ii)", dm.w, dm.h);
+        size_tuple = pg_tuple_couple_from_values_int( dm.w, dm.h);
         if (!size_tuple) {
             Py_DECREF(result);
             return NULL;

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -945,8 +945,8 @@ dict_from_event(SDL_Event *event)
 
     switch (event->type) {
         case SDL_VIDEORESIZE:
-            obj = Py_BuildValue("(ii)", event->window.data1,
-                                event->window.data2);
+            obj = pg_tuple_couple_from_values_int(event->window.data1,
+                                                  event->window.data2);
             _pg_insobj(dict, "size", obj);
             _pg_insobj(dict, "w", PyLong_FromLong(event->window.data1));
             _pg_insobj(dict, "h", PyLong_FromLong(event->window.data2));
@@ -993,10 +993,11 @@ dict_from_event(SDL_Event *event)
                        PyLong_FromLong(event->key.keysym.scancode));
             break;
         case SDL_MOUSEMOTION:
-            obj = Py_BuildValue("(ii)", event->motion.x, event->motion.y);
+            obj = pg_tuple_couple_from_values_int(event->motion.x,
+                                                  event->motion.y);
             _pg_insobj(dict, "pos", obj);
-            obj =
-                Py_BuildValue("(ii)", event->motion.xrel, event->motion.yrel);
+            obj = pg_tuple_couple_from_values_int(event->motion.xrel,
+                                                  event->motion.yrel);
             _pg_insobj(dict, "rel", obj);
             if ((tuple = PyTuple_New(3))) {
                 PyTuple_SET_ITEM(tuple, 0,
@@ -1016,7 +1017,8 @@ dict_from_event(SDL_Event *event)
             break;
         case SDL_MOUSEBUTTONDOWN:
         case SDL_MOUSEBUTTONUP:
-            obj = Py_BuildValue("(ii)", event->button.x, event->button.y);
+            obj = pg_tuple_couple_from_values_int(event->button.x,
+                                                  event->button.y);
             _pg_insobj(dict, "pos", obj);
             _pg_insobj(dict, "button", PyLong_FromLong(event->button.button));
             _pg_insobj(
@@ -1036,7 +1038,8 @@ dict_from_event(SDL_Event *event)
             _pg_insobj(dict, "instance_id",
                        PyLong_FromLong(event->jball.which));
             _pg_insobj(dict, "ball", PyLong_FromLong(event->jball.ball));
-            obj = Py_BuildValue("(ii)", event->jball.xrel, event->jball.yrel);
+            obj = pg_tuple_couple_from_values_int(event->jball.xrel,
+                                                  event->jball.yrel);
             _pg_insobj(dict, "rel", obj);
             break;
         case SDL_JOYHATMOTION:
@@ -1053,7 +1056,7 @@ dict_from_event(SDL_Event *event)
                 hx = 1;
             else if (event->jhat.value & SDL_HAT_LEFT)
                 hx = -1;
-            _pg_insobj(dict, "value", Py_BuildValue("(ii)", hx, hy));
+            _pg_insobj(dict, "value", pg_tuple_couple_from_values_int(hx, hy));
             break;
         case SDL_JOYBUTTONUP:
         case SDL_JOYBUTTONDOWN:

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -704,7 +704,7 @@ font_size(PyObject *self, PyObject *text)
     else {
         return RAISE_TEXT_TYPE_ERROR();
     }
-    return pg_tuple_couple_from_values_int( w, h);
+    return pg_tuple_couple_from_values_int(w, h);
 }
 
 static PyObject *

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -704,7 +704,7 @@ font_size(PyObject *self, PyObject *text)
     else {
         return RAISE_TEXT_TYPE_ERROR();
     }
-    return Py_BuildValue("(ii)", w, h);
+    return pg_tuple_couple_from_values_int( w, h);
 }
 
 static PyObject *

--- a/src_c/joystick.c
+++ b/src_c/joystick.c
@@ -421,7 +421,7 @@ joy_get_ball(PyObject *self, PyObject *args)
     }
 
     SDL_JoystickGetBall(joy, _index, &dx, &dy);
-    return pg_tuple_couple_from_values_int( dx, dy);
+    return pg_tuple_couple_from_values_int(dx, dy);
 }
 
 static PyObject *
@@ -479,7 +479,7 @@ joy_get_hat(PyObject *self, PyObject *args)
         px = -1;
     }
 
-    return pg_tuple_couple_from_values_int( px, py);
+    return pg_tuple_couple_from_values_int(px, py);
 }
 
 static PyMethodDef joy_methods[] = {

--- a/src_c/joystick.c
+++ b/src_c/joystick.c
@@ -421,7 +421,7 @@ joy_get_ball(PyObject *self, PyObject *args)
     }
 
     SDL_JoystickGetBall(joy, _index, &dx, &dy);
-    return Py_BuildValue("(ii)", dx, dy);
+    return pg_tuple_couple_from_values_int( dx, dy);
 }
 
 static PyObject *
@@ -479,7 +479,7 @@ joy_get_hat(PyObject *self, PyObject *args)
         px = -1;
     }
 
-    return Py_BuildValue("(ii)", px, py);
+    return pg_tuple_couple_from_values_int( px, py);
 }
 
 static PyMethodDef joy_methods[] = {

--- a/src_c/key.c
+++ b/src_c/key.c
@@ -56,7 +56,7 @@ key_get_repeat(PyObject *self, PyObject *_null)
 
     VIDEO_INIT_CHECK();
     pg_GetKeyRepeat(&delay, &interval);
-    return pg_tuple_couple_from_values_int( delay, interval);
+    return pg_tuple_couple_from_values_int(delay, interval);
 }
 
 /*

--- a/src_c/key.c
+++ b/src_c/key.c
@@ -56,7 +56,7 @@ key_get_repeat(PyObject *self, PyObject *_null)
 
     VIDEO_INIT_CHECK();
     pg_GetKeyRepeat(&delay, &interval);
-    return Py_BuildValue("(ii)", delay, interval);
+    return pg_tuple_couple_from_values_int( delay, interval);
 }
 
 /*

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -100,7 +100,7 @@ static PyObject *
 mask_get_size(PyObject *self, PyObject *_null)
 {
     bitmask_t *mask = pgMask_AsBitmap(self);
-    return Py_BuildValue("(ii)", mask->w, mask->h);
+    return pg_tuple_couple_from_values_int(mask->w, mask->h);
 }
 
 /* Creates a Rect object based on the given mask's size. The rect's
@@ -224,7 +224,7 @@ mask_overlap(PyObject *self, PyObject *args, PyObject *kwargs)
 
     val = bitmask_overlap_pos(mask, othermask, x, y, &xp, &yp);
     if (val) {
-        return Py_BuildValue("(ii)", xp, yp);
+        return pg_tuple_couple_from_values_int(xp, yp);
     }
     else {
         Py_INCREF(Py_None);
@@ -521,7 +521,7 @@ mask_outline(PyObject *self, PyObject *args, PyObject *kwargs)
             if (bitmask_getbit(m, x, y)) {
                 firstx = x;
                 firsty = y;
-                value = Py_BuildValue("(ii)", x - 1, y - 1);
+                value = pg_tuple_couple_from_values_int(x - 1, y - 1);
 
                 if (NULL == value) {
                     Py_DECREF(plist);
@@ -562,7 +562,7 @@ mask_outline(PyObject *self, PyObject *args, PyObject *kwargs)
             e--;
             if (!e) {
                 e = every;
-                value = Py_BuildValue("(ii)", secx - 1, secy - 1);
+                value = pg_tuple_couple_from_values_int(secx - 1, secy - 1);
 
                 if (NULL == value) {
                     Py_DECREF(plist);
@@ -606,7 +606,8 @@ mask_outline(PyObject *self, PyObject *args, PyObject *kwargs)
                         break;
                     }
 
-                    value = Py_BuildValue("(ii)", nextx - 1, nexty - 1);
+                    value =
+                        pg_tuple_couple_from_values_int(nextx - 1, nexty - 1);
 
                     if (NULL == value) {
                         Py_DECREF(plist);

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2463,7 +2463,7 @@ surf_get_size(PyObject *self, PyObject *_null)
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
     SURF_INIT_CHECK(surf)
-    return Py_BuildValue("(ii)", surf->w, surf->h);
+    return pg_tuple_couple_from_values_int(surf->w, surf->h);
 }
 
 static PyObject *
@@ -2716,8 +2716,8 @@ surf_get_offset(PyObject *self, PyObject *_null)
 
     subdata = ((pgSurfaceObject *)self)->subsurface;
     if (!subdata)
-        return Py_BuildValue("(ii)", 0, 0);
-    return Py_BuildValue("(ii)", subdata->offsetx, subdata->offsety);
+        return pg_tuple_couple_from_values_int(0, 0);
+    return pg_tuple_couple_from_values_int(subdata->offsetx, subdata->offsety);
 }
 
 static PyObject *
@@ -2732,7 +2732,7 @@ surf_get_abs_offset(PyObject *self, PyObject *_null)
 
     subdata = ((pgSurfaceObject *)self)->subsurface;
     if (!subdata)
-        return Py_BuildValue("(ii)", 0, 0);
+        return pg_tuple_couple_from_values_int(0, 0);
 
     subdata = ((pgSurfaceObject *)self)->subsurface;
     owner = subdata->owner;
@@ -2745,7 +2745,7 @@ surf_get_abs_offset(PyObject *self, PyObject *_null)
         offsetx += subdata->offsetx;
         offsety += subdata->offsety;
     }
-    return Py_BuildValue("(ii)", offsetx, offsety);
+    return pg_tuple_couple_from_values_int(offsetx, offsety);
 }
 
 static PyObject *

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -580,7 +580,7 @@ window_get_size(pgWindowObject *self, void *v)
     int w, h;
     SDL_GetWindowSize(self->_win, &w, &h);
 
-    return Py_BuildValue("(ii)", w, h);
+    return pg_tuple_couple_from_values_int(w, h);
 }
 
 static int
@@ -620,7 +620,7 @@ window_get_minimum_size(pgWindowObject *self, void *v)
     int w, h;
     SDL_GetWindowMinimumSize(self->_win, &w, &h);
 
-    return Py_BuildValue("(ii)", w, h);
+    return pg_tuple_couple_from_values_int(w, h);
 }
 
 static int
@@ -660,7 +660,7 @@ window_get_maximum_size(pgWindowObject *self, void *v)
     int w, h;
     SDL_GetWindowMaximumSize(self->_win, &w, &h);
 
-    return Py_BuildValue("(ii)", w, h);
+    return pg_tuple_couple_from_values_int(w, h);
 }
 
 static int
@@ -691,7 +691,7 @@ window_get_position(pgWindowObject *self, void *v)
     int x, y;
     SDL_GetWindowPosition(self->_win, &x, &y);
 
-    return Py_BuildValue("(ii)", x, y);
+    return pg_tuple_couple_from_values_int(x, y);
 }
 
 static int


### PR DESCRIPTION
This PR removes all occurrences of `Py_BuildValue("(ii)")` and swaps them with the faster pg_tuple_couple_from_values_int.