### PR TITLE
Track version only in pyproject.toml

### DIFF
--- a/buildconfig/get_version.py
+++ b/buildconfig/get_version.py
@@ -29,4 +29,29 @@ else:
 
     version = ast.literal_eval(finds[0].strip())
 
-print(version)
+
+_splits = version.split(".")
+
+# handle optional dev tag
+if len(_splits) == 3:
+    _splits.append('""')
+elif len(_splits) == 4:
+    _splits[3] = f'".{_splits[3]}"'
+else:
+    raise ValueError("Invalid version!")
+
+version_short = ".".join(_splits[:3])
+version_macros = tuple(
+    zip(
+        ("PG_MAJOR_VERSION", "PG_MINOR_VERSION", "PG_PATCH_VERSION", "PG_VERSION_TAG"),
+        _splits,
+    )
+)
+
+
+if __name__ == "__main__":
+    print(
+        "\n".join(f"-D{key}={value}" for key, value in version_macros)
+        if "--macros" in sys.argv
+        else version
+    )

--- a/docs/reST/conf.py
+++ b/docs/reST/conf.py
@@ -17,6 +17,8 @@ import sys, os
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.append(os.path.abspath('.'))
 
+import buildconfig.get_version as pg_ver
+
 # -- General configuration -----------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
@@ -46,10 +48,10 @@ copyright = '2000-2022, pygame developers, 2023 pygame-ce developers'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-# The short X.Y version.
-version = '2.5.0'
+# The short X.Y.Z version.
+version = pg_ver.version_short
 # The full version, including alpha/beta/rc tags.
-release = '2.5.0.dev3'
+release = pg_ver.version
 
 # Format strings for the version directives
 versionadded_format = 'New in pygame-ce %s'

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,14 @@ project(
     ],
 )
 
+defines = run_command(
+    [find_program('python3', 'python'), 'buildconfig/get_version.py', '--macros'],
+    check: true,
+).stdout().strip().split()
+foreach define : defines
+    add_global_arguments(define, language: 'c')
+endforeach
+
 pg = 'pygame' # python base package name
 
 if host_machine.system() == 'windows'

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@
 import platform
 import sysconfig
 
+import buildconfig.get_version as pg_ver
+
 with open('README.rst', encoding='utf-8') as readme:
     LONG_DESCRIPTION = readme.read()
 
@@ -16,7 +18,7 @@ EXTRAS = {}
 
 METADATA = {
     "name": "pygame-ce",
-    "version": "2.5.0.dev3",
+    "version": pg_ver.version,
     "license": "LGPL",
     "url": "https://pyga.me",
     "author": "A community project.",
@@ -406,6 +408,9 @@ else:
         raise
 
 for e in extensions:
+    # define version macros
+    e.define_macros.extend(pg_ver.version_macros)
+
     # Only define the ARM_NEON defines if they have been enabled at build time.
     if enable_arm_neon:
         e.define_macros.append(('PG_ENABLE_ARM_NEON', '1'))

--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -55,12 +55,22 @@
 #include <Python.h>
 
 /* version macros (defined since version 1.9.5) */
-#define PG_MAJOR_VERSION 2
-#define PG_MINOR_VERSION 5
-#define PG_PATCH_VERSION 0
-/* The below is of the form ".devX" for dev releases, and "" (empty) for full
- * releases */
-#define PG_VERSION_TAG ".dev3"
+#ifndef PG_MAJOR_VERSION
+#error PG_MAJOR_VERSION must be defined
+#endif
+
+#ifndef PG_MINOR_VERSION
+#error PG_MINOR_VERSION must be defined
+#endif
+
+#ifndef PG_PATCH_VERSION
+#error PG_PATCH_VERSION must be defined
+#endif
+
+#ifndef PG_VERSION_TAG
+#error PG_VERSION_TAG must be defined
+#endif
+
 #define PG_VERSIONNUM(MAJOR, MINOR, PATCH) \
     (1000 * (MAJOR) + 100 * (MINOR) + (PATCH))
 #define PG_VERSION_ATLEAST(MAJOR, MINOR, PATCH)                             \

--- a/test/version_test.py
+++ b/test/version_test.py
@@ -9,38 +9,18 @@ pg_header = os.path.join("src_c", "include", "_pygame.h")
 
 
 class VersionTest(unittest.TestCase):
-    @unittest.skipIf(
-        not os.path.isfile(pg_header), "Skipping because we cannot find _pygame.h"
-    )
-    def test_pg_version_consistency(self):
-        pgh_major = -1
-        pgh_minor = -1
-        pgh_patch = -1
-        import re
-
-        major_exp_search = re.compile(r"define\s+PG_MAJOR_VERSION\s+([0-9]+)").search
-        minor_exp_search = re.compile(r"define\s+PG_MINOR_VERSION\s+([0-9]+)").search
-        patch_exp_search = re.compile(r"define\s+PG_PATCH_VERSION\s+([0-9]+)").search
-        with open(pg_header) as f:
-            for line in f:
-                if pgh_major == -1:
-                    m = major_exp_search(line)
-                    if m:
-                        pgh_major = int(m.group(1))
-                if pgh_minor == -1:
-                    m = minor_exp_search(line)
-                    if m:
-                        pgh_minor = int(m.group(1))
-                if pgh_patch == -1:
-                    m = patch_exp_search(line)
-                    if m:
-                        pgh_patch = int(m.group(1))
-        self.assertEqual(pgh_major, pygame.version.vernum[0])
-        self.assertEqual(pgh_minor, pygame.version.vernum[1])
-        self.assertEqual(pgh_patch, pygame.version.vernum[2])
+    def test_vernum_obj(self):
+        major, minor, patch = map(int, pygame.version.ver.split(".")[:3])
+        self.assertEqual(pygame.version.vernum.major, major)
+        self.assertEqual(pygame.version.vernum[0], major)
+        self.assertEqual(pygame.version.vernum.minor, minor)
+        self.assertEqual(pygame.version.vernum[1], minor)
+        self.assertEqual(pygame.version.vernum.patch, patch)
+        self.assertEqual(pygame.version.vernum[2], patch)
 
     def test_sdl_version(self):
         self.assertEqual(len(pygame.version.SDL), 3)
+        self.assertEqual(tuple(pygame.version.SDL), pygame.get_sdl_version())
 
     def test_installed_version_and_dunder(self):
         self.assertEqual(pygame.__version__, pygame.version.ver)


### PR DESCRIPTION
Currently, every time we bump the version, we have to update the version in like 4 files, and in some cases multiple lines within these files.

We already have a mechanism to read the version info defined in `pyproject.toml` in python. This mechanism was recently implemented to be used in the meson buildconfig so that we don't have to re-define the version there.

I'm taking that a step further in this PR, and now this file can be used in all places that needs a version. After this PR, there will be only one line in the codebase that defines the version (in the `pyproject.toml` file)