### PR TITLE
Cleanup codebase, docs and examples with American spelling

### DIFF
--- a/docs/reST/ref/color.rst
+++ b/docs/reST/ref/color.rst
@@ -348,7 +348,7 @@
       | :sl:`returns a Color where the r,g,b components have been multiplied by the alpha.`
       | :sg:`premul_alpha() -> Color`
 
-      Returns a new Color where each of the red, green and blue colour
+      Returns a new Color where each of the red, green and blue color
       channels have been multiplied by the alpha channel of the original
       color. The alpha channel remains unchanged.
 

--- a/docs/reST/ref/pygame.rst
+++ b/docs/reST/ref/pygame.rst
@@ -401,7 +401,7 @@ available. Must be set before calling :func:`pygame.display.set_mode()`.
 This makes pygame use the SDL2 blitter for all alpha
 blending. The SDL2 blitter is sometimes faster than
 the default blitter but uses a different formula so
-the final colours may differ. Must be set before
+the final colors may differ. Must be set before
 :func:`pygame.init()` is called.
 
 |

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -1003,14 +1003,14 @@
       blend mode flag of the blit() method. Surfaces which have called this method will only look
       correct after blitting if the BLEND_PREMULTIPLED special flag is used.
 
-      It is worth noting that after calling this method, methods that return the colour of a pixel
-      such as get_at() will return the alpha multiplied colour values. It is not possible to fully
-      reverse an alpha multiplication of the colours in a surface as integer colour channel data
+      It is worth noting that after calling this method, methods that return the color of a pixel
+      such as get_at() will return the alpha multiplied color values. It is not possible to fully
+      reverse an alpha multiplication of the colors in a surface as integer color channel data
       is generally reduced by the operation (e.g. 255 x 0 = 0, from there it is not possible to reconstruct
-      the original 255 from just the two remaining zeros in the colour and alpha channels).
+      the original 255 from just the two remaining zeros in the color and alpha channels).
 
-      If you call this method, and then call it again, it will multiply the colour channels by the alpha channel
-      twice. There are many possible ways to obtain a surface with the colour channels pre-multiplied by the
+      If you call this method, and then call it again, it will multiply the color channels by the alpha channel
+      twice. There are many possible ways to obtain a surface with the color channels pre-multiplied by the
       alpha channel in pygame, and it is not possible to tell the difference just from the information in the pixels.
       It is completely possible to have two identical surfaces - one intended for pre-multiplied alpha blending and
       one intended for normal blending. For this reason we do not store state on surfaces intended for pre-multiplied
@@ -1022,7 +1022,7 @@
 
       In general pre-multiplied alpha blitting is faster then 'straight alpha' blitting and produces
       superior results when blitting an alpha surface onto another surface with alpha - assuming both
-      surfaces contain pre-multiplied alpha colours.
+      surfaces contain pre-multiplied alpha colors.
 
       There is a `tutorial on premultiplied alpha blending here. <tutorials/en/premultiplied-alpha>`
 

--- a/docs/reST/ref/transform.rst
+++ b/docs/reST/ref/transform.rst
@@ -283,7 +283,7 @@ Instead, always begin with the original image and scale to the desired size.)
 
    palette_colors - if true we average the colors in palette, otherwise we
    average the pixel values. This is useful if the surface is actually
-   greyscale colors, and not palette colors.
+   grayscale colors, and not palette colors.
 
    Note, this function currently does not handle palette using surfaces
    correctly.

--- a/docs/reST/tutorials/en/chimp-explanation.rst
+++ b/docs/reST/tutorials/en/chimp-explanation.rst
@@ -389,7 +389,7 @@ also needs to know the size of font we want to create.
 We then render that font into a new surface. The `render` function creates
 a new surface that is the appropriate size for our text. In this case
 we are also telling render to create antialiased text (for a nice smooth
-look) and to use a dark grey color.
+look) and to use a dark gray color.
 
 Next we need to find the centered position of the text on our display.
 We create a "Rect" object from the text dimensions, which allows us to

--- a/examples/glcube.py
+++ b/examples/glcube.py
@@ -258,16 +258,16 @@ def init_gl_modern(display_size):
     uniform mat4   view;
     uniform mat4   projection;
 
-    uniform vec4   colour_mul;
-    uniform vec4   colour_add;
+    uniform vec4   color_mul;
+    uniform vec4   color_add;
 
-    in vec4 vertex_colour;         // vertex colour in
+    in vec4 vertex_color;         // vertex color in
     in vec3 vertex_position;
 
-    out vec4   vertex_color_out;            // vertex colour out
+    out vec4   vertex_color_out;            // vertex color out
     void main()
     {
-        vertex_color_out = (colour_mul * vertex_colour) + colour_add;
+        vertex_color_out = (color_mul * vertex_color) + color_add;
         gl_Position = projection * view * model * vec4(vertex_position, 1.0);
     }
 
@@ -275,7 +275,7 @@ def init_gl_modern(display_size):
 
     fragment_code = """
     #version 150
-    in vec4 vertex_color_out;  // vertex colour from vertex shader
+    in vec4 vertex_color_out;  // vertex color from vertex shader
     out vec4 fragColor;
     void main()
     {
@@ -320,7 +320,7 @@ def init_gl_modern(display_size):
 
     # Cube Data
     vertices = zeros(
-        8, [("vertex_position", float32, 3), ("vertex_colour", float32, 4)]
+        8, [("vertex_position", float32, 3), ("vertex_color", float32, 4)]
     )
 
     vertices["vertex_position"] = [
@@ -334,7 +334,7 @@ def init_gl_modern(display_size):
         [-1, -1, -1],
     ]
 
-    vertices["vertex_colour"] = [
+    vertices["vertex_color"] = [
         [0, 1, 1, 1],
         [0, 0, 1, 1],
         [0, 0, 0, 1],
@@ -409,7 +409,7 @@ def init_gl_modern(display_size):
 
     offset = ctypes.c_void_p(vertices.dtype["vertex_position"].itemsize)
 
-    loc = GL.glGetAttribLocation(program, "vertex_colour")
+    loc = GL.glGetAttribLocation(program, "vertex_color")
     GL.glEnableVertexAttribArray(loc)
     GL.glVertexAttribPointer(loc, 4, GL.GL_FLOAT, False, stride, offset)
 
@@ -443,19 +443,19 @@ def init_gl_modern(display_size):
     )
     GL.glUniformMatrix4fv(shader_data["constants"]["projection"], 1, False, eye(4))
 
-    # This colour is multiplied with the base vertex colour in producing
+    # This color is multiplied with the base vertex color in producing
     # the final output
-    shader_data["constants"]["colour_mul"] = GL.glGetUniformLocation(
-        program, "colour_mul"
+    shader_data["constants"]["color_mul"] = GL.glGetUniformLocation(
+        program, "color_mul"
     )
-    GL.glUniform4f(shader_data["constants"]["colour_mul"], 1, 1, 1, 1)
+    GL.glUniform4f(shader_data["constants"]["color_mul"], 1, 1, 1, 1)
 
-    # This colour is added on to the base vertex colour in producing
+    # This color is added on to the base vertex color in producing
     # the final output
-    shader_data["constants"]["colour_add"] = GL.glGetUniformLocation(
-        program, "colour_add"
+    shader_data["constants"]["color_add"] = GL.glGetUniformLocation(
+        program, "color_add"
     )
-    GL.glUniform4f(shader_data["constants"]["colour_add"], 0, 0, 0, 0)
+    GL.glUniform4f(shader_data["constants"]["color_add"], 0, 0, 0, 0)
 
     # Set GL drawing data
     # -------------------
@@ -490,8 +490,8 @@ def draw_cube_modern(shader_data, filled_cube_indices, outline_cube_indices, rot
     GL.glDisable(GL.GL_BLEND)
     GL.glEnable(GL.GL_DEPTH_TEST)
     GL.glEnable(GL.GL_POLYGON_OFFSET_FILL)
-    GL.glUniform4f(shader_data["constants"]["colour_mul"], 1, 1, 1, 1)
-    GL.glUniform4f(shader_data["constants"]["colour_add"], 0, 0, 0, 0.0)
+    GL.glUniform4f(shader_data["constants"]["color_mul"], 1, 1, 1, 1)
+    GL.glUniform4f(shader_data["constants"]["color_add"], 0, 0, 0, 0.0)
     GL.glBindBuffer(GL.GL_ELEMENT_ARRAY_BUFFER, shader_data["buffer"]["filled"])
     GL.glDrawElements(
         GL.GL_TRIANGLES, len(filled_cube_indices), GL.GL_UNSIGNED_INT, None
@@ -500,8 +500,8 @@ def draw_cube_modern(shader_data, filled_cube_indices, outline_cube_indices, rot
     # Outlined cube
     GL.glDisable(GL.GL_POLYGON_OFFSET_FILL)
     GL.glEnable(GL.GL_BLEND)
-    GL.glUniform4f(shader_data["constants"]["colour_mul"], 0, 0, 0, 0.0)
-    GL.glUniform4f(shader_data["constants"]["colour_add"], 1, 1, 1, 1.0)
+    GL.glUniform4f(shader_data["constants"]["color_mul"], 0, 0, 0, 0.0)
+    GL.glUniform4f(shader_data["constants"]["color_add"], 1, 1, 1, 1.0)
     GL.glBindBuffer(GL.GL_ELEMENT_ARRAY_BUFFER, shader_data["buffer"]["outline"])
     GL.glDrawElements(GL.GL_LINES, len(outline_cube_indices), GL.GL_UNSIGNED_INT, None)
 

--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -665,7 +665,7 @@ rgb_to_hsv(const void *src, void *dst, int length, unsigned long source,
             min = MIN(MIN(r, g), b);
             delta = max - min;
             v = max;      /* value (similar to luminosity) */
-            if (!delta) { /* grey, zero hue and saturation */
+            if (!delta) { /* gray, zero hue and saturation */
                 s = 0;
                 h = 0;
             }
@@ -733,7 +733,7 @@ rgb_to_hsv(const void *src, void *dst, int length, unsigned long source,
             min = MIN(MIN(r, g), b);
             delta = max - min;
             v = max;      /* value (similar to luminosity) */
-            if (!delta) { /* grey, zero hue and saturation */
+            if (!delta) { /* gray, zero hue and saturation */
                 s = 0;
                 h = 0;
             }

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1509,7 +1509,7 @@ rle_line(Uint8 *src, Uint8 *dst, int w, int bpp)
 /*
  * Save a surface to an output stream in TGA format.
  * 8bpp surfaces are saved as indexed images with 24bpp palette, or with
- *     32bpp palette if colourkeying is used.
+ *     32bpp palette if colorkeying is used.
  * 15, 16, 24 and 32bpp surfaces are saved as 24bpp RGB images,
  * or as 32bpp RGBA images if alpha channel is used.
  *
@@ -1618,7 +1618,7 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
         }
     }
 
-    /* Temporarily remove colourkey and alpha from surface so copies are
+    /* Temporarily remove colorkey and alpha from surface so copies are
        opaque */
     SDL_SetSurfaceAlphaMod(surface, SDL_ALPHA_OPAQUE);
     if (have_surf_colorkey)

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -888,7 +888,7 @@ mask_from_surface(PyObject *self, PyObject *args, PyObject *kwargs)
 palette_colors - this only affects surfaces with a palette
     if true we look at the colors from the palette,
     otherwise we threshold the pixel values.  This is useful if
-    the surface is actually greyscale colors, and not palette colors.
+    the surface is actually grayscale colors, and not palette colors.
 
 */
 

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -1450,13 +1450,13 @@ blit_blend_premultiplied_avx2(SDL_BlitInfo *info)
                      */
 
                     /* blend on A half, at 16bit size, starts here.
-                     * overall target blend (with colours and alpha represented
+                     * overall target blend (with colors and alpha represented
                      * as values between 0 and 1) is:
                      *
                      * result = source.RGB + (dest.RGB * (1 - source.A))
                      *
                      * Optimised and rearranged for values between 0 and 255
-                     * the blend formula for a single colour channel is:
+                     * the blend formula for a single color channel is:
                      *
                      * (sC + dC - ((dC + 1) * sA >> 8))
                      */
@@ -1480,7 +1480,7 @@ blit_blend_premultiplied_avx2(SDL_BlitInfo *info)
 
                     mm256_dstA = _mm256_sub_epi16(mm256_src_shuff, mm256_dstA);
                     /* this is the final subtraction completing the original
-                     * colour channel blend formula. We now have blended
+                     * color channel blend formula. We now have blended
                      * channel values sitting in the same 16 bit, 00 padded
                      * arrangement of pixels as we did prior to the blend.
                      */

--- a/src_c/simd_transform_avx2.c
+++ b/src_c/simd_transform_avx2.c
@@ -60,9 +60,9 @@ grayscale_avx2(SDL_Surface *src, SDL_Surface *newsurf)
      *        for this operation in isolation.
      *     4. pack pixels back together from A & B while adding with a
      *        horizontal add (e.g. adds A+R and G+B in a ARGB layout)
-     *     5. shift and add to make final grey pixel colour in 0th
+     *     5. shift and add to make final gray pixel color in 0th
      *        8Bit channel in each 'pixel'
-     *     6. shuffle again to push the grey from the 0th channel into every
+     *     6. shuffle again to push the gray from the 0th channel into every
      *        channel of every pixel.
      *     7. add the alpha channel back in.
      */
@@ -147,8 +147,8 @@ grayscale_avx2(SDL_Surface *src, SDL_Surface *newsurf)
             // Do the 'percentage multiplications' with the weights
             // with accuracy correction so values like 255 * '255'
             // (here effectively 1.0) = 255 and not 254.
-            // For our greyscale this should mean 255 white stays 255 white
-            // after greyscaling.
+            // For our grayscale this should mean 255 white stays 255 white
+            // after grayscaling.
             mm256_dstA =
                 _mm256_mullo_epi16(mm256_srcA, mm256_shuffled_weights_A);
             mm256_dstA = _mm256_add_epi16(mm256_dstA, mm256_two_five_fives);
@@ -160,12 +160,12 @@ grayscale_avx2(SDL_Surface *src, SDL_Surface *newsurf)
             mm256_dstB = _mm256_srli_epi16(mm256_dstB, 8);
 
             // Add up weighted R+G+B into the first channel of each of the 8
-            // pixels. This is the grey value we want in all our colour
+            // pixels. This is the gray value we want in all our color
             // channels.
             mm256_dst = _mm256_hadd_epi16(mm256_dstA, mm256_dstB);
             mm256_dst =
                 _mm256_add_epi16(mm256_dst, _mm256_srli_epi32(mm256_dst, 16));
-            // Shuffle the grey value from ther first channel of each pixel
+            // Shuffle the gray value from ther first channel of each pixel
             // into every channel of each pixel
             mm256_dst = _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_gray);
 

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -2477,7 +2477,7 @@ average_surfaces(SDL_Surface **surfaces, size_t num_surfaces,
 
         palette_colors - if true we average the colors in palette, otherwise we
             average the pixel values.  This is useful if the surface is
-            actually greyscale colors, and not palette colors.
+            actually grayscale colors, and not palette colors.
 
     */
 
@@ -2553,7 +2553,7 @@ average_surfaces(SDL_Surface **surfaces, size_t num_surfaces,
              PG_FORMAT_BytesPerPixel(destformat) == 1) &&
             (format->palette) && (destformat->palette) && (!palette_colors)) {
             /*
-            This is useful if the surface is actually greyscale colors,
+            This is useful if the surface is actually grayscale colors,
             and not palette colors.
             */
             for (y = 0; y < height; y++) {
@@ -2645,7 +2645,7 @@ average_surfaces(SDL_Surface **surfaces, size_t num_surfaces,
 
     palette_colors - if true we average the colors in palette, otherwise we
         average the pixel values.  This is useful if the surface is
-        actually greyscale colors, and not palette colors.
+        actually grayscale colors, and not palette colors.
 
 */
 static PyObject *

--- a/src_py/surfarray.py
+++ b/src_py/surfarray.py
@@ -386,9 +386,9 @@ def map_array(surface, array):
     format to control the conversion.
 
     Note: arrays do not need to be 3D, as long as the minor axis has
-    three elements giving the component colours, any array shape can be
-    used (for example, a single colour can be mapped, or an array of
-    colours). The array shape is limited to eleven dimensions maximum,
+    three elements giving the component colors, any array shape can be
+    used (for example, a single color can be mapped, or an array of
+    colors). The array shape is limited to eleven dimensions maximum,
     including the three element minor axis.
     """
     if array.ndim == 0:

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -48,8 +48,8 @@ class ImageModuleTest(unittest.TestCase):
         reddish_pixel = (210, 0, 0, 255)
         greenish_pixel = (0, 220, 0, 255)
         bluish_pixel = (0, 0, 230, 255)
-        greyish_pixel = (110, 120, 130, 140)
-        pixel_array = [reddish_pixel + greenish_pixel, bluish_pixel + greyish_pixel]
+        grayish_pixel = (110, 120, 130, 140)
+        pixel_array = [reddish_pixel + greenish_pixel, bluish_pixel + grayish_pixel]
 
         f_descriptor, f_path = tempfile.mkstemp(suffix=".png")
 
@@ -63,7 +63,7 @@ class ImageModuleTest(unittest.TestCase):
         self.assertEqual(surf.get_at((0, 0)), reddish_pixel)
         self.assertEqual(surf.get_at((1, 0)), greenish_pixel)
         self.assertEqual(surf.get_at((0, 1)), bluish_pixel)
-        self.assertEqual(surf.get_at((1, 1)), greyish_pixel)
+        self.assertEqual(surf.get_at((1, 1)), grayish_pixel)
 
         # Read the PNG file obj. and verify that pygame interprets it correctly
         with open(f_path, "rb") as f:
@@ -72,7 +72,7 @@ class ImageModuleTest(unittest.TestCase):
         self.assertEqual(surf.get_at((0, 0)), reddish_pixel)
         self.assertEqual(surf.get_at((1, 0)), greenish_pixel)
         self.assertEqual(surf.get_at((0, 1)), bluish_pixel)
-        self.assertEqual(surf.get_at((1, 1)), greyish_pixel)
+        self.assertEqual(surf.get_at((1, 1)), grayish_pixel)
 
         os.remove(f_path)
 
@@ -168,13 +168,13 @@ class ImageModuleTest(unittest.TestCase):
         reddish_pixel = (215, 0, 0, 255)
         greenish_pixel = (0, 225, 0, 255)
         bluish_pixel = (0, 0, 235, 255)
-        greyish_pixel = (115, 125, 135, 145)
+        grayish_pixel = (115, 125, 135, 145)
 
         surf = pygame.Surface((1, 4), pygame.SRCALPHA, 32)
         surf.set_at((0, 0), reddish_pixel)
         surf.set_at((0, 1), greenish_pixel)
         surf.set_at((0, 2), bluish_pixel)
-        surf.set_at((0, 3), greyish_pixel)
+        surf.set_at((0, 3), grayish_pixel)
 
         f_path = tempfile.mktemp(suffix=".png")
         pygame.image.save(surf, f_path)
@@ -188,7 +188,7 @@ class ImageModuleTest(unittest.TestCase):
             self.assertEqual(tuple(next(pixels)), reddish_pixel)
             self.assertEqual(tuple(next(pixels)), greenish_pixel)
             self.assertEqual(tuple(next(pixels)), bluish_pixel)
-            self.assertEqual(tuple(next(pixels)), greyish_pixel)
+            self.assertEqual(tuple(next(pixels)), grayish_pixel)
 
         finally:
             # Ensures proper clean up.
@@ -207,13 +207,13 @@ class ImageModuleTest(unittest.TestCase):
         reddish_pixel = (215, 0, 0)
         greenish_pixel = (0, 225, 0)
         bluish_pixel = (0, 0, 235)
-        greyish_pixel = (115, 125, 135)
+        grayish_pixel = (115, 125, 135)
 
         surf = pygame.Surface((1, 4), 0, 24)
         surf.set_at((0, 0), reddish_pixel)
         surf.set_at((0, 1), greenish_pixel)
         surf.set_at((0, 2), bluish_pixel)
-        surf.set_at((0, 3), greyish_pixel)
+        surf.set_at((0, 3), grayish_pixel)
 
         f_path = tempfile.mktemp(suffix=".png")
         pygame.image.save(surf, f_path)
@@ -227,7 +227,7 @@ class ImageModuleTest(unittest.TestCase):
             self.assertEqual(tuple(next(pixels)), reddish_pixel)
             self.assertEqual(tuple(next(pixels)), greenish_pixel)
             self.assertEqual(tuple(next(pixels)), bluish_pixel)
-            self.assertEqual(tuple(next(pixels)), greyish_pixel)
+            self.assertEqual(tuple(next(pixels)), grayish_pixel)
 
         finally:
             # Ensures proper clean up.
@@ -274,13 +274,13 @@ class ImageModuleTest(unittest.TestCase):
         reddish_pixel = (215, 0, 0)
         greenish_pixel = (0, 225, 0)
         bluish_pixel = (0, 0, 235)
-        greyish_pixel = (115, 125, 135)
+        grayish_pixel = (115, 125, 135)
 
         surf = pygame.Surface((1, 4), 0, 8)
         surf.set_palette_at(0, reddish_pixel)
         surf.set_palette_at(1, greenish_pixel)
         surf.set_palette_at(2, bluish_pixel)
-        surf.set_palette_at(3, greyish_pixel)
+        surf.set_palette_at(3, grayish_pixel)
 
         f_path = tempfile.mktemp(suffix=".png")
         pygame.image.save(surf, f_path)
@@ -294,7 +294,7 @@ class ImageModuleTest(unittest.TestCase):
             self.assertEqual(tuple(next(palette)), reddish_pixel)
             self.assertEqual(tuple(next(palette)), greenish_pixel)
             self.assertEqual(tuple(next(palette)), bluish_pixel)
-            self.assertEqual(tuple(next(palette)), greyish_pixel)
+            self.assertEqual(tuple(next(palette)), grayish_pixel)
 
         finally:
             # Ensures proper clean up.

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -3034,7 +3034,7 @@ class MaskTypeTest(unittest.TestCase):
     def test_to_surface__kwargs_invalid_name(self):
         """Ensures to_surface detects invalid kwarg names."""
         mask = pygame.mask.Mask((3, 2))
-        kwargs = {"setcolour": pygame.Color("red")}
+        kwargs = {"setcolor": pygame.Color("red")}
 
         with self.assertRaises(TypeError):
             mask.to_surface(**kwargs)

--- a/test/sprite_test.py
+++ b/test/sprite_test.py
@@ -526,7 +526,7 @@ class AbstractGroupTypeTest(unittest.TestCase):
 
         self.bg = pygame.Surface((20, 20))
         self.scr = pygame.Surface((20, 20))
-        self.scr.fill(pygame.Color("grey"))
+        self.scr.fill(pygame.Color("gray"))
 
     def test_has(self):
         "See if AbstractGroup.has() works as expected."

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -3592,7 +3592,7 @@ class SurfaceBlendTest(unittest.TestCase):
 
             return (expected_col, actual_col)
 
-        # # Colour Tests
+        # # Color Tests
         self.assertEqual(
             *test_premul_surf(pygame.Color(40, 20, 0, 51), pygame.Color(40, 20, 0, 51))
         )
@@ -3962,7 +3962,7 @@ class SurfaceBlendTest(unittest.TestCase):
         s1_alpha = s1.premul_alpha()
         self.assertEqual(s1_alpha.get_at((50, 50)), pygame.Color(100, 100, 100, 100))
 
-        # 16-bit colour has less precision
+        # 16-bit color has less precision
         s2 = pygame.Surface((100, 100), pygame.SRCALPHA, 16)
         s2.fill(
             pygame.Color(

--- a/test/test_utils/png.py
+++ b/test/test_utils/png.py
@@ -44,7 +44,7 @@
 # 2006-06-17 Nicko: Reworked into a class, faster interlacing.
 # 2006-06-17 Johann: Very simple prototype PNG decoder.
 # 2006-06-17 Nicko: Test suite with various image generators.
-# 2006-06-17 Nicko: Alpha-channel, grey-scale, 16-bit/plane support.
+# 2006-06-17 Nicko: Alpha-channel, gray-scale, 16-bit/plane support.
 # 2006-06-15 Johann: Scanline iterator interface for large input files.
 # 2006-06-09 Johann: Very simple prototype PNG encoder.
 
@@ -61,8 +61,8 @@ Pure Python PNG Reader/Writer
 This Python module implements support for PNG images (see PNG
 specification at http://www.w3.org/TR/2003/REC-PNG-20031110/ ). It reads
 and writes PNG files with all allowable bit depths (1/2/4/8/16/24/32/48/64
-bits per pixel) and colour combinations: greyscale (1/2/4/8/16 bit); RGB,
-RGBA, LA (greyscale with alpha) with 8/16 bits per channel; colour mapped
+bits per pixel) and color combinations: grayscale (1/2/4/8/16 bit); RGB,
+RGBA, LA (grayscale with alpha) with 8/16 bits per channel; color mapped
 images (1/2/4/8 bit).  Adam7 interlacing is supported for reading and
 writing.  A number of optional chunks can be specified (when writing)
 and understood (when reading): ``tRNS``, ``bKGD``, ``gAMA``.
@@ -81,15 +81,15 @@ A note on spelling and terminology
 ----------------------------------
 
 Generally British English spelling is used in the documentation.  So
-that's "greyscale" and "colour".  This not only matches the author's
+that's "grayscale" and "color".  This not only matches the author's
 native language, it's also used by the PNG specification.
 
-The major colour models supported by PNG (and hence by PyPNG) are:
-greyscale, RGB, greyscale--alpha, RGB--alpha.  These are sometimes
+The major color models supported by PNG (and hence by PyPNG) are:
+grayscale, RGB, grayscale--alpha, RGB--alpha.  These are sometimes
 referred to using the abbreviations: L, RGB, LA, RGBA.  In this case
 each letter abbreviates a single channel: *L* is for Luminance or Luma or
-Lightness which is the channel used in greyscale images; *R*, *G*, *B* stand
-for Red, Green, Blue, the components of a colour image; *A* stands for
+Lightness which is the channel used in grayscale images; *R*, *G*, *B* stand
+for Red, Green, Blue, the components of a color image; *A* stands for
 Alpha, the opacity channel (used for transparency effects, but higher
 values are more opaque, so it makes sense to call it opacity).
 
@@ -125,7 +125,7 @@ Flat row flat pixel::
   [R,G,B, R,G,B, R,G,B,
    R,G,B, R,G,B, R,G,B]
 
-The entire image is one single giant sequence of colour values.
+The entire image is one single giant sequence of color values.
 Generally an array will be used (to save space), not a list.
 
 Boxed row boxed pixel::
@@ -138,7 +138,7 @@ tuple.  A serious memory burn in Python.
 
 In all cases the top row comes first, and for each row the pixels are
 ordered from left-to-right.  Within a pixel the values appear in the
-order, R-G-B-A (or L-A for greyscale--alpha).
+order, R-G-B-A (or L-A for grayscale--alpha).
 
 There is a fourth format, mentioned because it is used internally,
 is close to what lies inside a PNG file itself, and has some support
@@ -220,7 +220,7 @@ except:
 
 def interleave_planes(ipixels, apixels, ipsize, apsize):
     """
-    Interleave (colour) planes, e.g. RGB + A = RGBA.
+    Interleave (color) planes, e.g. RGB + A = RGBA.
 
     Return an array of pixels consisting of the `ipsize` elements of data
     from each pixel in `ipixels` followed by the `apsize` elements of data
@@ -307,7 +307,7 @@ class Writer:
         width=None,
         height=None,
         size=None,
-        greyscale=False,
+        grayscale=False,
         alpha=False,
         bitdepth=8,
         palette=None,
@@ -331,18 +331,18 @@ class Writer:
           Image size in pixels, as two separate arguments.
         size
           Image size (w,h) in pixels, as single argument.
-        greyscale
-          Input data is greyscale, not RGB.
+        grayscale
+          Input data is grayscale, not RGB.
         alpha
           Input data has alpha channel (RGBA or LA).
         bitdepth
           Bit depth: from 1 to 16.
         palette
-          Create a palette for a colour mapped image (colour type 3).
+          Create a palette for a color mapped image (color type 3).
         transparent
-          Specify a transparent colour (create a ``tRNS`` chunk).
+          Specify a transparent color (create a ``tRNS`` chunk).
         background
-          Specify a default background colour (create a ``bKGD`` chunk).
+          Specify a default background color (create a ``bKGD`` chunk).
         gamma
           Specify a gamma value (create a ``gAMA`` chunk).
         compression
@@ -357,8 +357,8 @@ class Writer:
         argument.  If `size` is used it should be a pair (*width*,
         *height*).
 
-        `greyscale` and `alpha` are booleans that specify whether
-        an image is greyscale (or colour), and whether it has an
+        `grayscale` and `alpha` are booleans that specify whether
+        an image is grayscale (or color), and whether it has an
         alpha channel (or not).
 
         `bitdepth` specifies the bit depth of the source pixel values.
@@ -371,27 +371,27 @@ class Writer:
         precision of the source image.  In this case the supplied pixel
         values will be rescaled to fit the range of the selected bit depth.
 
-        The details of which bit depth / colour model combinations the
+        The details of which bit depth / color model combinations the
         PNG file format supports directly, are somewhat arcane
         (refer to the PNG specification for full details).  Briefly:
-        "small" bit depths (1,2,4) are only allowed with greyscale and
-        colour mapped images; colour mapped images cannot have bit depth
+        "small" bit depths (1,2,4) are only allowed with grayscale and
+        color mapped images; color mapped images cannot have bit depth
         16.
 
-        For colour mapped images (in other words, when the `palette`
+        For color mapped images (in other words, when the `palette`
         argument is specified) the `bitdepth` argument must match one of
         the valid PNG bit depths: 1, 2, 4, or 8.  (It is valid to have a
         PNG image with a palette and an ``sBIT`` chunk, but the meaning
         is slightly different; it would be awkward to press the
         `bitdepth` argument into service for this.)
 
-        The `palette` option, when specified, causes a colour mapped image
-        to be created: the PNG colour type is set to 3; greyscale
+        The `palette` option, when specified, causes a color mapped image
+        to be created: the PNG color type is set to 3; grayscale
         must not be set; alpha must not be set; transparent must
-        not be set; the bit depth must be 1,2,4, or 8.  When a colour
+        not be set; the bit depth must be 1,2,4, or 8.  When a color
         mapped image is created, the pixel values are palette indexes
         and the `bitdepth` argument specifies the size of these indexes
-        (not the size of the colour values in the palette).
+        (not the size of the color values in the palette).
 
         The palette argument value should be a sequence of 3- or
         4-tuples.  3-tuples specify RGB palette entries; 4-tuples
@@ -406,7 +406,7 @@ class Writer:
 
         If specified, the `transparent` and `background` parameters must
         be a tuple with three integer values for red, green, blue, or
-        a simple integer (or singleton tuple) for a greyscale image.
+        a simple integer (or singleton tuple) for a grayscale image.
 
         If specified, the `gamma` parameter must be a positive number
         (generally, a float).  A ``gAMA`` chunk will be created.  Note that
@@ -455,22 +455,22 @@ class Writer:
                 return False
 
         def check_color(c, which):
-            """Checks that a colour argument for transparent or
+            """Checks that a color argument for transparent or
             background options is the right form. Also, "corrects" bare
             integers to 1-tuples.
             """
 
             if c is None:
                 return c
-            if greyscale:
+            if grayscale:
                 try:
                     l = len(c)
                 except TypeError:
                     c = (c,)
                 if len(c) != 1:
-                    raise ValueError(f"{which} for greyscale must be 1-tuple")
+                    raise ValueError(f"{which} for grayscale must be 1-tuple")
                 if not isinteger(c[0]):
-                    raise ValueError(f"{which} colour for greyscale must be integer")
+                    raise ValueError(f"{which} color for grayscale must be integer")
             else:
                 if not (
                     len(c) == 3
@@ -478,7 +478,7 @@ class Writer:
                     and isinteger(c[1])
                     and isinteger(c[2])
                 ):
-                    raise ValueError(f"{which} colour must be a triple of integers")
+                    raise ValueError(f"{which} color must be a triple of integers")
             return c
 
         if size:
@@ -506,7 +506,7 @@ class Writer:
             raise ValueError("width and height cannot exceed 2**32-1")
 
         if alpha and transparent is not None:
-            raise ValueError("transparent colour not allowed with alpha channel")
+            raise ValueError("transparent color not allowed with alpha channel")
 
         if bytes_per_sample is not None:
             warnings.warn(
@@ -529,18 +529,18 @@ class Writer:
                 raise ValueError("transparent and palette not compatible")
             if alpha:
                 raise ValueError("alpha and palette not compatible")
-            if greyscale:
-                raise ValueError("greyscale and palette not compatible")
+            if grayscale:
+                raise ValueError("grayscale and palette not compatible")
         else:
             # No palette, check for sBIT chunk generation.
-            if alpha or not greyscale:
+            if alpha or not grayscale:
                 if bitdepth not in (8, 16):
                     targetbitdepth = (8, 16)[bitdepth > 8]
                     self.rescale = (bitdepth, targetbitdepth)
                     bitdepth = targetbitdepth
                     del targetbitdepth
             else:
-                assert greyscale
+                assert grayscale
                 assert not alpha
                 if bitdepth not in (1, 2, 4, 8, 16):
                     if bitdepth > 8:
@@ -554,15 +554,15 @@ class Writer:
                     bitdepth = targetbitdepth
                     del targetbitdepth
 
-        if bitdepth < 8 and (alpha or not greyscale and not palette):
-            raise ValueError("bitdepth < 8 only permitted with greyscale or palette")
+        if bitdepth < 8 and (alpha or not grayscale and not palette):
+            raise ValueError("bitdepth < 8 only permitted with grayscale or palette")
         if bitdepth > 8 and palette:
             raise ValueError("bit depth must be 8 or less for images with palette")
 
         transparent = check_color(transparent, "transparent")
         background = check_color(background, "background")
 
-        # It's important that the true boolean values (greyscale, alpha,
+        # It's important that the true boolean values (grayscale, alpha,
         # colormap, interlace) are converted to bool because Iverson's
         # convention is relied upon later on.
         self.width = width
@@ -570,7 +570,7 @@ class Writer:
         self.transparent = transparent
         self.background = background
         self.gamma = gamma
-        self.greyscale = bool(greyscale)
+        self.grayscale = bool(grayscale)
         self.alpha = bool(alpha)
         self.colormap = bool(palette)
         self.bitdepth = int(bitdepth)
@@ -579,10 +579,10 @@ class Writer:
         self.interlace = bool(interlace)
         self.palette = check_palette(palette)
 
-        self.color_type = 4 * self.alpha + 2 * (not greyscale) + 1 * self.colormap
+        self.color_type = 4 * self.alpha + 2 * (not grayscale) + 1 * self.colormap
         assert self.color_type in (0, 2, 3, 4, 6)
 
-        self.color_planes = (3, 1)[self.greyscale or self.colormap]
+        self.color_planes = (3, 1)[self.grayscale or self.colormap]
         self.planes = self.color_planes + self.alpha
         # :todo: fix for bitdepth < 8
         self.psize = (self.bitdepth / 8) * self.planes
@@ -701,14 +701,14 @@ class Writer:
 
         # http://www.w3.org/TR/PNG/#11tRNS
         if self.transparent is not None:
-            if self.greyscale:
+            if self.grayscale:
                 write_chunk(outfile, "tRNS", struct.pack("!1H", *self.transparent))
             else:
                 write_chunk(outfile, "tRNS", struct.pack("!3H", *self.transparent))
 
         # http://www.w3.org/TR/PNG/#11bKGD
         if self.background is not None:
-            if self.greyscale:
+            if self.grayscale:
                 write_chunk(outfile, "bKGD", struct.pack("!1H", *self.background))
             else:
                 write_chunk(outfile, "bKGD", struct.pack("!3H", *self.background))
@@ -1103,17 +1103,17 @@ def from_array(a, mode=None, info={}):
     wide will use a 2-dimensional array that is 16x24 (each row will be
     8*3==24 sample values).
 
-    *mode* is a string that specifies the image colour format in a
+    *mode* is a string that specifies the image color format in a
     PIL-style mode.  It can be:
 
     ``'L'``
-      greyscale (1 channel)
+      grayscale (1 channel)
     ``'LA'``
-      greyscale with alpha (2 channel)
+      grayscale with alpha (2 channel)
     ``'RGB'``
-      colour image (3 channel)
+      color image (3 channel)
     ``'RGBA'``
-      colour image with alpha (4 channel)
+      color image with alpha (4 channel)
 
     The mode string can also specify the bit depth (overriding how this
     function normally derives the bit depth, see below).  Appending
@@ -1160,7 +1160,7 @@ def from_array(a, mode=None, info={}):
     Generally anything specified in the
     *info* dictionary will override any implicit choices that this
     function would otherwise make, but must match any explicit ones.
-    For example, if the *info* dictionary has a ``greyscale`` key then
+    For example, if the *info* dictionary has a ``grayscale`` key then
     this must be true when mode is ``'L'`` or ``'LA'`` and false when
     mode is ``'RGB'`` or ``'RGBA'``.
     """
@@ -1212,11 +1212,11 @@ def from_array(a, mode=None, info={}):
         except:
             raise Error("len(a) does not work, supply info['height'] instead.")
         info["height"] = l
-    # Colour format.
-    if "greyscale" in info:
-        if bool(info["greyscale"]) != ("L" in mode):
-            raise Error("info['greyscale'] should match mode.")
-    info["greyscale"] = "L" in mode
+    # Color format.
+    if "grayscale" in info:
+        if bool(info["grayscale"]) != ("L" in mode):
+            raise Error("info['grayscale'] should match mode.")
+    info["grayscale"] = "L" in mode
     if "alpha" in info:
         if bool(info["alpha"]) != ("A" in mode):
             raise Error("info['alpha'] should match mode.")
@@ -1271,7 +1271,7 @@ def from_array(a, mode=None, info={}):
                 bitdepth = 8 * dtype.itemsize
         info["bitdepth"] = bitdepth
 
-    for thing in "width height bitdepth greyscale alpha".split():
+    for thing in "width height bitdepth grayscale alpha".split():
         assert thing in info
     return Image(a, info)
 
@@ -1773,16 +1773,16 @@ class Reader:
             if self.bitdepth not in (1, 2, 4, 8, 16):
                 raise Error("invalid bit depth %d" % self.bitdepth)
             if self.color_type not in (0, 2, 3, 4, 6):
-                raise Error("invalid colour type %d" % self.color_type)
+                raise Error("invalid color type %d" % self.color_type)
             # Check indexed (palettized) images have 8 or fewer bits
-            # per pixel; check only indexed or greyscale images have
+            # per pixel; check only indexed or grayscale images have
             # fewer than 8 bits per pixel.
             if (self.color_type & 1 and self.bitdepth > 8) or (
                 self.bitdepth < 8 and self.color_type not in (0, 3)
             ):
                 raise FormatError(
                     "Illegal combination of bit depth (%d)"
-                    " and colour type (%d)."
+                    " and color type (%d)."
                     " See http://www.w3.org/TR/2003/REC-PNG-20031110/#table111 ."
                     % (self.bitdepth, self.color_type)
                 )
@@ -1804,13 +1804,13 @@ class Reader:
             # Derived values
             # http://www.w3.org/TR/PNG/#6Colour-values
             colormap = bool(self.color_type & 1)
-            greyscale = not (self.color_type & 2)
+            grayscale = not (self.color_type & 2)
             alpha = bool(self.color_type & 4)
-            color_planes = (3, 1)[greyscale or colormap]
+            color_planes = (3, 1)[grayscale or colormap]
             planes = color_planes + alpha
 
             self.colormap = colormap
-            self.greyscale = greyscale
+            self.grayscale = grayscale
             self.alpha = alpha
             self.color_planes = color_planes
             self.planes = planes
@@ -1861,7 +1861,7 @@ class Reader:
             else:
                 if self.alpha:
                     raise FormatError(
-                        "tRNS chunk is not valid with colour type %d." % self.color_type
+                        "tRNS chunk is not valid with color type %d." % self.color_type
                     )
                 try:
                     self.transparent = struct.unpack("!%dH" % self.color_planes, data)
@@ -1942,7 +1942,7 @@ class Reader:
         else:
             pixels = self.iterboxed(self.iterstraight(raw))
         meta = {}
-        for attr in "greyscale alpha planes bitdepth interlace".split():
+        for attr in "grayscale alpha planes bitdepth interlace".split():
             meta[attr] = getattr(self, attr)
         meta["size"] = (self.width, self.height)
         for attr in "gamma transparent background".split():
@@ -1975,7 +1975,7 @@ class Reader:
         chunks should have already been processed (for example, by
         calling the :meth:`preamble` method).  All the tuples are the
         same size: 3-tuples if there is no ``tRNS`` chunk, 4-tuples when
-        there is a ``tRNS`` chunk.  Assumes that the image is colour type
+        there is a ``tRNS`` chunk.  Assumes that the image is color type
         3 and therefore a ``PLTE`` chunk is required.
 
         If the `alpha` argument is ``'force'`` then an alpha channel is
@@ -1983,7 +1983,7 @@ class Reader:
         """
 
         if not self.plte:
-            raise FormatError("Required PLTE chunk is missing in colour type 3 image.")
+            raise FormatError("Required PLTE chunk is missing in color type 3 image.")
         plte = group(array("B", self.plte), 3)
         if self.trns or alpha == "force":
             trns = array("B", self.trns or "")
@@ -1995,11 +1995,11 @@ class Reader:
         """Returns the image data as a direct representation of an
         ``x * y * planes`` array.  This method is intended to remove the
         need for callers to deal with palettes and transparency
-        themselves.  Images with a palette (colour type 3)
+        themselves.  Images with a palette (color type 3)
         are converted to RGB or RGBA; images with transparency (a
         ``tRNS`` chunk) are converted to LA or RGBA as appropriate.
         When returned in this format the pixel values represent the
-        colour value directly without needing to refer to palettes or
+        color value directly without needing to refer to palettes or
         transparency information.
 
         Like the :meth:`read` method this method returns a 4-tuple:
@@ -2018,7 +2018,7 @@ class Reader:
         The *meta* dictionary that is returned reflects the `direct`
         format and not the original source image.  For example, an RGB
         source image with a ``tRNS`` chunk to represent a transparent
-        colour, will have ``planes=3`` and ``alpha=False`` for the
+        color, will have ``planes=3`` and ``alpha=False`` for the
         source image, but the *meta* dictionary returned by this method
         will have ``planes=4`` and ``alpha=True`` because an alpha
         channel is synthesized and added.
@@ -2163,8 +2163,8 @@ class Reader:
         return self._as_rescale(self.asRGBA, 8)
 
     def asRGB(self):
-        """Return image as RGB pixels.  RGB colour images are passed
-        through unchanged; greyscales are expanded into RGB
+        """Return image as RGB pixels.  RGB color images are passed
+        through unchanged; grayscales are expanded into RGB
         triplets (there is a small speed overhead for doing this).
 
         An alpha channel in the source image will raise an
@@ -2173,15 +2173,15 @@ class Reader:
         The return values are as for the :meth:`read` method
         except that the *metadata* reflect the returned pixels, not the
         source image.  In particular, for this method
-        ``metadata['greyscale']`` will be ``False``.
+        ``metadata['grayscale']`` will be ``False``.
         """
 
         width, height, pixels, meta = self.asDirect()
         if meta["alpha"]:
             raise Error("will not convert image with alpha channel to RGB")
-        if not meta["greyscale"]:
+        if not meta["grayscale"]:
             return width, height, pixels, meta
-        meta["greyscale"] = False
+        meta["grayscale"] = False
         typecode = "BH"[meta["bitdepth"] > 8]
 
         def iterrgb():
@@ -2194,17 +2194,17 @@ class Reader:
         return width, height, iterrgb(), meta
 
     def asRGBA(self):
-        """Return image as RGBA pixels.  Greyscales are expanded into
+        """Return image as RGBA pixels.  Grayscales are expanded into
         RGB triplets; an alpha channel is synthesized if necessary.
         The return values are as for the :meth:`read` method
         except that the *metadata* reflect the returned pixels, not the
         source image.  In particular, for this method
-        ``metadata['greyscale']`` will be ``False``, and
+        ``metadata['grayscale']`` will be ``False``, and
         ``metadata['alpha']`` will be ``True``.
         """
 
         width, height, pixels, meta = self.asDirect()
-        if meta["alpha"] and not meta["greyscale"]:
+        if meta["alpha"] and not meta["grayscale"]:
             return width, height, pixels, meta
         typecode = "BH"[meta["bitdepth"] > 8]
         maxval = 2 ** meta["bitdepth"] - 1
@@ -2212,7 +2212,7 @@ class Reader:
         def newarray():
             return array(typecode, [0]) * 4 * width
 
-        if meta["alpha"] and meta["greyscale"]:
+        if meta["alpha"] and meta["grayscale"]:
             # LA to RGBA
             def convert():
                 for row in pixels:
@@ -2225,7 +2225,7 @@ class Reader:
                     a[3::4] = row[1::2]
                     yield a
 
-        elif meta["greyscale"]:
+        elif meta["grayscale"]:
             # L to RGBA
             def convert():
                 for row in pixels:
@@ -2236,7 +2236,7 @@ class Reader:
                     yield a
 
         else:
-            assert not meta["alpha"] and not meta["greyscale"]
+            assert not meta["alpha"] and not meta["grayscale"]
 
             # RGB to RGBA
             def convert():
@@ -2248,7 +2248,7 @@ class Reader:
                     yield a
 
         meta["alpha"] = True
-        meta["greyscale"] = False
+        meta["grayscale"] = False
         return width, height, convert(), meta
 
 
@@ -2364,7 +2364,7 @@ class Test(unittest.TestCase):
         mask = (1 << n) - 1
         # Use small chunk_limit so that multiple chunk writing is
         # tested.  Making it a test for Issue 20.
-        w = Writer(15, 17, greyscale=True, bitdepth=n, chunk_limit=99)
+        w = Writer(15, 17, grayscale=True, bitdepth=n, chunk_limit=99)
         f = BytesIO()
         w.write_array(f, array("B", map(mask.__and__, range(1, 256))))
         r = Reader(bytes=f.getvalue())
@@ -2383,7 +2383,7 @@ class Test(unittest.TestCase):
 
     def testL2(self):
         "Also tests asRGB8."
-        w = Writer(1, 4, greyscale=True, bitdepth=2)
+        w = Writer(1, 4, grayscale=True, bitdepth=2)
         f = BytesIO()
         w.write_array(f, array("B", range(4)))
         r = Reader(bytes=f.getvalue())
@@ -2409,7 +2409,7 @@ class Test(unittest.TestCase):
         self.assertEqual(list(pixels), map(list, [a, b, b, c]))
 
     def testPtrns(self):
-        "Test colour type 3 and tRNS chunk (and 4-bit palette)."
+        "Test color type 3 and tRNS chunk (and 4-bit palette)."
         a = (50, 99, 50, 50)
         b = (200, 120, 120, 80)
         c = (255, 255, 255)
@@ -2430,7 +2430,7 @@ class Test(unittest.TestCase):
         self.assertEqual(map(list, pixels), map(list, flat))
 
     def testRGBtoRGBA(self):
-        "asRGBA8() on colour type 2 source." ""
+        "asRGBA8() on color type 2 source." ""
         # Test for pygame-ce issue 41
         r = Reader(bytes=_pngsuite["basn2c08"])
         x, y, pixels, meta = r.asRGBA8()
@@ -2439,7 +2439,7 @@ class Test(unittest.TestCase):
         self.assertEqual(row9[0:8], [0xFF, 0xDF, 0xFF, 0xFF, 0xFF, 0xDE, 0xFF, 0xFF])
 
     def testLtoRGBA(self):
-        "asRGBA() on grey source." ""
+        "asRGBA() on gray source." ""
         # Test for pygame-ce issue 75
         r = Reader(bytes=_pngsuite["basi0g08"])
         x, y, pixels, meta = r.asRGBA()
@@ -2447,7 +2447,7 @@ class Test(unittest.TestCase):
         self.assertEqual(row9[0:8], [222, 222, 222, 255, 221, 221, 221, 255])
 
     def testCtrns(self):
-        "Test colour type 2 and tRNS chunk."
+        "Test color type 2 and tRNS chunk."
         # Test for pygame-ce issue 40
         r = Reader(bytes=_pngsuite["tbrn2c08"])
         x, y, pixels, meta = r.asRGBA8()
@@ -2486,7 +2486,7 @@ class Test(unittest.TestCase):
         # we have written is to read it back again.
 
         for name, bytes in _pngsuite.items():
-            # Only certain colour types supported for this test.
+            # Only certain color types supported for this test.
             if name[3:5] not in ["n0", "n2", "n4", "n6"]:
                 continue
             it = Reader(bytes=bytes)
@@ -2497,7 +2497,7 @@ class Test(unittest.TestCase):
                 x=x,
                 y=y,
                 bitdepth=it.bitdepth,
-                greyscale=it.greyscale,
+                grayscale=it.grayscale,
                 alpha=it.alpha,
                 transparent=it.transparent,
                 interlace=False,
@@ -2511,7 +2511,7 @@ class Test(unittest.TestCase):
                 x=x,
                 y=y,
                 bitdepth=it.bitdepth,
-                greyscale=it.greyscale,
+                grayscale=it.grayscale,
                 alpha=it.alpha,
                 transparent=it.transparent,
                 interlace=True,
@@ -2534,7 +2534,7 @@ class Test(unittest.TestCase):
         testWithIO(s, o, do)
         r = Reader(bytes=o.getvalue())
         x, y, pixels, meta = r.read()
-        self.assertTrue(r.greyscale)
+        self.assertTrue(r.grayscale)
         self.assertEqual(r.bitdepth, 2)
 
     def testPAMin(self):
@@ -2561,13 +2561,13 @@ class Test(unittest.TestCase):
         r = Reader(bytes=o.getvalue())
         x, y, pixels, meta = r.read()
         self.assertTrue(r.alpha)
-        self.assertTrue(not r.greyscale)
+        self.assertTrue(not r.grayscale)
         self.assertEqual(list(itertools.chain(*pixels)), flat)
 
     def testLA4(self):
         """Create an LA image with bitdepth 4."""
         bytes = topngbytes(
-            "la4.png", [[5, 12]], 1, 1, greyscale=True, alpha=True, bitdepth=4
+            "la4.png", [[5, 12]], 1, 1, grayscale=True, alpha=True, bitdepth=4
         )
         sbit = Reader(bytes=bytes).chunk("sBIT")[1]
         self.assertEqual(sbit, strtobytes("\x04\x04"))
@@ -2591,7 +2591,7 @@ class Test(unittest.TestCase):
         self.assertEqual(sbit, strtobytes("\x01\x01\x01"))
 
     def testLtrns0(self):
-        """Create greyscale image with tRNS chunk."""
+        """Create grayscale image with tRNS chunk."""
         return self.helperLtrns(0)
 
     def testLtrns1(self):
@@ -2602,12 +2602,12 @@ class Test(unittest.TestCase):
         """Helper used by :meth:`testLtrns*`."""
         pixels = zip([0x00, 0x38, 0x4C, 0x54, 0x5C, 0x40, 0x38, 0x00])
         o = BytesIO()
-        w = Writer(8, 8, greyscale=True, bitdepth=1, transparent=transparent)
+        w = Writer(8, 8, grayscale=True, bitdepth=1, transparent=transparent)
         w.write_packed(o, pixels)
         r = Reader(bytes=o.getvalue())
         x, y, pixels, meta = r.asDirect()
         self.assertTrue(meta["alpha"])
-        self.assertTrue(meta["greyscale"])
+        self.assertTrue(meta["grayscale"])
         self.assertEqual(meta["bitdepth"], 1)
 
     def testWinfo(self):
@@ -2623,7 +2623,7 @@ class Test(unittest.TestCase):
 
         Indicative for pygame-ce issue 62.
         """
-        w = Writer(16, 2, greyscale=True, alpha=False, bitdepth=1)
+        w = Writer(16, 2, grayscale=True, alpha=False, bitdepth=1)
         o = BytesIO()
         w.write_packed(
             o, [itertools.chain([0x0A], [0xAA]), itertools.chain([0x0F], [0xFF])]
@@ -2763,7 +2763,7 @@ class Test(unittest.TestCase):
 
         rows = [map(numpy.uint16, range(0, 0x10000, 0x5555))]
         b = topngbytes(
-            "numpyuint16.png", rows, 4, 1, greyscale=True, alpha=False, bitdepth=16
+            "numpyuint16.png", rows, 4, 1, grayscale=True, alpha=False, bitdepth=16
         )
 
     def testNumpyuint8(self):
@@ -2777,7 +2777,7 @@ class Test(unittest.TestCase):
 
         rows = [map(numpy.uint8, range(0, 0x100, 0x55))]
         b = topngbytes(
-            "numpyuint8.png", rows, 4, 1, greyscale=True, alpha=False, bitdepth=8
+            "numpyuint8.png", rows, 4, 1, grayscale=True, alpha=False, bitdepth=8
         )
 
     def testNumpybool(self):
@@ -2791,7 +2791,7 @@ class Test(unittest.TestCase):
 
         rows = [map(numpy.bool, [0, 1])]
         b = topngbytes(
-            "numpybool.png", rows, 2, 1, greyscale=True, alpha=False, bitdepth=1
+            "numpybool.png", rows, 2, 1, grayscale=True, alpha=False, bitdepth=1
         )
 
     def testNumpyarray(self):
@@ -3539,7 +3539,7 @@ def test_suite(options, args):
         assert w == h
         # LAn for n < 8 is a special case for which we need to rescale
         # the data.
-        if meta["greyscale"] and meta["alpha"] and meta["bitdepth"] < 8:
+        if meta["grayscale"] and meta["alpha"] and meta["bitdepth"] < 8:
             factor = 255 // (2 ** meta["bitdepth"] - 1)
 
             def rescale(data):
@@ -3556,7 +3556,7 @@ def test_suite(options, args):
     if options.test_size:
         size = options.test_size
     options.bitdepth = options.test_depth
-    options.greyscale = bool(options.test_black)
+    options.grayscale = bool(options.test_black)
 
     kwargs = {}
     if options.test_red:
@@ -3567,10 +3567,10 @@ def test_suite(options, args):
         kwargs["blue"] = options.test_blue
     if options.test_alpha:
         kwargs["alpha"] = options.test_alpha
-    if options.greyscale:
+    if options.grayscale:
         if options.test_red or options.test_green or options.test_blue:
             raise ValueError(
-                "cannot specify colours (R, G, B) when greyscale image (black channel, K) is specified"
+                "cannot specify colors (R, G, B) when grayscale image (black channel, K) is specified"
             )
         kwargs["red"] = options.test_black
         kwargs["green"] = None
@@ -3580,7 +3580,7 @@ def test_suite(options, args):
         pixels = test_rgba(size, options.bitdepth, **kwargs)
     else:
         size, pixels, meta = pngsuite_image(args[0])
-        for k in ["bitdepth", "alpha", "greyscale"]:
+        for k in ["bitdepth", "alpha", "grayscale"]:
             setattr(options, k, meta[k])
 
     writer = Writer(
@@ -3590,7 +3590,7 @@ def test_suite(options, args):
         transparent=options.transparent,
         background=options.background,
         gamma=options.gamma,
-        greyscale=options.greyscale,
+        grayscale=options.grayscale,
         alpha=options.alpha,
         compression=options.compression,
         interlace=options.interlace,
@@ -3764,8 +3764,8 @@ def write_pnm(file, width, height, pixels, meta):
 
 def color_triple(color):
     """
-    Convert a command line colour value to a RGB triple of integers.
-    FIXME: Somewhere we need support for greyscale backgrounds etc.
+    Convert a command line color value to a RGB triple of integers.
+    FIXME: Somewhere we need support for grayscale backgrounds etc.
     """
     if color.startswith("#") and len(color) == 4:
         return (int(color[1], 16), int(color[2], 16), int(color[3], 16))
@@ -3807,7 +3807,7 @@ def _main(argv):
         action="store",
         type="string",
         metavar="color",
-        help="mark the specified colour (#RRGGBB) as transparent",
+        help="mark the specified color (#RRGGBB) as transparent",
     )
     parser.add_option(
         "-b",
@@ -3815,7 +3815,7 @@ def _main(argv):
         action="store",
         type="string",
         metavar="color",
-        help="save the specified background colour",
+        help="save the specified background color",
     )
     parser.add_option(
         "-a",
@@ -3893,7 +3893,7 @@ def _main(argv):
         action="store",
         type="string",
         metavar="pattern",
-        help="test pattern for greyscale image",
+        help="test pattern for grayscale image",
     )
     parser.add_option(
         "-d",
@@ -3953,12 +3953,12 @@ def _main(argv):
             infile, ("P5", "P6", "P7")
         )
         # When it comes to the variety of input formats, we do something
-        # rather rude.  Observe that L, LA, RGB, RGBA are the 4 colour
+        # rather rude.  Observe that L, LA, RGB, RGBA are the 4 color
         # types supported by PNG and that they correspond to 1, 2, 3, 4
         # channels respectively.  So we use the number of channels in
         # the source image to determine which one we have.  We do not
         # care about TUPLTYPE.
-        greyscale = depth <= 2
+        grayscale = depth <= 2
         pamalpha = depth in (2, 4)
         supported = (2**x - 1 for x in range(1, 17))
         try:
@@ -3971,7 +3971,7 @@ def _main(argv):
         writer = Writer(
             width,
             height,
-            greyscale=greyscale,
+            grayscale=grayscale,
             bitdepth=bitdepth,
             interlace=options.interlace,
             transparent=options.transparent,

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -48,7 +48,7 @@ def threshold(
     diff_color=(0, 0, 0),
     change_return=True,
 ):
-    """given the color it makes return_surf only have areas with the given colour."""
+    """given the color it makes return_surf only have areas with the given color."""
 
     width, height = surf.get_width(), surf.get_height()
 
@@ -234,10 +234,10 @@ class TransformModuleTest(unittest.TestCase):
         super_surf.fill((255, 0, 0), pygame.Rect(0, 0, 32, 32))
         sub_surf = super_surf.subsurface(pygame.Rect(0, 0, 32, 32))
 
-        grey_sub_surf = pygame.transform.grayscale(sub_surf)
-        self.assertEqual(pygame.transform.average_color(grey_sub_surf)[0], 76)
-        self.assertEqual(pygame.transform.average_color(grey_sub_surf)[0], 76)
-        self.assertEqual(pygame.transform.average_color(grey_sub_surf)[0], 76)
+        gray_sub_surf = pygame.transform.grayscale(sub_surf)
+        self.assertEqual(pygame.transform.average_color(gray_sub_surf)[0], 76)
+        self.assertEqual(pygame.transform.average_color(gray_sub_surf)[0], 76)
+        self.assertEqual(pygame.transform.average_color(gray_sub_surf)[0], 76)
 
     def test_grayscale_simd_assumptions(self):
         # The grayscale SIMD algorithm relies on the destination surface pitch


### PR DESCRIPTION
I used Visual Studio Code search tool to find all the occasions for non American spelling, looked quickly at each one and chose to replace them or not.
I ignored file names, files, links and the C/PY color dict files (where both spellings are intended)
The reason is:
- the codebase should use one convention and stick to it
- the American spelling is preferred to match the actual `pygame` classes and methods such as `Color` and `grayscale()`

For now I considered the following non American spelling (you can request more):
- grey -> gray
- colour -> color

If all checks pass it means I didn't break any variable name.