### PR TITLE
Try sleeping in window autoresize test

### DIFF
--- a/test/window_test.py
+++ b/test/window_test.py
@@ -1,6 +1,7 @@
 import unittest
 import pygame
 import os
+import time
 
 from pygame import Window
 from pygame.version import SDL
@@ -327,9 +328,14 @@ class WindowTypeTest(unittest.TestCase):
 
         # test auto resize
         self.assertTupleEqual(win.size, surf.get_size())
+        # autoresize uses an event callback that may take some time to get
+        # processed by the system event queue, sleep for 3 seconds to give
+        # the queue chance to catch up
         win.size = (100, 100)
+        time.sleep(3)
         self.assertTupleEqual(win.size, surf.get_size())
         win.size = (1280, 720)
+        time.sleep(3)
         self.assertTupleEqual(win.size, surf.get_size())
 
         # window surface should be invalid after the window is destroyed

--- a/test/window_test.py
+++ b/test/window_test.py
@@ -321,21 +321,23 @@ class WindowTypeTest(unittest.TestCase):
         pygame.init()
 
     def test_window_surface(self):
+        # window's surface uses an event callback that may take some time to get
+        # processed by the system event queue - sleep for 1 second to give
+        # the window event queue chance to catch up
         win = Window(size=(640, 480))
+        time.sleep(1)
         surf = win.get_surface()
 
         self.assertIsInstance(surf, pygame.Surface)
 
         # test auto resize
         self.assertTupleEqual(win.size, surf.get_size())
-        # autoresize uses an event callback that may take some time to get
-        # processed by the system event queue, sleep for 3 seconds to give
-        # the queue chance to catch up
+
         win.size = (100, 100)
-        time.sleep(3)
+        time.sleep(1)
         self.assertTupleEqual(win.size, surf.get_size())
         win.size = (1280, 720)
-        time.sleep(3)
+        time.sleep(1)
         self.assertTupleEqual(win.size, surf.get_size())
 
         # window surface should be invalid after the window is destroyed


### PR DESCRIPTION
An idea to hopefully reduce number of CI failures on this test.

Example failures:
https://github.com/pygame-community/pygame-ce/actions/runs/8573054619/job/23496953618?pr=2793
https://github.com/pygame-community/pygame-ce/actions/runs/8506569444/job/23297052392?pr=2766

I'm assuming that it is failing because the surface event has not yet been processed by the system at the time of checking and thus the callback has yet to be called for our window surface.

Adding a small delay after resizing the window should allow the system a chance to catch up.

If this doesn't work - we could also just try disabling it on Pypy where it seem to happen most often.