### PR TITLE
Add color argument to Surface constructor

### DIFF
--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -49,6 +49,7 @@ class Surface:
         flags: int = 0,
         depth: int = 0,
         masks: Optional[ColorValue] = None,
+        color: Optional[ColorValue] = None,
     ) -> None: ...
     @overload
     def __init__(
@@ -56,6 +57,7 @@ class Surface:
         size: Coordinate,
         flags: int = 0,
         surface: Surface = ...,
+        *, color: Optional[ColorValue] = None,
     ) -> None: ...
     def __copy__(self) -> Surface: ...
     def __deepcopy__(self, memo) -> Surface: ...

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -8,17 +8,17 @@
 .. class:: Surface
 
    | :sl:`pygame object for representing images`
-   | :sg:`Surface((width, height), flags=0, depth=0, masks=None) -> Surface`
-   | :sg:`Surface((width, height), flags=0, Surface) -> Surface`
+   | :sg:`Surface((width, height), flags=0, depth=0, masks=None, color=None) -> Surface`
+   | :sg:`Surface((width, height), flags=0, Surface, *, color=None) -> Surface`
 
    A pygame Surface is used to represent any image. The Surface has a fixed
    resolution and pixel format. Surfaces with 8-bit pixels use a color palette
    to map to 24-bit color.
 
    Call :meth:`pygame.Surface()` to create a new image object. The Surface will
-   be cleared to all black. The only required arguments are the sizes. With no
-   additional arguments, the Surface will be created in a format that best
-   matches the display Surface.
+   be cleared to all black or to the color specified in the constructor.
+   The only required arguments are the sizes. With no additional arguments, 
+   the Surface will be created in a format that best matches the display Surface.
 
    The pixel format can be controlled by passing the bit depth or an existing
    Surface. The flags argument is a bitmask of additional features for the

--- a/src_c/doc/surface_doc.h
+++ b/src_c/doc/surface_doc.h
@@ -1,5 +1,5 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
-#define DOC_SURFACE "Surface((width, height), flags=0, depth=0, masks=None) -> Surface\nSurface((width, height), flags=0, Surface) -> Surface\npygame object for representing images"
+#define DOC_SURFACE "Surface((width, height), flags=0, depth=0, masks=None, color=None) -> Surface\nSurface((width, height), flags=0, Surface, *, color=None) -> Surface\npygame object for representing images"
 #define DOC_SURFACE_BLIT "blit(source, dest, area=None, special_flags=0) -> Rect\ndraw another surface onto this one"
 #define DOC_SURFACE_BLITS "blits(blit_sequence=((source, dest), ...), doreturn=True) -> [Rect, ...] or None\nblits(((source, dest, area), ...)) -> [Rect, ...]\nblits(((source, dest, area, special_flags), ...)) -> [Rect, ...]\ndraw many images onto another"
 #define DOC_SURFACE_FBLITS "fblits(blit_sequence=((source, dest), ...), special_flags=0, /) -> None\ndraw many surfaces onto the calling surface at their corresponding location and the same special_flags"

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -516,7 +516,7 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
 
     char *kwids[] = {"size", "flags", "depth", "masks", "color", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iOOO", kwids, &size,
-+                                     &flags, &depth, &masks, &colorobj))
++                                    &flags, &depth, &masks, &colorobj))
         return -1;
 
     if (PySequence_Check(size) && PySequence_Length(size) == 2) {
@@ -716,7 +716,7 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
     if (colorobj && colorobj != Py_None) {
         Uint32 color;
         if (!pg_MappedColorFromObj(colorobj, surface->format, &color,
-                                    PG_COLOR_HANDLE_ALL)) {
+                                   PG_COLOR_HANDLE_ALL)) {
             SDL_FreeSurface(surface);
             return -1;
         }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -516,7 +516,7 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
 
     char *kwids[] = {"size", "flags", "depth", "masks", "color", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iOOO", kwids, &size,
-+                                     &flags, &depth, &masks, &colorobj))
+                                     &flags, &depth, &masks, &colorobj))
         return -1;
 
     if (PySequence_Check(size) && PySequence_Length(size) == 2) {

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -515,8 +515,8 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
     SDL_PixelFormat default_format;
 
     char *kwids[] = {"size", "flags", "depth", "masks", "color", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iOOO", kwids, &size, &flags,
-                                     &depth, &masks, &colorobj))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iOOO", kwids, &size,
++                                     &flags, &depth, &masks, &colorobj))
         return -1;
 
     if (PySequence_Check(size) && PySequence_Length(size) == 2) {
@@ -716,7 +716,7 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
     if (colorobj && colorobj != Py_None) {
         Uint32 color;
         if (!pg_MappedColorFromObj(colorobj, surface->format, &color,
-                               PG_COLOR_HANDLE_ALL)) {
+                                    PG_COLOR_HANDLE_ALL)) {
             SDL_FreeSurface(surface);
             return -1;
         }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -516,7 +516,7 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
 
     char *kwids[] = {"size", "flags", "depth", "masks", "color", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iOOO", kwids, &size,
-+                                    &flags, &depth, &masks, &colorobj))
++                                     &flags, &depth, &masks, &colorobj))
         return -1;
 
     if (PySequence_Check(size) && PySequence_Length(size) == 2) {

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -68,7 +68,13 @@ class SurfaceTypeTest(unittest.TestCase):
         self.assertEqual(surf.get_at((0, 0)), (255, 0, 0, 255))
 
         # when using a surface in the constructor the color is only available as a keyword argument
-        self.assertRaises(ValueError, pygame.Surface, (20, 20), pygame.SRCALPHA, pygame.Surface((10, 10)), (255, 0, 0, 255))
+        self.assertRaises(
+            ValueError,
+            pygame.Surface, (20, 20),
+            pygame.SRCALPHA,
+            pygame.Surface((10, 10)),
+            (255, 0, 0, 255)
+        )
 
     def test_set_clip(self):
         """see if surface.set_clip(None) works correctly."""

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -74,7 +74,7 @@ class SurfaceTypeTest(unittest.TestCase):
             (20, 20),
             pygame.SRCALPHA,
             pygame.Surface((10, 10)),
-            (255, 0, 0, 255)
+            (255, 0, 0, 255),
         )
 
     def test_set_clip(self):

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -50,6 +50,26 @@ class SurfaceTypeTest(unittest.TestCase):
         surf = pygame.Surface((20, 20))
         self.assertEqual(surf.get_at((0, 0)), (0, 0, 0, 255))
 
+    def test_surface_color_argument(self):
+        # surface without SRCALPHA should ignore the color's alpha value
+        surf = pygame.Surface((20, 20), color=(255, 0, 0, 100))
+        self.assertEqual(surf.get_at((0, 0)), (255, 0, 0, 255))
+
+        surf = pygame.Surface((20, 20), pygame.SRCALPHA, color=(255, 0, 0, 100))
+        self.assertEqual(surf.get_at((0, 0)), (255, 0, 0, 100))
+
+        # color = None should work as stated in the stubs and not raise TypeError
+        surf = pygame.Surface((20, 20), color=None)
+        self.assertEqual(surf.get_at((0, 0)), (0, 0, 0, 255))
+
+        surf = pygame.Surface(
+            (20, 20), pygame.SRCALPHA, 32, (0, 0, 0, 0), (255, 0, 0, 255)
+        )
+        self.assertEqual(surf.get_at((0, 0)), (255, 0, 0, 255))
+
+        # when using a surface in the constructor the color is only available as a keyword argument
+        self.assertRaises(ValueError, pygame.Surface, (20, 20), pygame.SRCALPHA, pygame.Surface((10, 10)), (255, 0, 0, 255))
+
     def test_set_clip(self):
         """see if surface.set_clip(None) works correctly."""
         s = pygame.Surface((800, 600))

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -70,7 +70,8 @@ class SurfaceTypeTest(unittest.TestCase):
         # when using a surface in the constructor the color is only available as a keyword argument
         self.assertRaises(
             ValueError,
-            pygame.Surface, (20, 20),
+            pygame.Surface,
+            (20, 20),
             pygame.SRCALPHA,
             pygame.Surface((10, 10)),
             (255, 0, 0, 255)


### PR DESCRIPTION
I added the C logic, the docs, stubs and tests for the color Surface argument.
I tested locally most cases and they work for me. I'm not too good with C so I hope I didn't mess up anything.
I didn't lock the surface when filling it as a few lines above it wasn't locked either.

As always the same question, why?
- It's backwards compatible
- It causes no harm
- It's very slightly faster than doing it on the next line  (and you don't need that line)
- You can create colored surfaces to pass to functions without having to store it in a variable to call fill on it
- It's one of those things you may feel should happen when building the surface
- I think many people would want this (I don't have any data to back this statement)

Tell me what you think of this and maybe why you don't think it's a good addition.