### PR TITLE
relax convert conditions

### DIFF
--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -247,6 +247,8 @@
       as Surface subclass inherit this method without the need to override,
       unless subclass specific instance attributes also need copying.
 
+      .. versionchanged:: 2.5.0 converting to a known format will succeed without a window/display surface.
+
       .. ## Surface.convert ##
 
    .. method:: convert_alpha

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1418,12 +1418,10 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "|Oi", &argobject, &flags))
         return NULL;
 
-
     if (!argobject && !SDL_WasInit(SDL_INIT_VIDEO))
         return RAISE(pgExc_SDLError,
                      "cannot convert without format "
                      "when pygame.display is not initialized");
-
 
     SURF_INIT_CHECK(surf)
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1415,12 +1415,15 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
     Uint8 key_r, key_g, key_b, key_a = 255;
     int has_colorkey = SDL_FALSE;
 
-    if (!SDL_WasInit(SDL_INIT_VIDEO))
-        return RAISE(pgExc_SDLError,
-                     "cannot convert without pygame.display initialized");
-
     if (!PyArg_ParseTuple(args, "|Oi", &argobject, &flags))
         return NULL;
+
+
+    if (!argobject && !SDL_WasInit(SDL_INIT_VIDEO))
+        return RAISE(pgExc_SDLError,
+                     "cannot convert without format "
+                     "when pygame.display is not initialized");
+
 
     SURF_INIT_CHECK(surf)
 

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1072,7 +1072,7 @@ class BaseLineMixin:
         for size in ((49, 49), (50, 50)):
             for depth in (8, 16, 24, 32):
                 for flags in (0, SRCALPHA):
-                    surface = pygame.display.set_mode(size, flags)
+                    surface=pygame.Surface(size, depth=depth)
                     surfaces.append(surface)
                     surfaces.append(surface.convert_alpha())
         return surfaces

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1070,10 +1070,12 @@ class BaseLineMixin:
         # Create some surfaces with different sizes, depths, and flags.
         surfaces = []
         for size in ((49, 49), (50, 50)):
+            surface = pygame.Surface(size, SRCALPHA)
+            surfaces.append(surface)
+
             for depth in (8, 16, 24, 32):
-                for flags in (0, SRCALPHA):
-                    surface = pygame.Surface(size, flags, depth=depth)
-                    surfaces.append(surface)
+                surface = pygame.Surface(size, depth=depth)
+                surfaces.append(surface)
         return surfaces
 
     @staticmethod

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1072,9 +1072,8 @@ class BaseLineMixin:
         for size in ((49, 49), (50, 50)):
             for depth in (8, 16, 24, 32):
                 for flags in (0, SRCALPHA):
-                    surface = pygame.Surface(size, depth=depth)
+                    surface = pygame.Surface(size, flags, depth=depth)
                     surfaces.append(surface)
-                    surfaces.append(surface.convert_alpha())
         return surfaces
 
     @staticmethod

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1070,12 +1070,11 @@ class BaseLineMixin:
         # Create some surfaces with different sizes, depths, and flags.
         surfaces = []
         for size in ((49, 49), (50, 50)):
-            surface = pygame.Surface(size, SRCALPHA)
-            surfaces.append(surface)
-
             for depth in (8, 16, 24, 32):
-                surface = pygame.Surface(size, depth=depth)
-                surfaces.append(surface)
+                for flags in (0, SRCALPHA):
+                    surface = pygame.display.set_mode(size, flags)
+                    surfaces.append(surface)
+                    surfaces.append(surface.convert_alpha())
         return surfaces
 
     @staticmethod

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1072,7 +1072,7 @@ class BaseLineMixin:
         for size in ((49, 49), (50, 50)):
             for depth in (8, 16, 24, 32):
                 for flags in (0, SRCALPHA):
-                    surface=pygame.Surface(size, depth=depth)
+                    surface = pygame.Surface(size, depth=depth)
                     surfaces.append(surface)
                     surfaces.append(surface.convert_alpha())
         return surfaces

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1234,7 +1234,7 @@ class GeneralSurfaceTests(unittest.TestCase):
         filename = example_path(os.path.join("data", "alien3.png"))  # 8bit PNG
         surf8bit = pygame.image.load(filename)
 
-        self.assertRaisesRegex(pygame.error, "display initialized", surf.convert)
+        self.assertRaisesRegex(pygame.error, "display is not initialized", surf.convert)
 
         pygame.display.init()
         try:

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1203,7 +1203,8 @@ class GeneralSurfaceTests(unittest.TestCase):
 
         pygame.display.init()
         try:
-            pygame.display.set_mode((640, 480))
+
+            #pygame.display.set_mode((640, 480))
 
             im = pygame.image.load(example_path(os.path.join("data", "city.png")))
             im2 = pygame.image.load(example_path(os.path.join("data", "brick.png")))
@@ -1296,7 +1297,7 @@ class GeneralSurfaceTests(unittest.TestCase):
     def test_convert_palettize(self):
         pygame.display.init()
         try:
-            pygame.display.set_mode((640, 480))
+            #pygame.display.set_mode((640, 480))
 
             surf = pygame.Surface((150, 250))
             surf.fill((255, 50, 0))

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1203,9 +1203,6 @@ class GeneralSurfaceTests(unittest.TestCase):
 
         pygame.display.init()
         try:
-
-            #pygame.display.set_mode((640, 480))
-
             im = pygame.image.load(example_path(os.path.join("data", "city.png")))
             im2 = pygame.image.load(example_path(os.path.join("data", "brick.png")))
 
@@ -1297,8 +1294,6 @@ class GeneralSurfaceTests(unittest.TestCase):
     def test_convert_palettize(self):
         pygame.display.init()
         try:
-            #pygame.display.set_mode((640, 480))
-
             surf = pygame.Surface((150, 250))
             surf.fill((255, 50, 0))
             surf = surf.convert(8)


### PR DESCRIPTION
There is no reason convert() has to wait for the display to be initialised. If a parameter with the target surface is provided, we can always convert.