### PR TITLE
Always call HasColorKey before GetColorKey

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -114,7 +114,9 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
         info.src = src->format;
         info.dst = dst->format;
         SDL_GetSurfaceAlphaMod(src, &info.src_blanket_alpha);
-        info.src_has_colorkey = SDL_GetColorKey(src, &info.src_colorkey) == 0;
+        if ((info.src_has_colorkey = SDL_HasColorKey(src))) {
+            SDL_GetColorKey(src, &info.src_colorkey);
+        }
         if (SDL_GetSurfaceBlendMode(src, &info.src_blend) ||
             SDL_GetSurfaceBlendMode(dst, &info.dst_blend)) {
             okay = 0;

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -548,7 +548,9 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
         byte_width = surf->w * 3;
     }
     else if (!strcmp(format, "RGBA")) {
-        hascolorkey = (SDL_GetColorKey(surf, &colorkey) == 0);
+        if ((hascolorkey = SDL_HasColorKey(surf))) {
+            SDL_GetColorKey(surf, &colorkey);
+        }
         byte_width = surf->w * 4;
     }
     else if (!strcmp(format, "RGBX") || !strcmp(format, "ARGB") ||
@@ -1542,7 +1544,9 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
     }
 
     SDL_GetSurfaceAlphaMod(surface, &surf_alpha);
-    have_surf_colorkey = (SDL_GetColorKey(surface, &surf_colorkey) == 0);
+    if ((have_surf_colorkey = SDL_HasColorKey(surface))) {
+        SDL_GetColorKey(surface, &surf_colorkey);
+    }
 
     if (srcbpp == 8) {
         h.has_cmap = 1;

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -831,7 +831,6 @@ mask_from_surface(PyObject *self, PyObject *args, PyObject *kwargs)
     pgMaskObject *maskobj = NULL;
     Uint32 colorkey;
     int threshold = 127; /* default value */
-    int use_thresh = 1;
     static char *keywords[] = {"surface", "threshold", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!|i", keywords,
@@ -864,13 +863,12 @@ mask_from_surface(PyObject *self, PyObject *args, PyObject *kwargs)
 
     Py_BEGIN_ALLOW_THREADS; /* Release the GIL. */
 
-    use_thresh = (SDL_GetColorKey(surf, &colorkey) == -1);
-
-    if (use_thresh) {
-        set_from_threshold(surf, maskobj->mask, threshold);
-    }
-    else {
+    if (SDL_HasColorKey(surf)) {
+        SDL_GetColorKey(surf, &colorkey);
         set_from_colorkey(surf, maskobj->mask, colorkey);
+    }
+    else {  // use threshold
+        set_from_threshold(surf, maskobj->mask, threshold);
     }
 
     Py_END_ALLOW_THREADS; /* Obtain the GIL. */

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -322,8 +322,8 @@ _copy_colorplane(Py_buffer *view_p, SDL_Surface *surf,
         dz_dst = -1;
     }
 #endif
-    if (view_kind == VIEWKIND_COLORKEY &&
-        SDL_GetColorKey(surf, &colorkey) == 0) {
+    if (view_kind == VIEWKIND_COLORKEY && SDL_HasColorKey(surf)) {
+        SDL_GetColorKey(surf, &colorkey);
         for (x = 0; x < w; ++x) {
             for (y = 0; y < h; ++y) {
                 for (z = 0; z < pixelsize; ++z) {

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -602,7 +602,8 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
          * Target surface is 32bit with source RGBA/ABGR ordering
          */
         rz_dst = PG_CreateSurface(dstwidth, dstheight, rz_src->format->format);
-        if (SDL_GetColorKey(src, &colorkey) == 0) {
+        if (SDL_HasColorKey(src)) {
+            SDL_GetColorKey(src, &colorkey);
             if (SDL_SetColorKey(rz_dst, SDL_TRUE, colorkey) != 0) {
                 SDL_FreeSurface(rz_dst);
                 return NULL;
@@ -660,7 +661,8 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
          */
 
         rz_dst = PG_CreateSurface(dstwidth, dstheight, rz_src->format->format);
-        if (SDL_GetColorKey(src, &colorkey) == 0) {
+        if (SDL_HasColorKey(src)) {
+            SDL_GetColorKey(src, &colorkey);
             if (SDL_SetColorKey(rz_dst, SDL_TRUE, colorkey) != 0) {
                 SDL_FreeSurface(rz_dst);
                 return NULL;

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -178,7 +178,8 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
         }
     }
 
-    if (SDL_GetColorKey(surf, &colorkey) == 0) {
+    if (SDL_HasColorKey(surf)) {
+        SDL_GetColorKey(surf, &colorkey);
         if (SDL_SetColorKey(newsurf, SDL_TRUE, colorkey) != 0) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
@@ -672,7 +673,7 @@ surf_rotate(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
 
     /* get the background color */
-    if (SDL_GetColorKey(surf, &bgcolor) != 0) {
+    if (!SDL_HasColorKey(surf)) {
         SDL_LockSurface(surf);
         switch (PG_SURF_BytesPerPixel(surf)) {
             case 1:
@@ -697,6 +698,9 @@ surf_rotate(PyObject *self, PyObject *args, PyObject *kwargs)
         }
         SDL_UnlockSurface(surf);
         bgcolor &= ~surf->format->Amask;
+    }
+    else {
+        SDL_GetColorKey(surf, &bgcolor);
     }
 
     SDL_LockSurface(newsurf);


### PR DESCRIPTION
SDL sets an error if GetColorKey is called on a surface that doesn't have colorkey, which is much more expensive performance-wise in the newest SDL versions. Therefore, let's call SDL_HasColorKey first to avoid the error setting cost.

Successor to #2835
Closes #2821 