### PR TITLE
Using blur on a surface with either width or height equal to 0 won't raise a ValueError

### DIFF
--- a/docs/reST/ref/transform.rst
+++ b/docs/reST/ref/transform.rst
@@ -245,6 +245,9 @@ Instead, always begin with the original image and scale to the desired size.)
    .. versionchanged:: 2.3.0
       Passing the calling surface as destination surface raises a ``ValueError``
 
+   .. versionchanged:: 2.5.0
+      A surface with either width or height equal to 0 won't raise a ``ValueError``
+
    .. ## pygame.transform.box_blur ##
 
 .. function:: gaussian_blur
@@ -270,6 +273,9 @@ Instead, always begin with the original image and scale to the desired size.)
    .. versionchanged:: 2.3.1
       Now the standard deviation of the Gaussian kernel is equal to the radius. 
       Blur results will be slightly different.
+
+   .. versionchanged:: 2.5.0
+      A surface with either width or height equal to 0 won't raise a ``ValueError``
 
    .. ## pygame.transform.gaussian_blur ##
 

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -3266,6 +3266,11 @@ blur(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int radius,
         retsurf = pgSurface_AsSurface(dstobj);
     }
 
+    if ((retsurf->w) != (src->w) || (retsurf->h) != (src->h)) {
+        return RAISE(PyExc_ValueError,
+                     "Destination surface not the same size.");
+    }
+    
     if (retsurf->w == 0 || retsurf->h == 0) {
         return retsurf;
     }
@@ -3281,11 +3286,6 @@ blur(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int radius,
             "Blur routines do not support dest_surfaces that share pixels "
             "with the source surface. Likely the surfaces are the same, one "
             "of them is a subsurface, or they are sharing the same buffer.");
-    }
-
-    if ((retsurf->w) != (src->w) || (retsurf->h) != (src->h)) {
-        return RAISE(PyExc_ValueError,
-                     "Destination surface not the same size.");
     }
 
     if (PG_SURF_BytesPerPixel(src) != PG_SURF_BytesPerPixel(retsurf)) {

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -3266,6 +3266,10 @@ blur(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int radius,
         retsurf = pgSurface_AsSurface(dstobj);
     }
 
+    if (retsurf->w == 0 || retsurf->h == 0) {
+        return retsurf;
+    }
+
     Uint8 *ret_start = retsurf->pixels;
     Uint8 *ret_end = ret_start + retsurf->h * retsurf->pitch;
     Uint8 *src_start = src->pixels;

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -3270,7 +3270,7 @@ blur(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int radius,
         return RAISE(PyExc_ValueError,
                      "Destination surface not the same size.");
     }
-    
+
     if (retsurf->w == 0 || retsurf->h == 0) {
         return retsurf;
     }

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1600,6 +1600,19 @@ class TransformDisplayModuleTest(unittest.TestCase):
         for pos in data2:
             self.assertTrue(sf_b2.get_at(pos) == data2[pos])
 
+    def test_blur_zero_size_surface(self):
+        surface = pygame.Surface((0, 0))
+        self.assertEqual(pygame.transform.box_blur(surface).get_size(), (0, 0))
+        self.assertEqual(pygame.transform.gaussian_blur(surface).get_size(), (0, 0))
+
+        surface = pygame.Surface((20, 0))
+        self.assertEqual(pygame.transform.box_blur(surface).get_size(), (20, 0))
+        self.assertEqual(pygame.transform.gaussian_blur(surface).get_size(), (20, 0))
+        
+        surface = pygame.Surface((0, 20))
+        self.assertEqual(pygame.transform.box_blur(surface).get_size(), (0, 20))
+        self.assertEqual(pygame.transform.gaussian_blur(surface).get_size(), (0, 20))
+
     def test_flip(self):
         """honors the set_color key on the returned surface from flip."""
         image_loaded = pygame.image.load(example_path("data/chimp.png"))

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1602,16 +1602,16 @@ class TransformDisplayModuleTest(unittest.TestCase):
 
     def test_blur_zero_size_surface(self):
         surface = pygame.Surface((0, 0))
-        self.assertEqual(pygame.transform.box_blur(surface).get_size(), (0, 0))
-        self.assertEqual(pygame.transform.gaussian_blur(surface).get_size(), (0, 0))
+        self.assertEqual(pygame.transform.box_blur(surface, 3).get_size(), (0, 0))
+        self.assertEqual(pygame.transform.gaussian_blur(surface, 3).get_size(), (0, 0))
 
         surface = pygame.Surface((20, 0))
-        self.assertEqual(pygame.transform.box_blur(surface).get_size(), (20, 0))
-        self.assertEqual(pygame.transform.gaussian_blur(surface).get_size(), (20, 0))
+        self.assertEqual(pygame.transform.box_blur(surface, 3).get_size(), (20, 0))
+        self.assertEqual(pygame.transform.gaussian_blur(surface, 3).get_size(), (20, 0))
 
         surface = pygame.Surface((0, 20))
-        self.assertEqual(pygame.transform.box_blur(surface).get_size(), (0, 20))
-        self.assertEqual(pygame.transform.gaussian_blur(surface).get_size(), (0, 20))
+        self.assertEqual(pygame.transform.box_blur(surface, 3).get_size(), (0, 20))
+        self.assertEqual(pygame.transform.gaussian_blur(surface, 3).get_size(), (0, 20))
 
     def test_flip(self):
         """honors the set_color key on the returned surface from flip."""

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1608,7 +1608,7 @@ class TransformDisplayModuleTest(unittest.TestCase):
         surface = pygame.Surface((20, 0))
         self.assertEqual(pygame.transform.box_blur(surface).get_size(), (20, 0))
         self.assertEqual(pygame.transform.gaussian_blur(surface).get_size(), (20, 0))
-        
+
         surface = pygame.Surface((0, 20))
         self.assertEqual(pygame.transform.box_blur(surface).get_size(), (0, 20))
         self.assertEqual(pygame.transform.gaussian_blur(surface).get_size(), (0, 20))


### PR DESCRIPTION
I tried to fix issue https://github.com/pygame-community/pygame-ce/issues/2849 and I tested locally that surfaces with either width == 0 or height == 0 won't raise a misleading error message. I also moved the comparison between `dst` and `src` sizes as if `src` is (30, 50) and `dst` is (0, 20), without moving the check, the function would have passed returning a (0, 20) sized surface which would probably cause bugs, both `src` and `dst` must have the same zero sizes for it to return gracefully.
Why not an exception? Like the issue creator said, all transform functions handle zero sized surfaces which are even returned some times (`pygame.Font.render`) so this one should be consistent. If you find anything wrong with my changes let me know.
I also modified the docs and added a test.