### PR TITLE
Deprecate `setup.py stubcheck`, suggest and use replacement `buildconfig/stubs/stubcheck.py`

### DIFF
--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -80,7 +80,7 @@ jobs:
       if: matrix.os == 'ubuntu-22.04' # run stubtest only once
       run: |
         pip3 install mypy
-        python3 setup.py stubcheck
+        python3 buildconfig/stubs/stubcheck.py
 
     # We upload the generated files under github actions assets
     - name: Upload sdist

--- a/buildconfig/stubs/stubcheck.py
+++ b/buildconfig/stubs/stubcheck.py
@@ -1,0 +1,45 @@
+"""
+A helper script to run mypy stubtest on the stubs directory
+"""
+
+import os
+import subprocess
+import sys
+
+from pathlib import Path
+
+STUBS_BASE_DIR = Path(__file__).parent
+
+
+def main():
+    """
+    Main entrypoint
+    """
+    for stubtest in ([sys.executable, "-m", "mypy.stubtest"], ["stubtest"]):
+        try:
+            version = subprocess.run(
+                [*stubtest, "--version"], capture_output=True, check=True, text=True
+            ).stdout.strip()
+        except subprocess.CalledProcessError:
+            continue
+
+        cmd = " ".join(stubtest)
+        print(f"Using stubtest invokation: `{cmd}` (version: {version})")
+        prev_dir = os.getcwd()
+        try:
+            os.chdir(STUBS_BASE_DIR)
+            sys.exit(
+                subprocess.run(
+                    [*stubtest, "pygame", "--allowlist", "mypy_allow_list.txt"]
+                ).returncode
+            )
+        finally:
+            os.chdir(prev_dir)
+
+    print("ERROR: Could not find a valid stubtest program.")
+    print("Make sure you have mypy installed.")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -827,20 +827,12 @@ class StubcheckCommand(Command):
         runs mypy to build the docs.
         '''
         import subprocess
-        import warnings
-
-        print("Using python:", sys.executable)
-
-        if shutil.which('mypy') is None:
-            warnings.warn("Please install 'mypy' in your environment. (hint: 'python3 -m pip install mypy')")
-            sys.exit(1)
-
-        os.chdir('buildconfig/stubs')
         command_line = [
-            sys.executable,'-m','mypy.stubtest',"pygame","--allowlist","mypy_allow_list.txt"
+            sys.executable, os.path.join("buildconfig", "stubs", "stubcheck.py")
         ]
+        print("WARNING: This command is deprecated and will be removed in the future.")
+        print(f"Please use the following replacement: `{' '.join(command_line)}`\n")  
         result = subprocess.run(command_line)
-        os.chdir('../../')
         if result.returncode != 0:
             raise SystemExit("Stubcheck failed.")
 


### PR DESCRIPTION
Another step in the move away from `setup.py`.

Added a new and improved stubtest caller script.