### PR TITLE
Optimized `transform.scale2x()`

### DIFF
--- a/src_c/scale2x.c
+++ b/src_c/scale2x.c
@@ -35,13 +35,13 @@
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
 static inline int
-read_int24(const Uint8 *restrict x)
+read_int24(const Uint8 *x)
 {
     return (x[0] << 16 | x[1] << 8 | x[2]);
 }
 
 static inline void
-store_int24(Uint8 *restrict x, int i)
+store_int24(Uint8 *x, int i)
 {
     x[0] = i >> 16;
     x[1] = (i >> 8) & 0xff;
@@ -59,8 +59,8 @@ scale2x(SDL_Surface *src, SDL_Surface *dst)
 {
     int looph, loopw;
 
-    Uint8 *restrict srcpix = (Uint8 *restrict)src->pixels;
-    Uint8 *restrict dstpix = (Uint8 *restrict)dst->pixels;
+    Uint8 *srcpix = (Uint8 *)src->pixels;
+    Uint8 *dstpix = (Uint8 *)dst->pixels;
 
     const int srcpitch = src->pitch;
     const int dstpitch = dst->pitch;
@@ -68,10 +68,12 @@ scale2x(SDL_Surface *src, SDL_Surface *dst)
     const int height = src->h;
 
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-    switch (src->format->bytes_per_pixel) {
+    const Uint8 Bpp = src->format->bytes_per_pixel;
 #else
-    switch (src->format->BytesPerPixel) {
+    const Uint8 Bpp = src->format->BytesPerPixel;
 #endif
+
+    switch (Bpp) {
         case 1: {
             Uint8 E0, E1, E2, E3, B, D, E, F, H;
             for (looph = 0; looph < height; ++looph) {
@@ -198,8 +200,7 @@ scale2x(SDL_Surface *src, SDL_Surface *dst)
                 Uint8 *dst_row1 = dstpix + (looph * 2 + 1) * dstpitch;
 
                 Uint8 *src_row_prev = srcpix + MAX(0, looph - 1) * srcpitch;
-                Uint8 *src_row_next =
-                    srcpix + MIN(height - 1, looph + 1) * srcpitch;
+                Uint8 *src_row_next = srcpix + MIN(height - 1, looph + 1) * srcpitch;
 
                 for (loopw = 0; loopw < width; ++loopw) {
                     B = *(Uint32 *)(src_row_prev + 4 * loopw);

--- a/src_c/scale2x.c
+++ b/src_c/scale2x.c
@@ -34,13 +34,19 @@
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
-#define READINT24(x) ((x)[0] << 16 | (x)[1] << 8 | (x)[2])
-#define WRITEINT24(x, i)          \
-    {                             \
-        (x)[0] = i >> 16;         \
-        (x)[1] = (i >> 8) & 0xff; \
-        x[2] = i & 0xff;          \
-    }
+static inline int
+read_int24(const Uint8 *restrict x)
+{
+    return (x[0] << 16 | x[1] << 8 | x[2]);
+}
+
+static inline void
+store_int24(Uint8 *restrict x, int i)
+{
+    x[0] = i >> 16;
+    x[1] = (i >> 8) & 0xff;
+    x[2] = i & 0xff;
+}
 
 /*
   this requires a destination surface already setup to be twice as
@@ -53,8 +59,8 @@ scale2x(SDL_Surface *src, SDL_Surface *dst)
 {
     int looph, loopw;
 
-    Uint8 *srcpix = (Uint8 *)src->pixels;
-    Uint8 *dstpix = (Uint8 *)dst->pixels;
+    Uint8 *restrict srcpix = (Uint8 *restrict)src->pixels;
+    Uint8 *restrict dstpix = (Uint8 *restrict)dst->pixels;
 
     const int srcpitch = src->pitch;
     const int dstpitch = dst->pitch;
@@ -69,31 +75,38 @@ scale2x(SDL_Surface *src, SDL_Surface *dst)
         case 1: {
             Uint8 E0, E1, E2, E3, B, D, E, F, H;
             for (looph = 0; looph < height; ++looph) {
+                Uint8 *src_row = srcpix + looph * srcpitch;
+                Uint8 *dst_row0 = dstpix + looph * 2 * dstpitch;
+                Uint8 *dst_row1 = dstpix + (looph * 2 + 1) * dstpitch;
+
+                Uint8 *src_row_prev = srcpix + MAX(0, looph - 1) * srcpitch;
+                Uint8 *src_row_next =
+                    srcpix + MIN(height - 1, looph + 1) * srcpitch;
+
                 for (loopw = 0; loopw < width; ++loopw) {
-                    B = *(Uint8 *)(srcpix + (MAX(0, looph - 1) * srcpitch) +
-                                   (1 * loopw));
-                    D = *(Uint8 *)(srcpix + (looph * srcpitch) +
-                                   (1 * MAX(0, loopw - 1)));
-                    E = *(Uint8 *)(srcpix + (looph * srcpitch) + (1 * loopw));
-                    F = *(Uint8 *)(srcpix + (looph * srcpitch) +
-                                   (1 * MIN(width - 1, loopw + 1)));
-                    H = *(Uint8 *)(srcpix +
-                                   (MIN(height - 1, looph + 1) * srcpitch) +
-                                   (1 * loopw));
+                    B = *(Uint8 *)(src_row_prev + loopw);
+                    D = *(Uint8 *)(src_row + MAX(0, loopw - 1));
+                    E = *(Uint8 *)(src_row + loopw);
+                    F = *(Uint8 *)(src_row + MIN(width - 1, loopw + 1));
+                    H = *(Uint8 *)(src_row_next + loopw);
 
-                    E0 = D == B && B != F && D != H ? D : E;
-                    E1 = B == F && B != D && F != H ? F : E;
-                    E2 = D == H && D != B && H != F ? D : E;
-                    E3 = H == F && D != H && B != F ? F : E;
+                    if (B != H && D != F) {
+                        E0 = (D == B) ? D : E;
+                        E1 = (B == F) ? F : E;
+                        E2 = (D == H) ? D : E;
+                        E3 = (H == F) ? F : E;
+                    }
+                    else {
+                        E0 = E;
+                        E1 = E;
+                        E2 = E;
+                        E3 = E;
+                    }
 
-                    *(Uint8 *)(dstpix + looph * 2 * dstpitch + loopw * 2 * 1) =
-                        E0;
-                    *(Uint8 *)(dstpix + looph * 2 * dstpitch +
-                               (loopw * 2 + 1) * 1) = E1;
-                    *(Uint8 *)(dstpix + (looph * 2 + 1) * dstpitch +
-                               loopw * 2 * 1) = E2;
-                    *(Uint8 *)(dstpix + (looph * 2 + 1) * dstpitch +
-                               (loopw * 2 + 1) * 1) = E3;
+                    *(Uint8 *)(dst_row0 + loopw * 2) = E0;
+                    *(Uint8 *)(dst_row0 + loopw * 2 + 1) = E1;
+                    *(Uint8 *)(dst_row1 + loopw * 2) = E2;
+                    *(Uint8 *)(dst_row1 + loopw * 2 + 1) = E3;
                 }
             }
             break;
@@ -101,31 +114,38 @@ scale2x(SDL_Surface *src, SDL_Surface *dst)
         case 2: {
             Uint16 E0, E1, E2, E3, B, D, E, F, H;
             for (looph = 0; looph < height; ++looph) {
+                Uint8 *src_row = srcpix + looph * srcpitch;
+                Uint8 *dst_row0 = dstpix + looph * 2 * dstpitch;
+                Uint8 *dst_row1 = dstpix + (looph * 2 + 1) * dstpitch;
+
+                Uint8 *src_row_prev = srcpix + MAX(0, looph - 1) * srcpitch;
+                Uint8 *src_row_next =
+                    srcpix + MIN(height - 1, looph + 1) * srcpitch;
+
                 for (loopw = 0; loopw < width; ++loopw) {
-                    B = *(Uint16 *)(srcpix + (MAX(0, looph - 1) * srcpitch) +
-                                    (2 * loopw));
-                    D = *(Uint16 *)(srcpix + (looph * srcpitch) +
-                                    (2 * MAX(0, loopw - 1)));
-                    E = *(Uint16 *)(srcpix + (looph * srcpitch) + (2 * loopw));
-                    F = *(Uint16 *)(srcpix + (looph * srcpitch) +
-                                    (2 * MIN(width - 1, loopw + 1)));
-                    H = *(Uint16 *)(srcpix +
-                                    (MIN(height - 1, looph + 1) * srcpitch) +
-                                    (2 * loopw));
+                    B = *(Uint16 *)(src_row_prev + 2 * loopw);
+                    D = *(Uint16 *)(src_row + 2 * MAX(0, loopw - 1));
+                    E = *(Uint16 *)(src_row + 2 * loopw);
+                    F = *(Uint16 *)(src_row + 2 * MIN(width - 1, loopw + 1));
+                    H = *(Uint16 *)(src_row_next + 2 * loopw);
 
-                    E0 = D == B && B != F && D != H ? D : E;
-                    E1 = B == F && B != D && F != H ? F : E;
-                    E2 = D == H && D != B && H != F ? D : E;
-                    E3 = H == F && D != H && B != F ? F : E;
+                    if (B != H && D != F) {
+                        E0 = (D == B) ? D : E;
+                        E1 = (B == F) ? F : E;
+                        E2 = (D == H) ? D : E;
+                        E3 = (H == F) ? F : E;
+                    }
+                    else {
+                        E0 = E;
+                        E1 = E;
+                        E2 = E;
+                        E3 = E;
+                    }
 
-                    *(Uint16 *)(dstpix + looph * 2 * dstpitch +
-                                loopw * 2 * 2) = E0;
-                    *(Uint16 *)(dstpix + looph * 2 * dstpitch +
-                                (loopw * 2 + 1) * 2) = E1;
-                    *(Uint16 *)(dstpix + (looph * 2 + 1) * dstpitch +
-                                loopw * 2 * 2) = E2;
-                    *(Uint16 *)(dstpix + (looph * 2 + 1) * dstpitch +
-                                (loopw * 2 + 1) * 2) = E3;
+                    *(Uint16 *)(dst_row0 + loopw * 2 * 2) = E0;
+                    *(Uint16 *)(dst_row0 + (loopw * 2 + 1) * 2) = E1;
+                    *(Uint16 *)(dst_row1 + loopw * 2 * 2) = E2;
+                    *(Uint16 *)(dst_row1 + (loopw * 2 + 1) * 2) = E3;
                 }
             }
             break;
@@ -134,65 +154,81 @@ scale2x(SDL_Surface *src, SDL_Surface *dst)
             int E0, E1, E2, E3, B, D, E, F, H;
             for (looph = 0; looph < height; ++looph) {
                 for (loopw = 0; loopw < width; ++loopw) {
-                    B = READINT24(srcpix + (MAX(0, looph - 1) * srcpitch) +
-                                  (3 * loopw));
-                    D = READINT24(srcpix + (looph * srcpitch) +
-                                  (3 * MAX(0, loopw - 1)));
-                    E = READINT24(srcpix + (looph * srcpitch) + (3 * loopw));
-                    F = READINT24(srcpix + (looph * srcpitch) +
-                                  (3 * MIN(width - 1, loopw + 1)));
-                    H = READINT24(srcpix +
-                                  (MIN(height - 1, looph + 1) * srcpitch) +
-                                  (3 * loopw));
+                    B = read_int24(srcpix + (MAX(0, looph - 1) * srcpitch) +
+                                   (3 * loopw));
+                    D = read_int24(srcpix + (looph * srcpitch) +
+                                   (3 * MAX(0, loopw - 1)));
+                    E = read_int24(srcpix + (looph * srcpitch) + (3 * loopw));
+                    F = read_int24(srcpix + (looph * srcpitch) +
+                                   (3 * MIN(width - 1, loopw + 1)));
+                    H = read_int24(srcpix +
+                                   (MIN(height - 1, looph + 1) * srcpitch) +
+                                   (3 * loopw));
 
-                    E0 = D == B && B != F && D != H ? D : E;
-                    E1 = B == F && B != D && F != H ? F : E;
-                    E2 = D == H && D != B && H != F ? D : E;
-                    E3 = H == F && D != H && B != F ? F : E;
+                    if (B != H && D != F) {
+                        E0 = (D == B) ? D : E;
+                        E1 = (B == F) ? F : E;
+                        E2 = (D == H) ? D : E;
+                        E3 = (H == F) ? F : E;
+                    }
+                    else {
+                        E0 = E;
+                        E1 = E;
+                        E2 = E;
+                        E3 = E;
+                    }
 
-                    WRITEINT24((dstpix + looph * 2 * dstpitch + loopw * 2 * 3),
-                               E0);
-                    WRITEINT24(
+                    store_int24(
+                        (dstpix + looph * 2 * dstpitch + loopw * 2 * 3), E0);
+                    store_int24(
                         (dstpix + looph * 2 * dstpitch + (loopw * 2 + 1) * 3),
                         E1);
-                    WRITEINT24(
+                    store_int24(
                         (dstpix + (looph * 2 + 1) * dstpitch + loopw * 2 * 3),
                         E2);
-                    WRITEINT24((dstpix + (looph * 2 + 1) * dstpitch +
-                                (loopw * 2 + 1) * 3),
-                               E3);
+                    store_int24((dstpix + (looph * 2 + 1) * dstpitch +
+                                 (loopw * 2 + 1) * 3),
+                                E3);
                 }
             }
             break;
         }
-        default: { /*case 4:*/
+        default: {
             Uint32 E0, E1, E2, E3, B, D, E, F, H;
+
             for (looph = 0; looph < height; ++looph) {
+                Uint8 *src_row = srcpix + looph * srcpitch;
+                Uint8 *dst_row0 = dstpix + looph * 2 * dstpitch;
+                Uint8 *dst_row1 = dstpix + (looph * 2 + 1) * dstpitch;
+
+                Uint8 *src_row_prev = srcpix + MAX(0, looph - 1) * srcpitch;
+                Uint8 *src_row_next =
+                    srcpix + MIN(height - 1, looph + 1) * srcpitch;
+
                 for (loopw = 0; loopw < width; ++loopw) {
-                    B = *(Uint32 *)(srcpix + (MAX(0, looph - 1) * srcpitch) +
-                                    (4 * loopw));
-                    D = *(Uint32 *)(srcpix + (looph * srcpitch) +
-                                    (4 * MAX(0, loopw - 1)));
-                    E = *(Uint32 *)(srcpix + (looph * srcpitch) + (4 * loopw));
-                    F = *(Uint32 *)(srcpix + (looph * srcpitch) +
-                                    (4 * MIN(width - 1, loopw + 1)));
-                    H = *(Uint32 *)(srcpix +
-                                    (MIN(height - 1, looph + 1) * srcpitch) +
-                                    (4 * loopw));
+                    B = *(Uint32 *)(src_row_prev + 4 * loopw);
+                    D = *(Uint32 *)(src_row + 4 * MAX(0, loopw - 1));
+                    E = *(Uint32 *)(src_row + 4 * loopw);
+                    F = *(Uint32 *)(src_row + 4 * MIN(width - 1, loopw + 1));
+                    H = *(Uint32 *)(src_row_next + 4 * loopw);
 
-                    E0 = D == B && B != F && D != H ? D : E;
-                    E1 = B == F && B != D && F != H ? F : E;
-                    E2 = D == H && D != B && H != F ? D : E;
-                    E3 = H == F && D != H && B != F ? F : E;
+                    if (B != H && D != F) {
+                        E0 = (D == B) ? D : E;
+                        E1 = (B == F) ? F : E;
+                        E2 = (D == H) ? D : E;
+                        E3 = (H == F) ? F : E;
+                    }
+                    else {
+                        E0 = E;
+                        E1 = E;
+                        E2 = E;
+                        E3 = E;
+                    }
 
-                    *(Uint32 *)(dstpix + looph * 2 * dstpitch +
-                                loopw * 2 * 4) = E0;
-                    *(Uint32 *)(dstpix + looph * 2 * dstpitch +
-                                (loopw * 2 + 1) * 4) = E1;
-                    *(Uint32 *)(dstpix + (looph * 2 + 1) * dstpitch +
-                                loopw * 2 * 4) = E2;
-                    *(Uint32 *)(dstpix + (looph * 2 + 1) * dstpitch +
-                                (loopw * 2 + 1) * 4) = E3;
+                    *(Uint32 *)(dst_row0 + loopw * 2 * 4) = E0;
+                    *(Uint32 *)(dst_row0 + (loopw * 2 + 1) * 4) = E1;
+                    *(Uint32 *)(dst_row1 + loopw * 2 * 4) = E2;
+                    *(Uint32 *)(dst_row1 + (loopw * 2 + 1) * 4) = E3;
                 }
             }
             break;

--- a/src_c/scale2x.c
+++ b/src_c/scale2x.c
@@ -153,17 +153,20 @@ scale2x(SDL_Surface *src, SDL_Surface *dst)
         case 3: {
             int E0, E1, E2, E3, B, D, E, F, H;
             for (looph = 0; looph < height; ++looph) {
+                Uint8 *src_row = srcpix + looph * srcpitch;
+                Uint8 *dst_row0 = dstpix + looph * 2 * dstpitch;
+                Uint8 *dst_row1 = dstpix + (looph * 2 + 1) * dstpitch;
+
+                Uint8 *src_row_prev = srcpix + MAX(0, looph - 1) * srcpitch;
+                Uint8 *src_row_next =
+                    srcpix + MIN(height - 1, looph + 1) * srcpitch;
+
                 for (loopw = 0; loopw < width; ++loopw) {
-                    B = read_int24(srcpix + (MAX(0, looph - 1) * srcpitch) +
-                                   (3 * loopw));
-                    D = read_int24(srcpix + (looph * srcpitch) +
-                                   (3 * MAX(0, loopw - 1)));
-                    E = read_int24(srcpix + (looph * srcpitch) + (3 * loopw));
-                    F = read_int24(srcpix + (looph * srcpitch) +
-                                   (3 * MIN(width - 1, loopw + 1)));
-                    H = read_int24(srcpix +
-                                   (MIN(height - 1, looph + 1) * srcpitch) +
-                                   (3 * loopw));
+                    B = read_int24(src_row_prev + (3 * loopw));
+                    D = read_int24(src_row + (3 * MAX(0, loopw - 1)));
+                    E = read_int24(src_row + (3 * loopw));
+                    F = read_int24(src_row + (3 * MIN(width - 1, loopw + 1)));
+                    H = read_int24(src_row_next + (3 * loopw));
 
                     if (B != H && D != F) {
                         E0 = (D == B) ? D : E;
@@ -178,17 +181,10 @@ scale2x(SDL_Surface *src, SDL_Surface *dst)
                         E3 = E;
                     }
 
-                    store_int24(
-                        (dstpix + looph * 2 * dstpitch + loopw * 2 * 3), E0);
-                    store_int24(
-                        (dstpix + looph * 2 * dstpitch + (loopw * 2 + 1) * 3),
-                        E1);
-                    store_int24(
-                        (dstpix + (looph * 2 + 1) * dstpitch + loopw * 2 * 3),
-                        E2);
-                    store_int24((dstpix + (looph * 2 + 1) * dstpitch +
-                                 (loopw * 2 + 1) * 3),
-                                E3);
+                    store_int24(dst_row0 + loopw * 2 * 3, E0);
+                    store_int24(dst_row0 + (loopw * 2 + 1) * 3, E1);
+                    store_int24(dst_row1 + loopw * 2 * 3, E2);
+                    store_int24(dst_row1 + (loopw * 2 + 1) * 3, E3);
                 }
             }
             break;

--- a/src_c/scale2x.c
+++ b/src_c/scale2x.c
@@ -200,7 +200,8 @@ scale2x(SDL_Surface *src, SDL_Surface *dst)
                 Uint8 *dst_row1 = dstpix + (looph * 2 + 1) * dstpitch;
 
                 Uint8 *src_row_prev = srcpix + MAX(0, looph - 1) * srcpitch;
-                Uint8 *src_row_next = srcpix + MIN(height - 1, looph + 1) * srcpitch;
+                Uint8 *src_row_next =
+                    srcpix + MIN(height - 1, looph + 1) * srcpitch;
 
                 for (loopw = 0; loopw < width; ++loopw) {
                     B = *(Uint32 *)(src_row_prev + 4 * loopw);


### PR DESCRIPTION
This PR optimizes all bpp cases for the `transform.scale2x()` function. It does so through better use of pointers / switch to static inline functions instead of macros that repeat some calculations and one optimization suggestion in https://www.scale2x.it/algorithm.

Performance improvements vary on a case by case basis depending on suface size and bpp, so I'll just leave my results here (top one is 32bpp):
![Figure_1](https://github.com/pygame-community/pygame-ce/assets/103119829/485166f8-49c1-471d-9648-385ca9a49443)
