### PR TITLE
Added shim to fix portmidi break

### DIFF
--- a/src_c/cython/pygame/pypm.pyx
+++ b/src_c/cython/pygame/pypm.pyx
@@ -523,7 +523,7 @@ cdef class Output:
 # in commit 64314cc3d1a6fdddfc6ff5408a3f83af685b8cea
 # portmidi changed the signature of Pt_Time from `PMEXPORT PtTimestamp Pt_Time()` to `PMEXPORT PtTimestamp Pt_Time(void)`
 # this change is significant in that no args in a C function declaration is treated differently than void
-cdef PtTimestamp compatShimDueToMidiChange(void* arg) noexcept:
+cdef PtTimestamp pgCompat_Pt_Time(void* arg) noexcept:
     return Pt_Time()
 
 cdef class Input:
@@ -546,7 +546,7 @@ cdef class Input:
         self.debug = 0
 
         err = Pm_OpenInput(&(self.midi), input_device, NULL, buffersize,
-                           &compatShimDueToMidiChange, NULL)
+                           &pgCompat_Pt_Time, NULL)
         if err < 0:
             raise Exception(Pm_GetErrorText(err))
 

--- a/src_c/cython/pygame/pypm.pyx
+++ b/src_c/cython/pygame/pypm.pyx
@@ -106,14 +106,13 @@ cdef extern from "portmidi.h":
                          PmDeviceID inputDevice,
                          void *inputDriverInfo,
                          long bufferSize,
-                         long (*PmPtr) (), # long = PtTimestamp
+                         PmTimeProcPtr time_proc, # long = PtTimestamp
                          void *time_info)
 
     PmError Pm_OpenOutput(PortMidiStream** stream,
                           PmDeviceID outputDevice,
                           void *outputDriverInfo,
                           long bufferSize,
-                          #long (*PmPtr) (), # long = PtTimestamp
                           PmTimeProcPtr time_proc, # long = PtTimestamp
                           void *time_info,
                           long latency)
@@ -521,6 +520,11 @@ cdef class Output:
         while Pt_Time() == cur_time:
             pass
 
+# in commit 64314cc3d1a6fdddfc6ff5408a3f83af685b8cea
+# portmidi changed the signature of Pt_Time from `PMEXPORT PtTimestamp Pt_Time()` to `PMEXPORT PtTimestamp Pt_Time(void)`
+# this change is significant in that no args in a C function declaration is treated differently than void
+cdef PtTimestamp compatShimDueToMidiChange(void* arg) noexcept:
+    return Pt_Time()
 
 cdef class Input:
     """Represents an input MIDI stream device.
@@ -542,7 +546,7 @@ cdef class Input:
         self.debug = 0
 
         err = Pm_OpenInput(&(self.midi), input_device, NULL, buffersize,
-                           &Pt_Time, NULL)
+                           &compatShimDueToMidiChange, NULL)
         if err < 0:
             raise Exception(Pm_GetErrorText(err))
 


### PR DESCRIPTION
Portmidi broke due to a signature change, and it manifested recently with the 2.0.4 release being installed on my sytem. This shim fixes the cython so that we don't get a compiler error when building with newer portmidi