### PR TITLE
Force window surface update after set_size, hopefully proper fix for that pesky frequent pypy test fail

### DIFF
--- a/src_c/window.c
+++ b/src_c/window.c
@@ -570,6 +570,11 @@ window_set_size(pgWindowObject *self, PyObject *arg, void *v)
     }
 
     SDL_SetWindowSize(self->_win, w, h);
+    if (self->surf) {
+        /* Ensure that the underlying surf is immediately updated, instead of
+         * relying on the event callback */
+        self->surf->surf = SDL_GetWindowSurface(self->_win);
+    }
 
     return 0;
 }

--- a/test/window_test.py
+++ b/test/window_test.py
@@ -1,7 +1,6 @@
 import unittest
 import pygame
 import os
-import time
 
 from pygame import Window
 from pygame.version import SDL
@@ -321,23 +320,16 @@ class WindowTypeTest(unittest.TestCase):
         pygame.init()
 
     def test_window_surface(self):
-        # window's surface uses an event callback that may take some time to get
-        # processed by the system event queue - sleep for 1 second to give
-        # the window event queue chance to catch up
         win = Window(size=(640, 480))
-        time.sleep(1)
         surf = win.get_surface()
 
         self.assertIsInstance(surf, pygame.Surface)
 
         # test auto resize
         self.assertTupleEqual(win.size, surf.get_size())
-
         win.size = (100, 100)
-        time.sleep(1)
         self.assertTupleEqual(win.size, surf.get_size())
         win.size = (1280, 720)
-        time.sleep(1)
         self.assertTupleEqual(win.size, surf.get_size())
 
         # window surface should be invalid after the window is destroyed


### PR DESCRIPTION
Reverts the hacky test fix applied in https://github.com/pygame-community/pygame-ce/pull/2832 that didn't work out

This new approach essentially forces the update via `SDL_GetWindowSurface` to happen immediately, so we are now ensuring that the window surface is updated before we even leave the function call.