### PR TITLE
Alter CODEOWNERS file to switch required PR review team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # example. The documentation can be seen here:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @pygame-community/pygame-contributing-admins
+* @pygame-community/pygame-senior-reviewers


### PR DESCRIPTION
The intention being that we can choose to expand our pool of senior reviewers beyond just the current maintainers. This may be important when one of the current maintainers retires from the role but is still active in the project and interested in reviewing. 

I hope expanding this pool might help tackle the current 72 open PR review mountain somewhat over time.

The current "senior/seasoned reviewers" team is here:

https://github.com/orgs/pygame-community/teams/pygame-senior-reviewers

and right now this team is identical with the current maintainers.

Other things we could consider with the CODEOWNERS file:

- Letting Pull Requests with only changes in the docs/ folder pass with just two reviews from any current member of the pygame organisation.
- Having teams or individuals who have the required reviewing power only over *.c files or *.py files if they are only confident in one language.

The file has cascading 'ownership', so more specific ownership lower down the file takes precedence over broader 'ownership' higher up. You can read more about customising the file here:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners