### PR TITLE
Deprecate `setup.py sdist`, suggest and use replacement pypa/build based command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# define files/directories that won't be exported in an sdist
+# Keep in sync with MANIFEST.in
+.circleci/ export-ignore
+.github/ export-ignore
+buildconfig/ci/ export-ignore
+buildconfig/macdependencies/ export-ignore
+buildconfig/manylinux-build/ export-ignore
+
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.pre-commit-config.yaml export-ignore

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -60,15 +60,14 @@ jobs:
       # https://github.com/orgs/community/discussions/47863
       run: |
         sudo apt-get update --fix-missing
-        sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev python3-setuptools python3-dev
+        sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev python3-dev
         pip3 install --upgrade pip
-        pip3 install sphinx"<7.2.0" numpy>=1.21.0
+        pip3 install build numpy>=1.21.0
 
     - name: Make sdist and install it
       run: |
-        python3 buildconfig/make_docs.py
-        python3 setup.py sdist
-        pip3 install dist/pygame-*.tar.gz -vv
+        python3 -m build --sdist --outdir dist .
+        pip3 install dist/pygame_ce-*.tar.gz -vv
 
     - name: Run tests
       env:

--- a/meson.build
+++ b/meson.build
@@ -365,7 +365,7 @@ subdir('src_py')
 
 if not get_option('stripped')
     # run make_docs and make docs
-    if not fs.is_dir('generated')
+    if not fs.is_dir('docs/generated')
         make_docs = files('buildconfig/make_docs.py')
         res = run_command(
             [find_program('python3', 'python'), make_docs],

--- a/setup.py
+++ b/setup.py
@@ -717,6 +717,9 @@ class OurSdist(sdist):
         # we do not want MANIFEST.in to appear in the root cluttering up things.
         self.template = os.path.join('buildconfig', 'MANIFEST.in')
 
+        print("WARNING: This command is deprecated and will be removed in the future.")
+        print("Use the alternative: `python3 -m build --sdist --outdir dist .`")
+
 
 if "bdist_msi" in sys.argv:
     # if you are making an msi, we want it to overwrite files


### PR DESCRIPTION
We can use pypa/build to make an sdist file, now that we have the meson buildconfig.

I added a `.gitattributes` file, to skip a few files and ensure that the generated sdist is identical* to the one generated by `setup.py sdist`

\* There is one point of difference, the `docs/generated` folder is included in the sdist generated by `setup.py sdist`, but not the pypa/build sdist. This is one of the things that will be taken care due to #2853 being merged.

PS: this PR also fixes a little bug in #2853 (so this is a sort of a successor PR to that)