### PR TITLE
Add test & fix for unusual pitch in `surface.premul_alpha()`

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -2841,7 +2841,8 @@ premul_surf_color_by_alpha(SDL_Surface *src, SDL_Surface *dst)
         // since we know dst is a copy of src we can simplify the normal checks
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-    if ((PG_SURF_BytesPerPixel(src) == 4) && pg_has_avx2()) {
+    if ((PG_SURF_BytesPerPixel(src) == 4) &&
+        (src->pitch % PG_SURF_BytesPerPixel(src) == 0) && pg_has_avx2()) {
         premul_surf_color_by_alpha_avx2(src, dst);
         return 0;
     }
@@ -2873,6 +2874,8 @@ premul_surf_color_by_alpha_non_simd(SDL_Surface *src, SDL_Surface *dst)
     int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
     int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 *src_pixels = (Uint8 *)src->pixels;
+    int srcskip = src->pitch - (width * srcbpp);
+    int dstskip = dst->pitch - (width * dstbpp);
     Uint8 *dst_pixels = (Uint8 *)dst->pixels;
 
     int srcpxskip = PG_SURF_BytesPerPixel(src);
@@ -2898,6 +2901,8 @@ premul_surf_color_by_alpha_non_simd(SDL_Surface *src, SDL_Surface *dst)
                 dst_pixels += dstpxskip;
             },
             n, width);
+        src_pixels += srcskip;
+        dst_pixels += dstskip;
     }
 }
 

--- a/src_c/simd_blitters_sse2.c
+++ b/src_c/simd_blitters_sse2.c
@@ -783,7 +783,9 @@ premul_surf_color_by_alpha_sse2(SDL_Surface *src, SDL_Surface *dst)
     int width = src->w;
     int height = src->h;
     Uint32 *srcp = (Uint32 *)src->pixels;
+    int srcskip = src->pitch - width * PG_SURF_BytesPerPixel(src);
     Uint32 *dstp = (Uint32 *)dst->pixels;
+    int dstskip = dst->pitch - width * PG_SURF_BytesPerPixel(dst);
 
     SDL_PixelFormat *srcfmt = src->format;
     Uint32 amask = srcfmt->Amask;
@@ -836,6 +838,8 @@ premul_surf_color_by_alpha_sse2(SDL_Surface *src, SDL_Surface *dst)
                 ++dstp;
             },
             n, width);
+        (Uint8 *)srcp += srcskip;
+        (Uint8 *)dstp += dstskip;
     }
 }
 

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -4029,6 +4029,26 @@ class SurfaceBlendTest(unittest.TestCase):
                         ),
                     )
 
+        def create_surface_from_byte_width(byte_width):
+            surf_height = 5
+            byte_data = bytes(byte_width * surf_height)  # 50 bytes
+            surf_width = byte_width // 4  # width = 2
+
+            dest = pygame.image.frombuffer(
+                byte_data, (surf_width, surf_height), "RGBA", pitch=byte_width
+            )
+            dest.fill((120, 50, 70, 200))
+            return dest
+
+        test_surf = create_surface_from_byte_width(10)
+        test_surf = test_surf.premul_alpha()
+
+        for y in range(0, test_surf.get_height()):
+            for x in range(0, test_surf.get_width()):
+                self.assertEqual(
+                    test_surf.get_at((x, y)), pygame.Color(94, 39, 55, 200)
+                )
+
 
 class SurfaceSelfBlitTest(unittest.TestCase):
     """Blit to self tests.


### PR DESCRIPTION
fixes #2750

From what I understand, these unusual, non-pixel aligned, surface pitches won't practically come up on any modern desktop systems (possibly no modern systems) so I prioritised fixing it for the least performance sensitive versions of this function - sse2 & the non-SIMD fallback. These are also the versions I originally wrote so I had a better idea of how they were supposed to work.

The basic fix is to add in the standard 'skip' value that is used in all the blitters to handle pitch issues between two different surfaces - usually these are pixel aligned. In the SSE2 case, to deal with the .5 of a pixel overlap in the pitch case we have to cast the skip value down to Uint8 to get to 'channel', or single byte, level of pointer incrementing as we only want to skip 2 channels worth of a pixel (2 bytes) rather than a whole pixel (4 bytes).

I think that makes sense anyway.

This probably needs feedback from @itzpr3d4t0r and @Starbuck5 to see if they think what I've changed makes sense and if we need to do anything else here.