### PR TITLE
Add SIMD paths to .set_alpha() blit onto opaque

### DIFF
--- a/src_c/simd_blitters.h
+++ b/src_c/simd_blitters.h
@@ -37,6 +37,8 @@ void
 blit_blend_rgb_min_sse2(SDL_BlitInfo *info);
 void
 blit_blend_premultiplied_sse2(SDL_BlitInfo *info);
+void
+blit_blend_surfalpha_to_opaque_sse2(SDL_BlitInfo *info);
 #endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
 
 /* Deliberately putting these outside of the preprocessor guards as I want to
@@ -83,3 +85,5 @@ void
 blit_blend_premultiplied_avx2(SDL_BlitInfo *info);
 void
 premul_surf_color_by_alpha_avx2(SDL_Surface *src, SDL_Surface *dst);
+void
+blit_blend_surfalpha_to_opaque_avx2(SDL_BlitInfo *info);

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -59,10 +59,7 @@ pg_avx2_at_runtime_but_uncompiled()
     int height = info->height;                                   \
     int i;                                                       \
                                                                  \
-    Uint32 *srcp = (Uint32 *)info->s_pixels;                     \
     const int srcskip = info->s_skip >> 2;                       \
-                                                                 \
-    Uint32 *dstp = (Uint32 *)info->d_pixels;                     \
     const int dstskip = info->d_skip >> 2;                       \
                                                                  \
     const int pxl_excess = width % 8;                            \

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -1653,4 +1653,4 @@ blit_blend_surfalpha_to_opaque_avx2(SDL_BlitInfo *info)
     BAD_AVX2_FUNCTION_CALL;
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
-        * !defined(SDL_DISABLE_IMMINTRIN_H) */
+!defined(SDL_DISABLE_IMMINTRIN_H) */

--- a/src_c/simd_blitters_sse2.c
+++ b/src_c/simd_blitters_sse2.c
@@ -705,13 +705,9 @@ blit_blend_surfalpha_to_opaque_sse2(SDL_BlitInfo *info)
     SETUP_SSE2_BLITTER;
     SETUP_SSE2_16BIT_SHUFFLE_OUT;
 
-    const int _a_off = info->src->Ashift >> 2;
-    const __m128i shuff_out_alpha = _mm_set_epi8(
-        -1, 4 + _a_off, -1, 4 + _a_off, -1, 4 + _a_off, -1, 4 + _a_off, -1,
-        0 + _a_off, -1, 0 + _a_off, -1, 0 + _a_off, -1, 0 + _a_off);
-
     __m128i src_alpha = _mm_set1_epi32(info->src_blanket_alpha);
-    src_alpha = _mm_shuffle_epi8(src_alpha, shuff_out_alpha);
+    src_alpha = _mm_unpacklo_epi16(src_alpha, src_alpha);
+    src_alpha = _mm_shuffle_epi32(src_alpha, _MM_SHUFFLE(2, 2, 0, 0));
     __m128i temp;
 
     RUN_SSE2_BLITTER(RUN_SSE2_16BIT_SHUFFLE_OUT({

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3827,6 +3827,7 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
     int result, suboffsetx = 0, suboffsety = 0;
     SDL_Rect orig_clip, sub_clip;
     Uint8 alpha;
+    SDL_BlendMode blend_mode;
 
     /* passthrough blits to the real surface */
     if (((pgSurfaceObject *)dstobj)->subsurface) {
@@ -3930,6 +3931,10 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
         /* If we have a 32bit source surface with per pixel alpha
            and no RLE we'll use pygame_Blit so we can mimic how SDL1
             behaved */
+        result = pygame_Blit(src, srcrect, dst, dstrect, blend_flags);
+    }
+    else if (!SDL_GetSurfaceBlendMode(src, &blend_mode) &&
+             blend_mode == SDL_BLENDMODE_BLEND) {
         result = pygame_Blit(src, srcrect, dst, dstrect, blend_flags);
     }
     else {

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3934,7 +3934,9 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
         result = pygame_Blit(src, srcrect, dst, dstrect, blend_flags);
     }
     else if (!SDL_GetSurfaceBlendMode(src, &blend_mode) &&
-             blend_mode == SDL_BLENDMODE_BLEND) {
+             blend_mode == SDL_BLENDMODE_BLEND && !pg_HasSurfaceRLE(src) &&
+             !pg_HasSurfaceRLE(dst) && !(src->flags & SDL_RLEACCEL) &&
+             !(dst->flags & SDL_RLEACCEL)) {
         result = pygame_Blit(src, srcrect, dst, dstrect, blend_flags);
     }
     else {

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3937,7 +3937,7 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
              !SDL_GetSurfaceBlendMode(src, &blend_mode) &&
              blend_mode == SDL_BLENDMODE_BLEND && !pg_HasSurfaceRLE(src) &&
              !pg_HasSurfaceRLE(dst) && !(src->flags & SDL_RLEACCEL) &&
-             !(dst->flags & SDL_RLEACCEL)) {
+             !(dst->flags & SDL_RLEACCEL) && (src != dst)) {
         result = pygame_Blit(src, srcrect, dst, dstrect, blend_flags);
     }
     else {

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3933,7 +3933,8 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
             behaved */
         result = pygame_Blit(src, srcrect, dst, dstrect, blend_flags);
     }
-    else if (!SDL_GetSurfaceBlendMode(src, &blend_mode) &&
+    else if (blend_flags != PYGAME_BLEND_ALPHA_SDL2 &&
+             !SDL_GetSurfaceBlendMode(src, &blend_mode) &&
              blend_mode == SDL_BLENDMODE_BLEND && !pg_HasSurfaceRLE(src) &&
              !pg_HasSurfaceRLE(dst) && !(src->flags & SDL_RLEACCEL) &&
              !(dst->flags & SDL_RLEACCEL)) {


### PR DESCRIPTION
The way we currently handle this code uses `SDL_BlitSurface` internally:
```Py
import pygame

pygame.init()

screen = pygame.display.set_mode((500, 500))

s = pygame.Surface((size, size))
s.fill((31, 3, 44))
s.set_alpha(123)

screen.blit(s, (0, 0))
```

Unfortunately, SDL_BlitSurface only implements a "pixel by pixel" approach, which significantly slows down these types of blits. In comparison, performing a similar blit with a natively alpha surface filled with a specific color is substantially faster. This difference is puzzling because, with a surface alpha, we can reuse the same alpha value for all pixels, whereas we cannot do this in the other case.

Moreover, all our alpha blit algorithms are maintained for compatibility reasons. Specifically, these blitters use special alpha blending formulas to conform to older SDL versions, something the set_alpha() blit mode does not address.

Currently, we have an AVX/SSE implementation for set_alpha(), but it only applies when blitting to another surface with alpha. This PR extends the implementation to handle blitting onto an opaque surface.

This PR also adjusts our AVX2 macros to be slightly more efficient and simpler (code size wise).

As expected, the results show a significant improvement:
![image](https://github.com/pygame-community/pygame-ce/assets/103119829/9a83ae01-9c7b-45f3-a569-85b44b5262dc)

![image](https://github.com/pygame-community/pygame-ce/assets/103119829/7a94de02-c827-4bbd-9518-3fe429154715)

A small program to test some sizes and times:
```Py
import pygame
from timeit import timeit

pygame.init()

screen = pygame.display.set_mode((500, 500))

data = []

for size in range(10, 500, 10):
    s = pygame.Surface((size, size))
    s.fill((31, 3, 44))
    s.set_alpha(123)

    tot_time = timeit(lambda: screen.blit(s, (0, 0)), number=10000)
    print(f"Finished size {size} in {tot_time:.8f} seconds")
    data.append(tot_time)

print(f"Total time: {sum(data):.8f} seconds")
```