### PR TITLE
Try re-enabling tests disabled since SDL 2.0.18

### DIFF
--- a/test/event_test.py
+++ b/test/event_test.py
@@ -1,4 +1,5 @@
 import collections
+import os
 import time
 import unittest
 
@@ -818,12 +819,10 @@ class EventModuleTest(unittest.TestCase):
         """Ensure pump() functions properly."""
         pygame.event.pump()
 
-    # @unittest.skipIf(
-    #     os.environ.get("SDL_VIDEODRIVER") == pygame.NULL_VIDEODRIVER,
-    #     'requires the SDL_VIDEODRIVER to be a non-null value',
-    # )
-    # Fails on SDL 2.0.18
-    @unittest.skip("flaky test, and broken on 2.0.18 windows")
+    @unittest.skipIf(
+        os.environ.get("SDL_VIDEODRIVER") == pygame.NULL_VIDEODRIVER,
+        'requires the SDL_VIDEODRIVER to be a non-null value',
+    )
     def test_set_grab__and_get_symmetric(self):
         """Ensure event grabbing can be enabled and disabled.
 
@@ -888,12 +887,10 @@ class EventModuleTest(unittest.TestCase):
 
         self.assertTrue(blocked)
 
-    # @unittest.skipIf(
-    #     os.environ.get("SDL_VIDEODRIVER") == pygame.NULL_VIDEODRIVER,
-    #     'requires the SDL_VIDEODRIVER to be a non-null value',
-    # )
-    # Fails on SDL 2.0.18
-    @unittest.skip("flaky test, and broken on 2.0.18 windows")
+    @unittest.skipIf(
+        os.environ.get("SDL_VIDEODRIVER") == pygame.NULL_VIDEODRIVER,
+        'requires the SDL_VIDEODRIVER to be a non-null value',
+    )
     def test_get_grab(self):
         """Ensure get_grab() works as expected"""
         surf = pygame.display.set_mode((10, 10))

--- a/test/key_test.py
+++ b/test/key_test.py
@@ -186,9 +186,6 @@ class KeyModuleTest(unittest.TestCase):
         """does it import?"""
         import pygame.key
 
-    # fixme: test_get_focused failing systematically in some linux
-    # fixme: test_get_focused failing on SDL 2.0.18 on Windows
-    @unittest.skip("flaky test, and broken on 2.0.18 windows")
     def test_get_focused(self):
         # This test fails in SDL2 in some linux
         # This test was skipped in SDL1.


### PR DESCRIPTION
fixes #1492

These tests work locally on Windows now which seems to have been the main trigger for them being disabled. We'll see if the key test works on the CI.