### PR TITLE
fix some METH_NOARGS arg missing

### DIFF
--- a/src_c/window.c
+++ b/src_c/window.c
@@ -145,7 +145,7 @@ window_destroy(pgWindowObject *self, PyObject *_null)
 }
 
 static PyObject *
-window_get_surface(pgWindowObject *self)
+window_get_surface(pgWindowObject *self, PyObject *_null)
 {
     PyObject *surf = NULL;
     SDL_Surface *_surf;
@@ -185,7 +185,7 @@ window_get_surface(pgWindowObject *self)
 }
 
 static PyObject *
-window_flip(pgWindowObject *self)
+window_flip(pgWindowObject *self, PyObject *_null)
 {
     int result;
 


### PR DESCRIPTION
References:
https://docs.python.org/3/c-api/structures.html#c.METH_NOARGS

why it is important: 
https://blog.pyodide.org/posts/function-pointer-cast-handling/


A parser in CI would be usefull indeed, as only WebAssembly can spot them, and only at runtime.