### PR TITLE
Add SSE2, AVX2 & NEON support to `pygame.print_debug_info()`

### DIFF
--- a/src_py/_debug.py
+++ b/src_py/_debug.py
@@ -8,6 +8,7 @@ from typing import Tuple, Optional, Callable
 from os import environ
 
 from pygame.version import ver
+from pygame.system import get_cpu_instruction_sets
 
 ImportResult = Tuple[str, bool, Optional[Callable]]
 
@@ -60,10 +61,14 @@ def _get_platform_info():
     """
     Internal helper to get platform information
     """
+    cpu_inst_dict = get_cpu_instruction_sets()
+    sse2 = 'Yes' if cpu_inst_dict['SSE2'] else 'No'
+    avx2 = 'Yes' if cpu_inst_dict['AVX2'] else 'No'
+    neon = 'Yes' if cpu_inst_dict['NEON'] else 'No'
     ret = f"Platform:\t\t{platform.platform()}\n"
     ret += f"System:\t\t\t{platform.system()}\n"
     ret += f"System Version:\t\t{platform.version()}\n"
-    ret += f"Processor:\t\t{platform.processor()}\n"
+    ret += f"Processor:\t\t{platform.processor()}\tSSE2: {sse2}\tAVX2: {avx2}\tNEON: {neon}\n"
     ret += (
         f"Architecture:\t\tBits: {platform.architecture()[0]}\t"
         f"Linkage: {platform.architecture()[1]}\n\n"


### PR DESCRIPTION
These are the most common instruction sets we support paths for and could assist us in detecting bugs. There are more instruction sets listed in `system.get_cpu_instuction_sets()` but currently we don't make much use of them in pygame-ce.

Suggested by @Starbuck5 