### PR TITLE
Add a delta of 2 ms to test_music_pause__unpause()

### DIFF
--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -297,7 +297,7 @@ class MixerMusicModuleTest(unittest.TestCase):
         pygame.mixer.music.unpause()
         after_unpause = pygame.mixer.music.get_pos()
 
-        self.assertEqual(before_unpause, after_unpause)
+        self.assertAlmostEqual(before_unpause, after_unpause, delta=2)
 
     def test_music_get_metadata(self):
         file_dir = example_path("data")


### PR DESCRIPTION
The pause/unpause functionality is just not accurate enough for true equality and occasionally fails in unit testing with 1ms difference.

Realistically nobody can hear a 2ms position difference in a sound.

[Recent example](https://github.com/pygame-community/pygame-ce/actions/runs/9332598260/job/25688646290?pr=2654)