### PR TITLE
Update docs of `Surface.get_(f)rect()` and `(F)Rect.move_to()`

### DIFF
--- a/docs/reST/ref/rect.rst
+++ b/docs/reST/ref/rect.rst
@@ -127,12 +127,12 @@
 
       | :sl:`moves the rectangle to the specified position`
       | :sg:`move_to(**kwargs) -> Rect`
-      
-      Returns a new rectangle that is moved to the given position. You must provide keyword
-      arguments to the method such as ``center``, ``left``, ``midbottom`` that correspond
-      to the rectangle's attributes and the method will return a new rectangle whose specified
-      attributes are set to the given value. 
-      
+
+      Returns a new rectangle that is moved to the given position and optionally resized.
+      You must provide keyword arguments to the method such as ``center``, ``left``,
+      ``midbottom``, ``size`` that correspond to the rectangle's attributes and the
+      method will return a new rectangle whose specified attributes are set to the given value.
+
       It is similar to :meth:`Surface.get_rect` but instead of a calling it as a surface method
       you call it as a rectangle method.
 

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -754,7 +754,8 @@
       You can pass keyword argument values to this function. These named values
       will be applied to the attributes of the Rect before it is returned. An
       example would be ``mysurf.get_rect(center=(100, 100))`` to create a
-      rectangle for the Surface centered at a given position.
+      rectangle for the Surface centered at a given position. Size attributes
+      such as ``size`` or ``w`` can also be applied to resize the Rect.
 
       .. ## Surface.get_rect ##
 
@@ -762,14 +763,15 @@
 
       | :sl:`get the rectangular area of the Surface`
       | :sg:`get_frect(\**kwargs) -> FRect`
-      
+
       This is the same as :meth:`Surface.get_rect` but returns an FRect. FRect is similar
       to Rect, except it stores float values instead.
 
       You can pass keyword argument values to this function. These named values
       will be applied to the attributes of the FRect before it is returned. An
       example would be ``mysurf.get_frect(center=(100.5, 100.5))`` to create a
-      rectangle for the Surface centered at a given position.
+      rectangle for the Surface centered at a given position. Size attributes
+      such as ``size`` or ``w`` can also be applied to resize the FRect.
 
       .. ## Surface.get_frect ##
 


### PR DESCRIPTION
As you can see from the changed docs I think I made them clearer. I didn't know you could pass size kwargs myself for a long time. The docs technically didn't hide them, but it's very unclear that they do that. Why?
- Surface.get_rect -> it says the rect will have the surface dimentions, so _intuitively_ you'd think you can't resize it
- Rect.move_to -> the name and the docs only mentions that the rect will be moved to a new position, not that it will also resize it.

Yes, they both say that the kwargs should match the attributes and they don't say those are not allowed, but I think this small update makes it more clear.