### PR TITLE
Contribution Section Added to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,7 +149,18 @@ Dependency versions:
 | SDL_ttf  | >= 2.0.15              |
 +----------+------------------------+
 
+How to Contribute
+-----------------
+First of all, thank you for considering contributing to pygame-ce! It's people like you that make pygame-ce a great library. Please follow these steps to get started:
 
+1. Read the `Contribution Guidelines`_ and the `Many Ways to Contribute`_ wiki pages.
+2. Read the documentataion on `Opening A Pull Request`_ and `Opening a Great Pull Request`_.
+3. Read how to `label and link reported issues`_.
+4. Check the `issue tracker`_ for open issues that interest you or open a new issue to start a discussion about your idea.
+
+There are many more resources throughout the `wiki pages`_ that can help you get started.
+
+If you have any questions, please feel free to ask in the `pygame Discord server`_ or open an issue.
 
 License
 -------
@@ -192,6 +203,14 @@ See docs/licenses for licenses of dependencies.
 .. _Compilation wiki page: https://github.com/pygame-community/pygame-ce/wiki#compiling
 .. _docs page: https://pyga.me/docs
 .. _GNU LGPL version 2.1: https://www.gnu.org/copyleft/lesser.html
+.. _Contribution Guidelines: https://github.com/pygame-community/pygame-ce/wiki/Contribution-guidelines
+.. _Many Ways to Contribute: https://github.com/pygame-community/pygame-ce/wiki/Many-ways-to-contribute
+.. _Opening A Pull Request: https://github.com/pygame-community/pygame-ce/wiki/Opening-a-pull-request
+.. _Opening a Great Pull Request: https://github.com/pygame-community/pygame-ce/wiki/Opening-a-great-pull-request
+.. _issue tracker: https://github.com/pygame-community/pygame-ce/issues
+.. _label and link reported issues: https://github.com/pygame-community/pygame-ce/wiki/Labelling-&-linking-reported-issues
+.. _pygame Discord server: https://discord.gg/pygame
+.. _wiki pages: https://github.com/pygame-community/pygame-ce/wiki
 
 .. _简体中文: ./docs/readmes/README.zh-cn.rst
 .. _Français: ./docs/readmes/README.fr.rst

--- a/README.rst
+++ b/README.rst
@@ -160,7 +160,7 @@ First of all, thank you for considering contributing to pygame-ce! It's people l
 
 There are many more resources throughout the `wiki pages`_ that can help you get started.
 
-If you have any questions, please feel free to ask in the `pygame Discord server`_ or open an issue.
+If you have any questions, please feel free to ask in the `Pygame Community Discord Server`_ or open an issue.
 
 License
 -------
@@ -209,7 +209,7 @@ See docs/licenses for licenses of dependencies.
 .. _Opening a Great Pull Request: https://github.com/pygame-community/pygame-ce/wiki/Opening-a-great-pull-request
 .. _issue tracker: https://github.com/pygame-community/pygame-ce/issues
 .. _label and link reported issues: https://github.com/pygame-community/pygame-ce/wiki/Labelling-&-linking-reported-issues
-.. _pygame Discord server: https://discord.gg/pygame
+.. _Pygame Community Discord Server: https://discord.gg/pygame
 .. _wiki pages: https://github.com/pygame-community/pygame-ce/wiki
 
 .. _简体中文: ./docs/readmes/README.zh-cn.rst


### PR DESCRIPTION
### Why Change was Made
As previously stated, sifting through all the project docs to figure out how to contribute was a bit of a maze. It took some digging and hopping between wiki pages to find what I needed. After some good discussion, it was clear that the addition of another file such as `CONTRIBUTING.md` would be unnecessary and not for the pygame GitHub. However, even though the addition of a whole other file was not the right call, the need for a place that will guide new and existing contributors to the documentation in the wiki pages related to contributing was still there. 

### Why pygame CE should accept changes
If pygame CE accepts these changes, I know that it will speed-up the onboarding process for contributors, making it more inviting for new folks to jump in and for seasoned contributors to navigate with ease. Additionally, it will lessen the amount of questions people have about how to get started or where to find essential information. It is a win-win all around!

### What I did
A small "How to Contribute" section was added to the `README.rst`. It provides a short and concise summary of where to find the documentation in the wiki pages about contributing to pygame-ce. 

This pull request addresses the following:

- Changes requested in PR #2892 
- Issue #2883 
