### PR TITLE
Allow degenerate circles (radius = 0)

### DIFF
--- a/docs/reST/ref/geometry.rst
+++ b/docs/reST/ref/geometry.rst
@@ -39,11 +39,6 @@
       ((x, y), radius)
       (x, y, radius)
 
-   It is important to note that you cannot create degenerate circles, which are circles with
-   a radius of 0 or less. If you try to create such a circle, the `Circle` object will not be
-   created and an error will be raised. This is because a circle with a radius of 0 or
-   less is not a valid geometric object.
-
    The `Circle` class has both virtual and non-virtual attributes. Non-virtual attributes
    are attributes that are stored in the `Circle` object itself. Virtual attributes are the
    result of calculations that utilize the Circle's non-virtual attributes.
@@ -90,6 +85,9 @@
          The circle will not be moved from its original position.
 
          .. versionadded:: 2.4.0
+
+         .. versionchanged:: 2.5.1 It is allowed to create degenerate circles with radius
+            equal to ``0``. This also applies to virtual attributes.
 
          .. ## Circle.r ##
 

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -47,8 +47,8 @@ pg_circle_init(pgCircleObject *self, PyObject *args, PyObject *kwds)
         PyErr_SetString(
             PyExc_TypeError,
             "Arguments must be a Circle, a sequence of length 3 or 2, or an "
-            "object with an attribute called 'circle' and the radius must be "
-            "nonnegative");
+            "object with an attribute called 'circle', all with corresponding "
+            "nonnegative radius argument");
         return -1;
     }
     return 0;

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -48,7 +48,7 @@ pg_circle_init(pgCircleObject *self, PyObject *args, PyObject *kwds)
             PyExc_TypeError,
             "Arguments must be a Circle, a sequence of length 3 or 2, or an "
             "object with an attribute called 'circle' and the radius must be "
-            ">= 0");
+            "nonnegative");
         return -1;
     }
     return 0;
@@ -496,7 +496,7 @@ pg_circle_setr(pgCircleObject *self, PyObject *value, void *closure)
     }
 
     if (radius < 0) {
-        PyErr_SetString(PyExc_ValueError, "Radius must be >= 0");
+        PyErr_SetString(PyExc_ValueError, "Radius must be nonnegative");
         return -1;
     }
 
@@ -526,7 +526,7 @@ pg_circle_setr_sqr(pgCircleObject *self, PyObject *value, void *closure)
 
     if (radius_squared < 0) {
         PyErr_SetString(PyExc_ValueError,
-                        "Invalid radius squared value, must be >= 0");
+                        "Invalid radius squared value, must be nonnegative");
         return -1;
     }
 
@@ -572,7 +572,8 @@ pg_circle_setarea(pgCircleObject *self, PyObject *value, void *closure)
     }
 
     if (area < 0) {
-        PyErr_SetString(PyExc_ValueError, "Invalid area value, must be >= 0");
+        PyErr_SetString(PyExc_ValueError,
+                        "Invalid area value, must be nonnegative");
         return -1;
     }
 
@@ -603,7 +604,7 @@ pg_circle_setcircumference(pgCircleObject *self, PyObject *value,
 
     if (circumference < 0) {
         PyErr_SetString(PyExc_ValueError,
-                        "Invalid circumference value, must be >= 0");
+                        "Invalid circumference value, must be nonnegative");
         return -1;
     }
 
@@ -633,7 +634,7 @@ pg_circle_setdiameter(pgCircleObject *self, PyObject *value, void *closure)
 
     if (diameter < 0) {
         PyErr_SetString(PyExc_ValueError,
-                        "Invalid diameter value, must be >= 0");
+                        "Invalid diameter value, must be nonnegative");
         return -1;
     }
 

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -47,7 +47,8 @@ pg_circle_init(pgCircleObject *self, PyObject *args, PyObject *kwds)
         PyErr_SetString(
             PyExc_TypeError,
             "Arguments must be a Circle, a sequence of length 3 or 2, or an "
-            "object with an attribute called 'circle'");
+            "object with an attribute called 'circle' and the radius must be "
+            ">= 0");
         return -1;
     }
     return 0;
@@ -494,8 +495,8 @@ pg_circle_setr(pgCircleObject *self, PyObject *value, void *closure)
         return -1;
     }
 
-    if (radius <= 0) {
-        PyErr_SetString(PyExc_ValueError, "Radius must be positive");
+    if (radius < 0) {
+        PyErr_SetString(PyExc_ValueError, "Radius must be >= 0");
         return -1;
     }
 
@@ -523,9 +524,9 @@ pg_circle_setr_sqr(pgCircleObject *self, PyObject *value, void *closure)
         return -1;
     }
 
-    if (radius_squared <= 0) {
+    if (radius_squared < 0) {
         PyErr_SetString(PyExc_ValueError,
-                        "Invalid radius squared value, must be > 0");
+                        "Invalid radius squared value, must be >= 0");
         return -1;
     }
 
@@ -570,8 +571,8 @@ pg_circle_setarea(pgCircleObject *self, PyObject *value, void *closure)
         return -1;
     }
 
-    if (area <= 0) {
-        PyErr_SetString(PyExc_ValueError, "Invalid area value, must be > 0");
+    if (area < 0) {
+        PyErr_SetString(PyExc_ValueError, "Invalid area value, must be >= 0");
         return -1;
     }
 
@@ -600,9 +601,9 @@ pg_circle_setcircumference(pgCircleObject *self, PyObject *value,
         return -1;
     }
 
-    if (circumference <= 0) {
+    if (circumference < 0) {
         PyErr_SetString(PyExc_ValueError,
-                        "Invalid circumference value, must be > 0");
+                        "Invalid circumference value, must be >= 0");
         return -1;
     }
 
@@ -630,9 +631,9 @@ pg_circle_setdiameter(pgCircleObject *self, PyObject *value, void *closure)
         return -1;
     }
 
-    if (diameter <= 0) {
+    if (diameter < 0) {
         PyErr_SetString(PyExc_ValueError,
-                        "Invalid diameter value, must be > 0");
+                        "Invalid diameter value, must be >= 0");
         return -1;
     }
 

--- a/src_c/geometry_common.c
+++ b/src_c/geometry_common.c
@@ -4,7 +4,7 @@ int
 _pg_circle_set_radius(PyObject *value, pgCircleBase *circle)
 {
     double radius = 0.0;
-    if (!pg_DoubleFromObj(value, &radius) || radius <= 0.0) {
+    if (!pg_DoubleFromObj(value, &radius) || radius < 0.0) {
         return 0;
     }
     circle->r = radius;

--- a/test/geometry_test.py
+++ b/test/geometry_test.py
@@ -183,7 +183,7 @@ class CircleTypeTest(unittest.TestCase):
             with self.assertRaises(TypeError):
                 c.radius = value
 
-        for value in (-10.3234, -1, 0, 0.0):
+        for value in (-10.3234, -1):
             with self.assertRaises(ValueError):
                 c.r = value
             with self.assertRaises(ValueError):
@@ -317,7 +317,7 @@ class CircleTypeTest(unittest.TestCase):
             with self.assertRaises(TypeError):
                 c.area = value
 
-        for value in (-10.3234, -1, 0, 0.0):
+        for value in (-10.3234, -1):
             with self.assertRaises(ValueError):
                 c.area = value
 
@@ -352,7 +352,7 @@ class CircleTypeTest(unittest.TestCase):
             with self.assertRaises(TypeError):
                 c.circumference = value
 
-        for value in (-10.3234, -1, 0, 0.0):
+        for value in (-10.3234, -1):
             with self.assertRaises(ValueError):
                 c.circumference = value
 
@@ -390,7 +390,7 @@ class CircleTypeTest(unittest.TestCase):
             with self.assertRaises(TypeError):
                 c.diameter = value
 
-        for value in (-10.3234, -1, 0, 0.0):
+        for value in (-10.3234, -1):
             with self.assertRaises(ValueError):
                 c.diameter = value
             with self.assertRaises(ValueError):

--- a/test/geometry_test.py
+++ b/test/geometry_test.py
@@ -95,6 +95,13 @@ class CircleTypeTest(unittest.TestCase):
         self.assertEqual(2.0, c.y)
         self.assertEqual(3.0, c.r)
 
+    def testConstruction_zero_radius(self):
+        c = Circle(1, 2, 0)
+
+        self.assertEqual(1.0, c.x)
+        self.assertEqual(2.0, c.y)
+        self.assertEqual(0, c.r)
+
     def test_x(self):
         """Ensures changing the x attribute moves the circle and does not change
         the circle's radius.


### PR DESCRIPTION
### note: I've modified the circle init error message to include the radius, as it was _very_ unclear before. If you don't want degenerate circles, this modification should still be added IMHO, so let me know.

I've slightly modified the code, the tests and the docs to allow degenerate circles to exist.
I've run through every line where the radius attribute is used and I checked for divisions with the radius but they were not present.
Why?
- You can create 'degenerate' rects by passing 0 as width and height, so for consistency I think you should be able to create degenerate circles aswell
- It will unintentionally be treated like a point when checking for collisions, and virtual attributes will be automatically affected
- degenerate circles are still considered circles in analitic geometry so I would consider them colliders
- If degenerate rects are valid colliders/shapes, degenerate circles should aswell

Tell me if you'd like more tests or if I missed something.
Of course you can not agree with allowing degenerate circles, I made this pull request so that if you think they should be there, you'll find a PR ready for it.