### PR TITLE
Update OpenGL Viewport when Window resizes

### DIFF
--- a/src_c/window.c
+++ b/src_c/window.c
@@ -605,7 +605,7 @@ window_set_size(pgWindowObject *self, PyObject *arg, void *v)
         self->surf->surf = SDL_GetWindowSurface(self->_win);
     }
     if (self->context) {
-        /* Update the OpenGl viewport immediately instead of relying on the
+        /* Update the OpenGL viewport immediately instead of relying on the
          * event callback */
         _window_opengl_set_viewport(self->_win, self->context, w, h);
     }

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -223,7 +223,7 @@ _window_opengl_set_viewport(SDL_Window *window, SDL_GLContext context,
         return -1;
     }
     if (p_glViewport == NULL) {
-        PyErr_SetString(pgExc_SDLError, "glViewport is unavailable");
+        PyErr_SetString(pgExc_SDLError, "glViewport function is unavailable");
         return -1;
     }
     p_glViewport(0, 0, wnew, hnew);
@@ -255,7 +255,8 @@ _resize_event_watch(void *userdata, SDL_Event *event)
         if (_window_opengl_set_viewport(event_window, event_window_pg->context,
                                         event->window.data1,
                                         event->window.data2) < 0) {
-            PyErr_Clear();
+            return PyErr_WarnEx(PyExc_RuntimeWarning,
+                                "Failed to set OpenGL viewport", 0);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/pygame-community/pygame-ce/issues/2877
The documentation has been updated by MyreMylar already.

As stated in the issue, the newly functional OpenGL `Window`s, unlike the display windows, would not resize the OpenGL viewport causing bugs and inconsistencies.

With the addition of a function, used both in the event watch and in the `set_size` function, the OpenGl viewport is now correctly updated. I tested locally, it works for fullscreen/maximization/autoresize/manualresize.

If it works for you too (should, it's identical to the display's one), I think this should be added not later than 2.5.1