### PR TITLE
More SDL3 compat: Surface things

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -191,7 +191,9 @@ struct SDL_BlitMap {
 #define SDL_COPY_RLE_DESIRED 0x00001000
 
 #define PG_SurfaceHasRLE(surface) \
-    ((surface == NULL) ? 0 : (surface->map->info.flags & SDL_COPY_RLE_DESIRED))
+    (((surface) == NULL)          \
+         ? 0                      \
+         : ((surface)->map->info.flags & SDL_COPY_RLE_DESIRED))
 
 #endif
 

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -190,8 +190,9 @@ struct SDL_BlitMap {
 };
 #define SDL_COPY_RLE_DESIRED 0x00001000
 
-SDL_bool
-PG_SurfaceHasRLE(SDL_Surface *surface);
+#define PG_SurfaceHasRLE(surface) \
+    ((surface == NULL) ? 0 : (surface->map->info.flags & SDL_COPY_RLE_DESIRED))
+
 #endif
 
 #endif

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -786,10 +786,10 @@ aacircle(PyObject *self, PyObject *args, PyObject *kwargs)
     surf = pgSurface_AsSurface(surfobj);
     SURF_INIT_CHECK(surf)
 
-    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+    if (PG_SURF_BytesPerPixel(surf) <= 0 || PG_SURF_BytesPerPixel(surf) > 4) {
         return PyErr_Format(PyExc_ValueError,
                             "unsupported surface bit depth (%d) for drawing",
-                            surf->format->BytesPerPixel);
+                            PG_SURF_BytesPerPixel(surf));
     }
 
     CHECK_LOAD_COLOR(colorobj)

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -32,23 +32,6 @@ typedef struct tColorRGBA {
 #define M_PI 3.141592654
 #endif
 
-#if !SDL_VERSION_ATLEAST(2, 0, 14)
-// Remove this when our minimum version is 2.0.14 or larger
-SDL_bool
-PG_SurfaceHasRLE(SDL_Surface *surface)
-{
-    if (surface == NULL) {
-        return SDL_FALSE;
-    }
-
-    if (!(surface->map->info.flags & SDL_COPY_RLE_DESIRED)) {
-        return SDL_FALSE;
-    }
-
-    return SDL_TRUE;
-}
-#endif
-
 /*
 
  32bit Zoomer with optional anti-aliasing by bilinear interpolation.

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -63,41 +63,6 @@ typedef struct pg_bufferinternal_s {
     Py_ssize_t mem[6];      /* Enough memory for dim 3 shape and strides  */
 } pg_bufferinternal;
 
-/* copy of SDL Blit mapping definitions to enable pointer casting hack
-   for checking state of the SDL_COPY_RLE_DESIRED flag */
-#define PGS_COPY_RLE_DESIRED 0x00001000
-
-typedef struct {
-    Uint8 *src;
-    int src_w, src_h;
-    int src_pitch;
-    int src_skip;
-    Uint8 *dst;
-    int dst_w, dst_h;
-    int dst_pitch;
-    int dst_skip;
-    SDL_PixelFormat *src_fmt;
-    SDL_PixelFormat *dst_fmt;
-    Uint8 *table;
-    int flags;
-    Uint32 colorkey;
-    Uint8 r, g, b, a;
-} pg_BlitInfo;
-
-typedef struct pg_BlitMap {
-    SDL_Surface *dst;
-    int identity;
-    SDL_blit blit;
-    void *data;
-    pg_BlitInfo info;
-
-    /* the version count matches the destination; mismatch indicates
-       an invalid mapping */
-    Uint32 dst_palette_version;
-    Uint32 src_palette_version;
-} pg_BlitMap;
-/* end PGS_COPY_RLE_DESIRED hack definitions */
-
 int
 pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
                SDL_Rect *dstrect, SDL_Rect *srcrect, int blend_flags);
@@ -2383,25 +2348,6 @@ surf_scroll(PyObject *self, PyObject *args, PyObject *keywds)
     Py_RETURN_NONE;
 }
 
-int
-pg_HasSurfaceRLE(SDL_Surface *surface)
-{
-    pg_BlitMap *blit_map;
-    /* this is part of a hack to allow us to access
-       the COPY_RLE_DESIRED flag from pygame */
-    if (!surface) {
-        return SDL_FALSE;
-    }
-
-    blit_map = (pg_BlitMap *)surface->map;
-
-    if (!(blit_map->info.flags & PGS_COPY_RLE_DESIRED)) {
-        return SDL_FALSE;
-    }
-
-    return SDL_TRUE;
-}
-
 static int
 _PgSurface_SrcAlpha(SDL_Surface *surf)
 {
@@ -2443,7 +2389,7 @@ surf_get_flags(PyObject *self, PyObject *_null)
         flags |= PGS_SRCCOLORKEY;
     if (sdl_flags & SDL_PREALLOC)
         flags |= PGS_PREALLOC;
-    if (pg_HasSurfaceRLE(surf))
+    if (PG_SurfaceHasRLE(surf))
         flags |= PGS_RLEACCELOK;
     if ((sdl_flags & SDL_RLEACCEL))
         flags |= PGS_RLEACCEL;
@@ -3925,7 +3871,7 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
               PG_SURF_BytesPerPixel(dst) == 2) &&
              _PgSurface_SrcAlpha(src) &&
              (SDL_ISPIXELFORMAT_ALPHA(src->format->format)) &&
-             !pg_HasSurfaceRLE(src) && !pg_HasSurfaceRLE(dst) &&
+             !PG_SurfaceHasRLE(src) && !PG_SurfaceHasRLE(dst) &&
              !(src->flags & SDL_RLEACCEL) && !(dst->flags & SDL_RLEACCEL)) {
         /* If we have a 32bit source surface with per pixel alpha
            and no RLE we'll use pygame_Blit so we can mimic how SDL1

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -2309,9 +2309,12 @@ modify_hsl(SDL_Surface *surf, SDL_Surface *dst, float h, float s, float l)
         }
     }
 
-    if (PG_FORMAT_BytesPerPixel(fmt) == 4 || PG_FORMAT_BytesPerPixel(fmt) == 3) {
-        const int src_skip = surf->pitch - surf->w * PG_FORMAT_BytesPerPixel(fmt);
-        const int dst_skip = dst->pitch - dst->w * PG_FORMAT_BytesPerPixel(fmt);
+    if (PG_FORMAT_BytesPerPixel(fmt) == 4 ||
+        PG_FORMAT_BytesPerPixel(fmt) == 3) {
+        const int src_skip =
+            surf->pitch - surf->w * PG_FORMAT_BytesPerPixel(fmt);
+        const int dst_skip =
+            dst->pitch - dst->w * PG_FORMAT_BytesPerPixel(fmt);
 
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
         const int Ridx = fmt->Rshift >> 3;

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -2309,9 +2309,9 @@ modify_hsl(SDL_Surface *surf, SDL_Surface *dst, float h, float s, float l)
         }
     }
 
-    if (fmt->BytesPerPixel == 4 || fmt->BytesPerPixel == 3) {
-        const int src_skip = surf->pitch - surf->w * fmt->BytesPerPixel;
-        const int dst_skip = dst->pitch - dst->w * fmt->BytesPerPixel;
+    if (PG_FORMAT_BytesPerPixel(fmt) == 4 || PG_FORMAT_BytesPerPixel(fmt) == 3) {
+        const int src_skip = surf->pitch - surf->w * PG_FORMAT_BytesPerPixel(fmt);
+        const int dst_skip = dst->pitch - dst->w * PG_FORMAT_BytesPerPixel(fmt);
 
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
         const int Ridx = fmt->Rshift >> 3;
@@ -2351,8 +2351,8 @@ modify_hsl(SDL_Surface *surf, SDL_Surface *dst, float h, float s, float l)
                 dstp8[Gidx] = g;
                 dstp8[Bidx] = b;
 
-                srcp8 += fmt->BytesPerPixel;
-                dstp8 += fmt->BytesPerPixel;
+                srcp8 += PG_FORMAT_BytesPerPixel(fmt);
+                dstp8 += PG_FORMAT_BytesPerPixel(fmt);
             }
             srcp8 += src_skip;
             dstp8 += dst_skip;
@@ -2459,7 +2459,7 @@ surf_hsl(PyObject *self, PyObject *args, PyObject *kwargs)
     if (src->format->Rmask != dst->format->Rmask ||
         src->format->Gmask != dst->format->Gmask ||
         src->format->Bmask != dst->format->Bmask ||
-        src->format->BytesPerPixel != dst->format->BytesPerPixel) {
+        PG_SURF_BytesPerPixel(src) != PG_SURF_BytesPerPixel(dst)) {
         return RAISE(PyExc_ValueError,
                      "Source and destination surfaces need the same format.");
     }


### PR DESCRIPTION
Adds surface BPP macros to new code that slipped around https://github.com/pygame-community/pygame-ce/pull/2804

Makes PG_SurfaceHasRLE work everywhere, not just in rotozoom, and uses it to replace a nearly identical hack in surface.c, but with a strategy that instead calls an SDL function in SDL 2.0.14 and above (which works in SDL3, where the original hack doesn't).