### PR TITLE
Fix scaled-after-non-scaled usage

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1215,6 +1215,15 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                     SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY,
                                             "nearest", SDL_HINT_DEFAULT);
 
+#if SDL_VERSION_ATLEAST(2, 28, 0)
+                    /* If the window has a surface associated with it already,
+                     * we need to destroy it (if possible) because now we are
+                     * associating a renderer with it. */
+                    if (SDL_HasWindowSurface(win)) {
+                        SDL_DestroyWindowSurface(win);
+                    }
+#endif
+
                     if (vsync) {
                         pg_renderer = SDL_CreateRenderer(
                             win, -1, SDL_RENDERER_PRESENTVSYNC);
@@ -1224,8 +1233,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                     }
 
                     if (pg_renderer == NULL) {
-                        return RAISE(pgExc_SDLError,
-                                     "failed to create renderer");
+                        return RAISE(pgExc_SDLError, SDL_GetError());
                     }
 
                     if (flags & PGS_SCALED) {


### PR DESCRIPTION
this PR fixes #2737 and fixes #2376 (they are essentially the same issue).

Note that I couldn't reproduce the original issue on Ubuntu, however @zoldalma999 has tested this branch and reported that this fix has worked on windows. Would be nice if someone gave this a test on a mac as well.

Also worth mentioning that the fix only works for SDL 2.28.0+, but all the wheels we distribute are on 2.30.3 so this shouldn't be a big deal.

It was also mentioned in one of the linked issues that #2571 is also the same issue, but I don't think that's the case.