### PR TITLE
Remove SDL v1.2.10 checks in display.c

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -284,18 +284,6 @@ pg_vidinfo_getattr(PyObject *self, char *name)
 {
     pg_VideoInfo *info = &((pgVidInfoObject *)self)->info;
 
-    int current_w = -1;
-    int current_h = -1;
-
-    SDL_version versioninfo;
-    SDL_VERSION(&versioninfo);
-
-    if (versioninfo.major > 1 ||
-        (versioninfo.minor >= 2 && versioninfo.patch >= 10)) {
-        current_w = info->current_w;
-        current_h = info->current_h;
-    }
-
     if (!strcmp(name, "hw"))
         return PyLong_FromLong(info->hw_available);
     else if (!strcmp(name, "wm"))
@@ -330,9 +318,9 @@ pg_vidinfo_getattr(PyObject *self, char *name)
         return Py_BuildValue("(iiii)", info->vfmt->Rloss, info->vfmt->Gloss,
                              info->vfmt->Bloss, info->vfmt->Aloss);
     else if (!strcmp(name, "current_h"))
-        return PyLong_FromLong(current_h);
+        return PyLong_FromLong(info->current_h);
     else if (!strcmp(name, "current_w"))
-        return PyLong_FromLong(current_w);
+        return PyLong_FromLong(info->current_w);
     else if (!strcmp(name, "pixel_format")) {
         const char *pixel_format_name =
             SDL_GetPixelFormatName(info->vfmt->format);
@@ -348,21 +336,10 @@ pg_vidinfo_getattr(PyObject *self, char *name)
 PyObject *
 pg_vidinfo_str(PyObject *self)
 {
-    int current_w = -1;
-    int current_h = -1;
     pg_VideoInfo *info = &((pgVidInfoObject *)self)->info;
     const char *pixel_format_name = SDL_GetPixelFormatName(info->vfmt->format);
     if (!strncmp(pixel_format_name, "SDL_", 4)) {
         pixel_format_name += 4;
-    }
-
-    SDL_version versioninfo;
-    SDL_VERSION(&versioninfo);
-
-    if (versioninfo.major > 1 ||
-        (versioninfo.minor >= 2 && versioninfo.patch >= 10)) {
-        current_w = info->current_w;
-        current_h = info->current_h;
     }
 
     return PyUnicode_FromFormat(
@@ -383,7 +360,7 @@ pg_vidinfo_str(PyObject *self)
         info->vfmt->Gmask, info->vfmt->Bmask, info->vfmt->Amask,
         info->vfmt->Rshift, info->vfmt->Gshift, info->vfmt->Bshift,
         info->vfmt->Ashift, info->vfmt->Rloss, info->vfmt->Gloss,
-        info->vfmt->Bloss, info->vfmt->Aloss, current_w, current_h,
+        info->vfmt->Bloss, info->vfmt->Aloss, info->current_w, info->current_h,
         pixel_format_name);
 }
 


### PR DESCRIPTION
Ran into this while working on SDL3 support, since they changed how version number getting works. Removing this is an easy win though, regardless.