### PR TITLE
Fix failing tests based on numpy v2

### DIFF
--- a/test/pixelcopy_test.py
+++ b/test/pixelcopy_test.py
@@ -534,7 +534,7 @@ class PixelCopyTestWithArrayNumpy(unittest.TestCase):
 
     def test_map_array(self):
         try:
-            from numpy import array, zeros, uint8, int32, alltrue
+            from numpy import array, zeros, uint8, int32, all as np_all
         except ImportError:
             return
 
@@ -545,7 +545,7 @@ class PixelCopyTestWithArrayNumpy(unittest.TestCase):
         target = zeros((5, 7), int32)
         map_array(target, color, surf)
 
-        self.assertTrue(alltrue(target == surf.map_rgb(color)))
+        self.assertTrue(np_all(target == surf.map_rgb(color)))
 
         # array column stripes
         stripe = array([[2, 5, 7], [11, 19, 23], [37, 53, 101]], uint8)
@@ -553,7 +553,7 @@ class PixelCopyTestWithArrayNumpy(unittest.TestCase):
         map_array(target, stripe, surf)
         target_stripe = array([surf.map_rgb(c) for c in stripe], int32)
 
-        self.assertTrue(alltrue(target == target_stripe))
+        self.assertTrue(np_all(target == target_stripe))
 
         # array row stripes
         stripe = array(
@@ -563,7 +563,7 @@ class PixelCopyTestWithArrayNumpy(unittest.TestCase):
         map_array(target, stripe, surf)
         target_stripe = array([[surf.map_rgb(c)] for c in stripe[:, 0]], int32)
 
-        self.assertTrue(alltrue(target == target_stripe))
+        self.assertTrue(np_all(target == target_stripe))
 
         # mismatched shape
         w = 4

--- a/test/sndarray_test.py
+++ b/test/sndarray_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from numpy import int8, int16, uint8, uint16, float32, array, alltrue
+from numpy import int8, int16, uint8, uint16, float32, array, all as np_all
 
 import pygame
 import pygame.sndarray
@@ -28,7 +28,7 @@ class SndarrayTest(unittest.TestCase):
                     arr = pygame.sndarray.array(snd)
                     self._assert_compatible(arr, size)
                     self.assertTrue(
-                        alltrue(arr == srcarr),
+                        np_all(arr == srcarr),
                         "size: %i\n%s\n%s" % (size, arr, test_data),
                     )
             finally:
@@ -71,7 +71,7 @@ class SndarrayTest(unittest.TestCase):
                     snd = pygame.sndarray.make_sound(srcarr)
                     arr = pygame.sndarray.samples(snd)
                     self.assertTrue(
-                        alltrue(arr == srcarr),
+                        np_all(arr == srcarr),
                         "size: %i\n%s\n%s" % (size, arr, test_data),
                     )
             finally:
@@ -110,7 +110,7 @@ class SndarrayTest(unittest.TestCase):
                     samples[...] = test_data
                     arr = pygame.sndarray.array(snd)
                     self.assertTrue(
-                        alltrue(samples == arr),
+                        np_all(samples == arr),
                         "size: %i\n%s\n%s" % (size, arr, test_data),
                     )
             finally:

--- a/test/sndarray_test.py
+++ b/test/sndarray_test.py
@@ -41,7 +41,7 @@ class SndarrayTest(unittest.TestCase):
             16, 2, [[0, 0xFFFF], [0xFFFF, 0], [0x00FF, 0xFF00], [0x0F0F, 0xF0F0]]
         )
         check_array(-8, 1, [0, -0x80, 0x7F, 0x64])
-        check_array(-8, 2, [[0, -0x80], [-0x64, 0x64], [0x25, -0x50], [0xFF, 0]])
+        check_array(-8, 2, [[0, -0x80], [-0x64, 0x64], [0x25, -0x50], [0x7F, 0]])
         check_array(-16, 1, [0, 0x7FFF, -0x7FFF, -1])
         check_array(-16, 2, [[0, -0x7FFF], [-0x7FFF, 0], [0x7FFF, 0], [0, 0x7FFF]])
 
@@ -84,7 +84,7 @@ class SndarrayTest(unittest.TestCase):
             16, 2, [[0, 0xFFFF], [0xFFFF, 0], [0x00FF, 0xFF00], [0x0F0F, 0xF0F0]]
         )
         check_sound(-8, 1, [0, -0x80, 0x7F, 0x64])
-        check_sound(-8, 2, [[0, -0x80], [-0x64, 0x64], [0x25, -0x50], [0xFF, 0]])
+        check_sound(-8, 2, [[0, -0x80], [-0x64, 0x64], [0x25, -0x50], [0x7F, 0]])
         check_sound(-16, 1, [0, 0x7FFF, -0x7FFF, -1])
         check_sound(-16, 2, [[0, -0x7FFF], [-0x7FFF, 0], [0x7FFF, 0], [0, 0x7FFF]])
         check_sound(32, 2, [[0.0, -1.0], [-1.0, 0], [1.0, 0], [0, 1.0]])
@@ -123,7 +123,7 @@ class SndarrayTest(unittest.TestCase):
             16, 2, [[0, 0xFFFF], [0xFFFF, 0], [0x00FF, 0xFF00], [0x0F0F, 0xF0F0]]
         )
         check_sample(-8, 1, [0, -0x80, 0x7F, 0x64])
-        check_sample(-8, 2, [[0, -0x80], [-0x64, 0x64], [0x25, -0x50], [0xFF, 0]])
+        check_sample(-8, 2, [[0, -0x80], [-0x64, 0x64], [0x25, -0x50], [0x7F, 0]])
         check_sample(-16, 1, [0, 0x7FFF, -0x7FFF, -1])
         check_sample(-16, 2, [[0, -0x7FFF], [-0x7FFF, 0], [0x7FFF, 0], [0, 0x7FFF]])
         check_sample(32, 2, [[0.0, -1.0], [-1.0, 0], [1.0, 0], [0, 1.0]])

--- a/test/surfarray_test.py
+++ b/test/surfarray_test.py
@@ -12,6 +12,7 @@ from numpy import (
     all as np_all,
     rint,
     arange,
+    __version__ as np_version,
 )
 
 import pygame
@@ -560,6 +561,11 @@ class SurfarrayModuleTest(unittest.TestCase):
             self._make_array2d(uint8),
         )
 
+    @unittest.skipIf(
+        int(np_version.split(".")[0]) >= 2,
+        "This test fails due to a change in numpy 2.0.0, and a 'proper fix' "
+        "requires an API/behaviour change",
+    )
     def test_pixels2d(self):
         sources = [
             self._make_surface(8),

--- a/test/surfarray_test.py
+++ b/test/surfarray_test.py
@@ -9,7 +9,7 @@ from numpy import (
     zeros,
     float32,
     float64,
-    alltrue,
+    all as np_all,
     rint,
     arange,
 )
@@ -235,7 +235,7 @@ class SurfarrayModuleTest(unittest.TestCase):
                         ),
                     )
             else:
-                self.assertTrue(alltrue(arr == 255))
+                self.assertTrue(np_all(arr == 255))
 
         # No per-pixel alpha when blanket alpha is None.
         for surf in targets:
@@ -243,7 +243,7 @@ class SurfarrayModuleTest(unittest.TestCase):
             surf.set_alpha(None)
             arr = pygame.surfarray.array_alpha(surf)
             self.assertTrue(
-                alltrue(arr == 255),
+                np_all(arr == 255),
                 "All alpha values should be 255 when"
                 " surf.set_alpha(None) has been set."
                 " bitsize: %i, flags: %i" % (surf.get_bitsize(), surf.get_flags()),
@@ -257,12 +257,12 @@ class SurfarrayModuleTest(unittest.TestCase):
             arr = pygame.surfarray.array_alpha(surf)
             if surf.get_masks()[3]:
                 self.assertFalse(
-                    alltrue(arr == 255),
+                    np_all(arr == 255),
                     "bitsize: %i, flags: %i" % (surf.get_bitsize(), surf.get_flags()),
                 )
             else:
                 self.assertTrue(
-                    alltrue(arr == 255),
+                    np_all(arr == 255),
                     "bitsize: %i, flags: %i" % (surf.get_bitsize(), surf.get_flags()),
                 )
             surf.set_alpha(blanket_alpha)
@@ -290,7 +290,7 @@ class SurfarrayModuleTest(unittest.TestCase):
                 p = [surf.unmap_rgb(surf.map_rgb(c)) for c in p]
             surf.set_colorkey(None)
             arr = pygame.surfarray.array_colorkey(surf)
-            self.assertTrue(alltrue(arr == 255))
+            self.assertTrue(np_all(arr == 255))
 
             for i in range(1, len(palette)):
                 surf.set_colorkey(p[i])


### PR DESCRIPTION
Using the [ruff plugin suggested in NumPy 2.0 migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#ruff-plugin)
```
(base_env) ankith@AnkithLaptop:~/mount/gitstuff/personal/pygame-community/pygame-ce$ ruff check . --select NPY201
test/pixelcopy_test.py:548:25: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
test/pixelcopy_test.py:556:25: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
test/pixelcopy_test.py:566:25: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
test/sndarray_test.py:31:25: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
test/sndarray_test.py:74:25: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
test/sndarray_test.py:113:25: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
test/surfarray_test.py:238:33: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
test/surfarray_test.py:246:17: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
test/surfarray_test.py:260:21: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
test/surfarray_test.py:265:21: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
test/surfarray_test.py:293:29: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
Found 11 errors.
[*] 11 fixable with the `--fix` option.
```

Fixed all these issues by replacing the `alltrue` import with the `all` import, now aliased to `np_all` to prevent name collision with python's builtin `all`.

Also fixed a few incorrect `sndarray` testcases and added a skip for a failing `surfarray` test (we will deal with it in the future)
 
PS: the `numpy.all` function is `numpy v1` API, so now our tests can run on both numpy v1 and numpy v2