### PR TITLE
Add default dest (0, 0) to Surface.blit

### DIFF
--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -69,7 +69,7 @@ class Surface:
     def blit(
         self,
         source: Surface,
-        dest: Union[Coordinate, RectValue],
+        dest: Optional[Union[Coordinate, RectValue]] = (0, 0),
         area: Optional[RectValue] = None,
         special_flags: int = 0,
     ) -> Rect: ...

--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -69,7 +69,7 @@ class Surface:
     def blit(
         self,
         source: Surface,
-        dest: Optional[Union[Coordinate, RectValue]] = (0, 0),
+        dest: Union[Coordinate, RectValue] = (0, 0),
         area: Optional[RectValue] = None,
         special_flags: int = 0,
     ) -> Rect: ...

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -137,7 +137,7 @@
           - The blit is ignored if the ``source`` is positioned completely outside this ``Surface``'s
             clipping area. Otherwise only the overlapping area will be drawn.
 
-      .. versionchanged:: 2.5.1 The dest argument can be omitted and defaults to (0, 0)
+      .. versionchanged:: 2.5.1 The dest argument is optional and defaults to (0, 0)
 
       .. ## Surface.blit ##
 

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -90,7 +90,7 @@
    .. method:: blit
 
       | :sl:`draw another surface onto this one`
-      | :sg:`blit(source, dest, area=None, special_flags=0) -> Rect`
+      | :sg:`blit(source, dest=(0, 0), area=None, special_flags=0) -> Rect`
 
       Draws another Surface onto this Surface.
 
@@ -98,8 +98,8 @@
           - ``source``
               The ``Surface`` object to draw onto this ``Surface``.
               If it has transparency, transparent pixels will be ignored when blittting to an 8-bit ``Surface``.
-          - ``dest``
-              The ``source`` draw position onto this ``Surface``.
+          - ``dest`` *(optional)*
+              The ``source`` draw position onto this ``Surface``, defaults to (0, 0).
               It can be a coordinate ``(x, y)`` or a ``Rect`` (using its top-left corner).
               If a ``Rect`` is passed, its size will not affect the blit.
           - ``area`` *(optional)*

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -137,6 +137,8 @@
           - The blit is ignored if the ``source`` is positioned completely outside this ``Surface``'s
             clipping area. Otherwise only the overlapping area will be drawn.
 
+      .. versionchanged:: 2.5.1 The dest argument can be omitted and defaults to (0, 0)
+
       .. ## Surface.blit ##
 
    .. method:: blits

--- a/src_c/doc/surface_doc.h
+++ b/src_c/doc/surface_doc.h
@@ -1,6 +1,6 @@
 /* Auto generated file: with make_docs.py .  Docs go in docs/reST/ref/ . */
 #define DOC_SURFACE "Surface((width, height), flags=0, depth=0, masks=None) -> Surface\nSurface((width, height), flags=0, Surface) -> Surface\npygame object for representing images"
-#define DOC_SURFACE_BLIT "blit(source, dest, area=None, special_flags=0) -> Rect\ndraw another surface onto this one"
+#define DOC_SURFACE_BLIT "blit(source, dest=(0, 0), area=None, special_flags=0) -> Rect\ndraw another surface onto this one"
 #define DOC_SURFACE_BLITS "blits(blit_sequence=((source, dest), ...), doreturn=True) -> [Rect, ...] or None\nblits(((source, dest, area), ...)) -> [Rect, ...]\nblits(((source, dest, area, special_flags), ...)) -> [Rect, ...]\ndraw many surfaces onto this surface at their corresponding location"
 #define DOC_SURFACE_FBLITS "fblits(blit_sequence=((source, dest), ...), special_flags=0, /) -> None\ndraw many surfaces onto this surface at their corresponding location and with the same special_flags"
 #define DOC_SURFACE_CONVERT "convert(surface, /) -> Surface\nconvert(depth, flags=0, /) -> Surface\nconvert(masks, flags=0, /) -> Surface\nconvert() -> Surface\nchange the pixel format of a surface"

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1810,7 +1810,7 @@ surf_blit(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
 {
     SDL_Surface *src, *dest = pgSurface_AsSurface(self);
     SDL_Rect *src_rect, temp;
-    PyObject *argpos, *argrect = NULL;
+    PyObject *argpos = NULL, *argrect = NULL;
     pgSurfaceObject *srcobject;
     int dx, dy, result;
     SDL_Rect dest_rect;
@@ -1818,7 +1818,7 @@ surf_blit(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
     int blend_flags = 0;
 
     static char *kwids[] = {"source", "dest", "area", "special_flags", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O!O|Oi", kwids,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O!|OOi", kwids,
                                      &pgSurface_Type, &srcobject, &argpos,
                                      &argrect, &blend_flags))
         return NULL;
@@ -1827,7 +1827,11 @@ surf_blit(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
     SURF_INIT_CHECK(src)
     SURF_INIT_CHECK(dest)
 
-    if ((src_rect = pgRect_FromObject(argpos, &temp))) {
+    if (argpos == NULL) { /* dest argument is absent  */
+        dx = 0;
+        dy = 0;
+    }
+    else if ((src_rect = pgRect_FromObject(argpos, &temp))) {
         dx = src_rect->x;
         dy = src_rect->y;
     }

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1203,6 +1203,15 @@ class TestSurfaceBlit(unittest.TestCase):
             # +3 gets the "alpha channel" in this pixel format
             assert surf1_bytes[i * 4 + 3] == 0
 
+    def test_blit_default_dest(self):
+        surf1 = pygame.Surface((20, 20))
+        surf1.fill("black")
+        surf2 = pygame.Surface((10, 10))
+        surf2.fill("red")
+        surf1.blit(surf2)
+        self.assertEqual(surf1.get_at((0, 0)), pygame.Color("red"))
+        self.assertEqual(surf1.get_at((10, 10)), pygame.Color("black"))
+
 
 class GeneralSurfaceTests(unittest.TestCase):
     @unittest.skipIf(


### PR DESCRIPTION
Implements https://github.com/pygame-community/pygame-ce/issues/2935

I'm not sure if you want this to be added, personally I like it. I didn't discuss it because the implementation seemed pretty simple, so even if you don't want it it's not a big deal. 
The reasoning for it can be understood in the issue description.

I only modified blit and not blits/fblits, but I'm pretty sure I can add it to them too if you want, but for now I don't think it's a good idea.