### PR TITLE
Fix `Surface.fill` with rects with negative positions that overlap the surface

### DIFF
--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -306,6 +306,11 @@
 
       This will return the affected Surface area.
 
+      .. note:: As of pygame-ce version 2.5.1, a long-standing bug has been fixed!
+         Now when passing in a ``Rect`` with negative ``x`` or negative ``y`` (or both),
+         the ``Rect`` filled will no longer be shifted to ``(0, 0)``, but instead only the
+         part of the ``Rect`` overlapping the window's ``Rect`` will be filled.
+
       .. ## Surface.fill ##
 
    .. method:: scroll

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1772,9 +1772,15 @@ surf_fill(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
         }
 
         if (sdlrect.x < 0) {
+            if (abs(sdlrect.w) > abs(sdlrect.x)) {
+                sdlrect.w += sdlrect.x;
+            }
             sdlrect.x = 0;
         }
         if (sdlrect.y < 0) {
+            if (abs(sdlrect.h) > abs(sdlrect.y)) {
+                sdlrect.h += sdlrect.y;
+            }
             sdlrect.y = 0;
         }
 

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -4280,13 +4280,17 @@ class SurfaceFillTest(unittest.TestCase):
         negative_both = pygame.Rect(-10, -10, 20, 20)
         negative_both_drawn = pygame.Rect(0, 0, 10, 10)
 
-        screen.fill("red", negative_x_rect)
-        screen.fill("blue", negative_y_rect)
-        screen.fill("green", negative_both)
+        red_rect_1 = screen.fill("red", negative_x_rect)
+        blue_rect_1 = screen.fill("blue", negative_y_rect)
+        green_rect_1 = screen.fill("green", negative_both)
 
-        other_surface.fill("red", negative_x_rect_drawn)
-        other_surface.fill("blue", negative_y_rect_drawn)
-        other_surface.fill("green", negative_both_drawn)
+        red_rect_2 = other_surface.fill("red", negative_x_rect_drawn)
+        blue_rect_2 = other_surface.fill("blue", negative_y_rect_drawn)
+        green_rect_2 = other_surface.fill("green", negative_both_drawn)
+
+        self.assertEqual(red_rect_1, red_rect_2)
+        self.assertEqual(blue_rect_1, blue_rect_2)
+        self.assertEqual(green_rect_1, green_rect_2)
 
         # verify both have the same pixels
         width, height = screen.get_size()

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -4296,7 +4296,9 @@ class SurfaceFillTest(unittest.TestCase):
         width, height = screen.get_size()
         for row in range(height):
             for col in range(width):
-                assert screen.get_at((col, row)) == other_surface.get_at((col, row))
+                self.assertEqual(
+                    screen.get_at((col, row)), other_surface.get_at((col, row))
+                )
 
 
 if __name__ == "__main__":

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -4268,6 +4268,32 @@ class SurfaceFillTest(unittest.TestCase):
         for y in range(5, 480, 10):
             self.assertEqual(screen.get_at((10, y)), screen.get_at((330, 480 - y)))
 
+    def test_fill_negative_rectpos(self):
+        """Regression test for https://github.com/pygame-community/pygame-ce/issues/2938"""
+        screen = pygame.display.set_mode((640, 480))
+        other_surface = screen.copy()
+
+        negative_x_rect = pygame.Rect(-10, 10, 20, 20)
+        negative_x_rect_drawn = pygame.Rect(0, 10, 10, 20)
+        negative_y_rect = pygame.Rect(100, -10, 20, 20)
+        negative_y_rect_drawn = pygame.Rect(100, 0, 20, 10)
+        negative_both = pygame.Rect(-10, -10, 20, 20)
+        negative_both_drawn = pygame.Rect(0, 0, 10, 10)
+
+        screen.fill("red", negative_x_rect)
+        screen.fill("blue", negative_y_rect)
+        screen.fill("green", negative_both)
+
+        other_surface.fill("red", negative_x_rect_drawn)
+        other_surface.fill("blue", negative_y_rect_drawn)
+        other_surface.fill("green", negative_both_drawn)
+
+        # verify both have the same pixels
+        width, height = screen.get_size()
+        for row in range(height):
+            for col in range(width):
+                assert screen.get_at((col, row)) == other_surface.get_at((col, row))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #2938 