### PR TITLE
Improve security of releases by adding hash checks

### DIFF
--- a/.github/workflows/release-gh-draft.yml
+++ b/.github/workflows/release-gh-draft.yml
@@ -55,6 +55,14 @@ jobs:
         id: ver
         run: echo "VER=${GITHUB_REF_NAME#'release/'}" >> $GITHUB_OUTPUT
 
+      # First generate release.sha512sum which contains hashes of all release files, then
+      # encrypt these hashes so that the hash file itself cannot be tampered with.
+      - name: Generate release hashes (encrypted)
+        run: |
+          cd pygame-wheels
+          sha512sum * > release.sha512sum
+          gpg --batch --output release.sha512sum.gpg --passphrase ${{ secrets.GITHUB_TOKEN }} --symmetric release.sha512sum
+
       - name: Draft a release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -23,5 +23,16 @@ jobs:
           zipBall: false
           out-file-path: "dist"
 
+      # Check that all the files that successfully uploaded from the release-gh-draft
+      # action have not been tampered with. This however ignores any extra files that
+      # were manually added.
+      - name: Verify release hashes
+        run: |
+          cd dist
+          gpg --batch --output release.decrypted.sha512sum --passphrase ${{ secrets.GITHUB_TOKEN }} --decrypt release.sha512sum.gpg
+          diff -s release.sha512sum release.decrypted.sha512sum
+          sha512sum -c release.decrypted.sha512sum
+          rm release.*
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This change ensures that no organization member can modify or delete any release artifact that was generated and uploaded by `release-gh-draft` action.
