### PR TITLE
Centralize CI config and make it more uniform (Adds macOS arm64 pypy CI)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,14 +28,9 @@ jobs:
 
     environment:
       # these environment variables will be passed to the docker container
-      - CIBW_ENVIRONMENT: SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=disk
-      - CIBW_BUILD: "cp3{8,9,10,11,12}-* pp3{8,9,10}-*"
       - CIBW_ARCHS: aarch64
-      - CIBW_SKIP: '*-musllinux_*'
       - CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014_base_aarch64
       - CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: manylinux2014_base_aarch64
-      - CIBW_TEST_COMMAND: python -m pygame.tests -v --exclude opengl,music,timing --time_out 300
-      - CIBW_BUILD_VERBOSITY: 2
 
     steps:
       - checkout

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -132,6 +132,9 @@ jobs:
           key: macdep-${{ hashFiles('buildconfig/manylinux-build/**') }}-${{ hashFiles('buildconfig/macdependencies/*.sh') }}-${{ matrix.macarch }}
           fail-on-cache-miss: true
 
+      - name: Install uv for speed
+        uses: yezz123/setup-uv@v4
+
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.19.2
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -76,58 +76,18 @@ jobs:
       #     path: ${{ github.workspace }}/pygame_mac_deps_${{ matrix.macarch }}
 
   build:
-    name: ${{ matrix.name }}
+    name: ${{ matrix.macarch }}
     needs: deps
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       matrix:
-        # Split job into 5 matrix builds, because GH actions provides 5 concurrent
-        # builds on macOS. This needs to be manually kept updated so that each
-        # of these builds take roughly the same time
         include:
-          - { 
-            name: "x86_64 (CPython 3.9 - 3.12)",
-            macarch: x86_64,
-            os: macos-13,
-            pyversions: "cp3{9,10,11,12}-*",
-          }
-
-          - { 
-            name: "x86_64 (Python 3.8)",
-            macarch: x86_64,
-            os: macos-13,
-            # CPython/PyPy 3.8
-            pyversions: "?p38-*",
-          }
-
-          - { 
-            name: "x86_64 (PyPy 3.9 and 3.10)",
-            macarch: x86_64,
-            os: macos-13,
-            pyversions: "pp39-* pp310-*",
-          }
-
-          - { 
-            name: "arm64 (CPython 3.8 - 3.10)",
-            macarch: arm64,
-            os: macos-14,
-            pyversions: "cp3{8,9,10}-*",
-          }
-
-          - { 
-            name: "arm64 (CPython 3.11 - 3.12)",
-            macarch: arm64,
-            os: macos-14,
-            pyversions: "cp3{11,12}-*",
-          }
+          - { macarch: arm64, os: macos-14 }
+          - { macarch: x86_64, os: macos-13 }
 
     env:
       MAC_ARCH: ${{ matrix.macarch }}
-      # load pip config from this file. Define this in 'CIBW_ENVIRONMENT'
-      # because this should not affect cibuildwheel machinery
-      # also define environment variables needed for testing
-      CIBW_ENVIRONMENT: SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=disk
 
       # Explicitly tell CIBW what the wheel arch deployment target should be
       # There seems to be no better way to set this than this env
@@ -140,8 +100,6 @@ jobs:
       # should be for 10.11 on x86
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macarch == 'x86_64' && '10.11' || '11.0' }}
 
-      CIBW_BUILD: ${{ matrix.pyversions }}
-
       CIBW_ARCHS: ${{ matrix.macarch }}
 
       # Setup macOS dependencies
@@ -152,16 +110,10 @@ jobs:
         bash ./install_mac_deps.sh
 
       CIBW_BEFORE_BUILD: |
-        pip install numpy
         cp -r ${{ github.workspace }}/pygame_mac_deps_${{ matrix.macarch }} ${{ github.workspace }}/pygame_mac_deps
 
       # To remove any speculations about the wheel not being self-contained
       CIBW_BEFORE_TEST: rm -rf ${{ github.workspace }}/pygame_mac_deps
-
-      CIBW_TEST_COMMAND: python -m pygame.tests -v --exclude opengl,timing --time_out 300
-
-      # Increase pip debugging output
-      CIBW_BUILD_VERBOSITY: 2
 
     steps:
       - uses: actions/checkout@v4.1.7
@@ -170,7 +122,7 @@ jobs:
         uses: actions/cache@v4.0.2
         with:
           path: ~/Library/Caches/pip  # This cache path is only right on mac
-          key: pip-cache-${{ matrix.name }}
+          key: pip-cache-${{ matrix.macarch }}-${{ matrix.os }}
 
       - name: Fetch Mac deps
         id: macdep-cache
@@ -185,7 +137,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: pygame-wheels-macos-${{ matrix.name }}
+          name: pygame-wheels-macos-${{ matrix.macarch }}
           path: ./wheelhouse/*.whl
           compression-level: 0  # wheels are already zip files, no need for more compression
 

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -49,29 +49,7 @@ jobs:
         arch: [x86_64, i686]
     
     env:
-      # load pip config from this file. Define this in 'CIBW_ENVIRONMENT'
-      # because this should not affect cibuildwheel machinery
-      # also define environment variables needed for testing
-      CIBW_ENVIRONMENT: SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=disk
-
-      CIBW_BUILD: "cp3{8,9,10,11,12}-* pp3{8,9,10}-*"
       CIBW_ARCHS: ${{ matrix.arch }}
-
-      # skip musllinux for now
-      CIBW_SKIP: '*-musllinux_*'
-
-      CIBW_TEST_COMMAND: python -m pygame.tests -v --exclude opengl,music,timing --time_out 300
-
-      # To 'solve' this issue:
-      #   >>> process 338: D-Bus library appears to be incorrectly set up; failed to read
-      #   machine uuid: Failed to open "/var/lib/dbus/machine-id": No such file or directory
-      CIBW_BEFORE_TEST: |
-        if [ ! -f /var/lib/dbus/machine-id ]; then
-            dbus-uuidgen > /var/lib/dbus/machine-id
-        fi
-
-      # Increase pip debugging output
-      CIBW_BUILD_VERBOSITY: 2
 
     steps:
     - uses: actions/checkout@v4.1.7

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -37,107 +37,17 @@ concurrency:
 
 jobs:
   build:
-    name: ${{ matrix.name }}
+    name: ${{ matrix.winarch }}
     runs-on: windows-latest
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       matrix:
         include:
-          - {
-            name: "CPython 3.12 (64 bit)",
-            winarch: AMD64,
-            msvc-dev-arch: x86_amd64,
-            pyversions: "cp312-*"
-          }
-          - {
-            name: "CPython 3.11 (64 bit)",
-            winarch: AMD64,
-            msvc-dev-arch: x86_amd64,
-            pyversions: "cp311-*"
-          }
-          - {
-            name: "CPython 3.10 (64 bit)",
-            winarch: AMD64,
-            msvc-dev-arch: x86_amd64,
-            pyversions: "cp310-*"
-          }
-          - {
-            name: "CPython 3.9 (64 bit)",
-            winarch: AMD64,
-            msvc-dev-arch: x86_amd64,
-            pyversions: "cp39-*"
-          }
-          - {
-            name: "CPython 3.8 (64 bit)",
-            winarch: AMD64,
-            msvc-dev-arch: x86_amd64,
-            pyversions: "cp38-*"
-          }
-          - {
-            name: "CPython 3.12 (32 bit)",
-            winarch: x86,
-            msvc-dev-arch: x86,
-            pyversions: "cp312-win32*"
-          }
-          - {
-            name: "CPython 3.11 (32 bit)",
-            winarch: x86,
-            msvc-dev-arch: x86,
-            pyversions: "cp311-win32"
-          }
-          - {
-            name: "CPython 3.10 (32 bit)",
-            winarch: x86,
-            msvc-dev-arch: x86,
-            pyversions: "cp310-win32"
-          }
-          - {
-            name: "CPython 3.9 (32 bit)",
-            winarch: x86,
-            msvc-dev-arch: x86,
-            pyversions: "cp39-win32"
-          }
-          - {
-            name: "CPython 3.8 (32 bit)",
-            winarch: x86,
-            msvc-dev-arch: x86,
-            pyversions: "cp38-win32"
-          }
-          - {
-            name: "Pypy 3.8",
-            winarch: AMD64,
-            msvc-dev-arch: x86_amd64,
-            pyversions: "pp38-*"
-          }
-          - {
-            name: "Pypy 3.9",
-            winarch: AMD64,
-            msvc-dev-arch: x86_amd64,
-            pyversions: "pp39-*"
-          }
-          - {
-            name: "Pypy 3.10",
-            winarch: AMD64,
-            msvc-dev-arch: x86_amd64,
-            pyversions: "pp310-*"
-          }
-
+          - { winarch: AMD64, msvc-dev-arch: x86_amd64 }
+          - { winarch: x86, msvc-dev-arch: x86 }
 
     env:
-      # load pip config from this file. Define this in 'CIBW_ENVIRONMENT'
-      # because this should not affect cibuildwheel machinery
-      # also define environment variables needed for testing
-      CIBW_ENVIRONMENT: SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=disk
-
-      CIBW_BUILD: ${{ matrix.pyversions }}
       CIBW_ARCHS: ${{ matrix.winarch }}
-
-      CIBW_BEFORE_BUILD: pip install numpy
-
-      CIBW_TEST_COMMAND: python -m pygame.tests -v --exclude opengl,timing --time_out 300
-
-      # Increase pip debugging output
-      CIBW_BUILD_VERBOSITY: 2
 
     steps:
       - uses: actions/checkout@v4.1.7
@@ -151,6 +61,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: pygame-wheels-windows-${{ matrix.name }}
+          name: pygame-wheels-windows-${{ matrix.winarch }}
           path: ./wheelhouse/*.whl
           compression-level: 0  # wheels are already zip files, no need for more compression

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -56,6 +56,9 @@ jobs:
         with:
           arch: ${{ matrix.msvc-dev-arch }}
 
+      - name: Install uv for speed
+        uses: yezz123/setup-uv@v4
+
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.19.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,14 @@ install = ['--tags=runtime,python-runtime,pg-tag']
 # uncomment to get werror locally
 # setup = ["-Derror_on_warns=true"]
 
+[tool.cibuildwheel]
+build = "cp3{8,9,10,11,12}-* pp3{8,9,10}-*"
+skip = "*-musllinux_*"
+build-verbosity = 3
+
+environment = { SDL_VIDEODRIVER="dummy", SDL_AUDIODRIVER="disk" }
+test-command = "python -m pygame.tests -v --exclude opengl,music,timing --time_out 300"
+
 [tool.cibuildwheel.config-settings]
 setup-args = [
     "-Derror_on_warns=true",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ skip = "*-musllinux_*"
 
 environment = { SDL_VIDEODRIVER="dummy", SDL_AUDIODRIVER="disk" }
 test-command = "python -m pygame.tests -v --exclude opengl,music,timing --time_out 300"
+test-requires = ["numpy"]
 
 [tool.cibuildwheel.config-settings]
 setup-args = [
@@ -91,3 +92,17 @@ exclude = [
 
 [tool.ruff.format]
 quote-style = "preserve"
+
+# numpy is a test dependency, but we build for systems that numpy doesn't have
+# binary wheels for. In such cases, we do not want to waste CI time building
+# numpy from source. So, we are gonna force numpy to be "only-binary" and skip
+# numpy on platforms that it doesn't have wheels for
+[tool.uv.pip]
+only-binary = ["numpy"]
+
+# 1. skip all 32-bit manylinux (i686) 
+# 2. skip all pypy+arm combinations
+# 3. skip all pypy 310 because it is so new numpy does not have wheels for it
+[[tool.cibuildwheel.overrides]]
+select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp310-*}"
+test-requires = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,16 @@ install = ['--tags=runtime,python-runtime,pg-tag']
 # setup = ["-Derror_on_warns=true"]
 
 [tool.cibuildwheel]
+# The default build-frontend is "pip", but we use the recommended "build" frontend.
+# build (AKA pypa/build) is a simple tool that just focusses on one thing: building
+# wheels. build still needs to interact with a pip-like tool to handle build-time
+# dependencies. Here is where uv comes into the picture. It is an "installer" like pip,
+# but faster. It has been observed to save a couple of minutes of CI time.
+build-frontend = "build[uv]"
 build = "cp3{8,9,10,11,12}-* pp3{8,9,10}-*"
 skip = "*-musllinux_*"
-build-verbosity = 3
+# build[uv] is verbose by default, so below flag is not needed here
+# build-verbosity = 3
 
 environment = { SDL_VIDEODRIVER="dummy", SDL_AUDIODRIVER="disk" }
 test-command = "python -m pygame.tests -v --exclude opengl,music,timing --time_out 300"


### PR DESCRIPTION
The goal of this PR is to centralize all common cibuildwheel config, and make our CI more uniform.

We currently take different strategies on different workflows. manylinux takes the "build for all pythons in one workflow per arch" strategy. Mac takes an (ever so slightly harder to maintain) strategy of handwritten "split jobs evenly" while windows takes the "every run on its own" thing. 
I figured that the strategy manylinux takes is actually the most efficient, even if it's slower than the rest. Why?
- We can re-use more stuff across runs - cibuildwheel dependencies, buildtime dependencies, SDL prebuilt downloads (in windows) and doc building.
- By using less concurrent workflows per PR we are actually making room for more across-PR CI concurrency.
- Simpler config to maintain. Want to support a new python version on CI? It's now a one line change in `pyproject.toml`
- There is no real advantage from a PR maker POV if all windows builds can finish in 8 minutes, and the linux one is going to take like 15 minutes anyways which the PR maker has to wait for.
- It is also wasteful if there is say, a windows specific CI fail that just causes multiple separate runs to fail when one fail would be enough to convey the message.

Also switches build backend to `build[uv]` which should again save some CI time.

I may also explore more in the caching area in future PRs and see how that improves things.