### PR TITLE
compile SSE3 tobytes implementation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -316,28 +316,11 @@ if simd_sse2_neon
     add_global_arguments('-DPG_ENABLE_ARM_NEON=1', language: 'c')
 endif
 
-# SSE3 configuration
-simd_sse3 = false
-simd_sse3_flags = []
-if host_machine.cpu_family().startswith('x86')
-    flag = (cc.get_argument_syntax() == 'msvc') ? '/arch:SSE3' : '-msse3'
-    if cc.has_argument(flag)
-        simd_sse3_flags += flag
-        simd_sse3 = true
-    endif
-endif
-
-# Adding global arguments for SSE3
-if simd_sse3
-    add_global_arguments('-DPG_ENABLE_SSE3=1', language: 'c')
-endif
-
 # Summary of SIMD support
 summary(
     {
         'AVX2': simd_avx2,
         'NEON': simd_sse2_neon,
-        'SSE3': simd_sse3,
     },
     section: 'SIMD',
 )

--- a/meson.build
+++ b/meson.build
@@ -285,6 +285,7 @@ summary(
     section: 'Dependencies',
 )
 
+# AVX2 configuration
 simd_avx2 = false
 simd_avx2_flags = []
 if host_machine.cpu_family().startswith('x86')
@@ -295,6 +296,7 @@ if host_machine.cpu_family().startswith('x86')
     endif
 endif
 
+# SSE2/NEON configuration
 simd_sse2_neon = false
 simd_sse2_neon_flags = []
 if host_machine.cpu_family() == 'arm'
@@ -314,10 +316,28 @@ if simd_sse2_neon
     add_global_arguments('-DPG_ENABLE_ARM_NEON=1', language: 'c')
 endif
 
+# SSE3 configuration
+simd_sse3 = false
+simd_sse3_flags = []
+if host_machine.cpu_family().startswith('x86')
+    flag = (cc.get_argument_syntax() == 'msvc') ? '/arch:SSE3' : '-msse3'
+    if cc.has_argument(flag)
+        simd_sse3_flags += flag
+        simd_sse3 = true
+    endif
+endif
+
+# Adding global arguments for SSE3
+if simd_sse3
+    add_global_arguments('-DPG_ENABLE_SSE3=1', language: 'c')
+endif
+
+# Summary of SIMD support
 summary(
     {
         'AVX2': simd_avx2,
         'NEON': simd_sse2_neon,
+        'SSE3': simd_sse3,
     },
     section: 'SIMD',
 )

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -32,14 +32,14 @@
 
 #include "simd_shared.h"
 
+#define __SSSE3__ 1
+
 #if PG_ENABLE_ARM_NEON
 // sse2neon.h is from here: https://github.com/DLTcollab/sse2neon
 #include "include/sse2neon.h"
 #endif /* PG_ENABLE_ARM_NEON */
 
-#if defined(__SSSE3__)
 #include <tmmintrin.h>
-#endif
 
 static int
 SaveTGA(SDL_Surface *surface, const char *file, int rle);
@@ -263,7 +263,7 @@ image_get_sdl_image_version(PyObject *self, PyObject *args, PyObject *kwargs)
         return PyObject_Call(extverobj, args, kwargs);
 }
 
-#if defined(__SSE3__) || defined(PG_ENABLE_ARM_NEON)
+#if defined(__SSSE3__) || defined(PG_ENABLE_ARM_NEON)
 
 #define _SHIFT_N_STEP2ALIGN(shift, step) (shift / 8 + step * 4)
 
@@ -405,7 +405,7 @@ tobytes_surf_32bpp(SDL_Surface *surf, int flipped, int hascolorkey,
     Uint32 Bloss = surf->format->Bloss;
     Uint32 Aloss = surf->format->Aloss;
 
-#if defined(__SSE3__) || defined(PG_ENABLE_ARM_NEON)
+#if defined(__SSSE3__) || defined(PG_ENABLE_ARM_NEON)
     if (/* SDL uses Uint32, SSE uses int for building vectors.
          * Related, we assume that Uint32 is packed so 4 of
          * them perfectly matches an __m128i.

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -37,6 +37,12 @@
 #include "include/sse2neon.h"
 #endif /* PG_ENABLE_ARM_NEON */
 
+#if PG_COMPILE_SSE4_2
+#include <emmintrin.h>
+/* SSSE 3 */
+#include <tmmintrin.h>
+#endif
+
 static int
 SaveTGA(SDL_Surface *surface, const char *file, int rle);
 static int

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -296,7 +296,7 @@ compute_align_vector(SDL_PixelFormat *format, int color_offset,
                      int alpha_offset)
 {
     int output_align[4];
-    size_t i;
+    int i;
     size_t limit = sizeof(output_align) / sizeof(int);
     int a_shift = alpha_offset * 8;
     int r_shift = (color_offset + 0) * 8;

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -32,10 +32,6 @@
 
 #include "simd_shared.h"
 
-#if PG_ENABLE_SSE_NEON
-#include <immintrin.h>
-#endif
-
 #if PG_ENABLE_ARM_NEON
 // sse2neon.h is from here: https://github.com/DLTcollab/sse2neon
 #include "include/sse2neon.h"

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -36,6 +36,11 @@
 #include <immintrin.h>
 #endif
 
+#if PG_ENABLE_ARM_NEON
+// sse2neon.h is from here: https://github.com/DLTcollab/sse2neon
+#include "include/sse2neon.h"
+#endif /* PG_ENABLE_ARM_NEON */
+
 static int
 SaveTGA(SDL_Surface *surface, const char *file, int rle);
 static int
@@ -258,7 +263,7 @@ image_get_sdl_image_version(PyObject *self, PyObject *args, PyObject *kwargs)
         return PyObject_Call(extverobj, args, kwargs);
 }
 
-#if PG_ENABLE_SSE_NEON
+#if defined(__SSE3__) || defined(PG_ENABLE_ARM_NEON)
 
 #define _SHIFT_N_STEP2ALIGN(shift, step) (shift / 8 + step * 4)
 
@@ -378,7 +383,7 @@ tobytes_surf_32bpp_sse42(SDL_Surface *surf, int flipped, char *data,
         }
     }
 }
-#endif /* PG_ENABLE_SSE_NEON */
+#endif /* defined(__SSE3__) || defined(PG_ENABLE_ARM_NEON) */
 
 static void
 tobytes_surf_32bpp(SDL_Surface *surf, int flipped, int hascolorkey,
@@ -400,7 +405,7 @@ tobytes_surf_32bpp(SDL_Surface *surf, int flipped, int hascolorkey,
     Uint32 Bloss = surf->format->Bloss;
     Uint32 Aloss = surf->format->Aloss;
 
-#if PG_ENABLE_SSE_NEON
+#if defined(__SSE3__) || defined(PG_ENABLE_ARM_NEON)
     if (/* SDL uses Uint32, SSE uses int for building vectors.
          * Related, we assume that Uint32 is packed so 4 of
          * them perfectly matches an __m128i.
@@ -429,7 +434,7 @@ tobytes_surf_32bpp(SDL_Surface *surf, int flipped, int hascolorkey,
                                  alpha_offset);
         return;
     }
-#endif /* PG_ENABLE_SSE_NEON */
+#endif /* defined(__SSE3__) || defined(PG_ENABLE_ARM_NEON) */
 
     for (h = 0; h < surf->h; ++h) {
         Uint32 *pixel_row =

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -37,9 +37,7 @@
 #include "include/sse2neon.h"
 #endif /* PG_ENABLE_ARM_NEON */
 
-#if PG_COMPILE_SSE4_2
-#include <emmintrin.h>
-/* SSSE 3 */
+#if defined(__SSSE3__)
 #include <tmmintrin.h>
 #endif
 

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -298,7 +298,7 @@ compute_align_vector(SDL_PixelFormat *format, int color_offset,
 {
     int output_align[4];
     int i;
-    size_t limit = sizeof(output_align) / sizeof(int);
+    int limit = (int)(sizeof(output_align) / sizeof(int));
     int a_shift = alpha_offset * 8;
     int r_shift = (color_offset + 0) * 8;
     int g_shift = (color_offset + 1) * 8;

--- a/src_c/include/pgplatform.h
+++ b/src_c/include/pgplatform.h
@@ -52,19 +52,17 @@
 #define WIN32
 #endif
 
-/* Commenting out SSE4_2 stuff because it does not do runtime detection.
 #ifndef PG_TARGET_SSE4_2
-#if defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ == 4 &&
-__GNUC_MINOR__ >= 9) || __GNUC__ >= 5 ))
-//The old gcc 4.8 on centos used by manylinux1 does not seem to get sse4.2
-intrinsics #define PG_FUNCTION_TARGET_SSE4_2 __attribute__((target("sse4.2")))
+#if defined(__clang__) || \
+    (defined(__GNUC__) && \
+     ((__GNUC__ == 4 && __GNUC_MINOR__ >= 9) || __GNUC__ >= 5))
+// The old gcc 4.8 on centos used by manylinux1 does not seem to get sse4.2
+#define PG_FUNCTION_TARGET_SSE4_2 __attribute__((target("sse4.2")))
 // No else; we define the fallback later
 #endif
 #endif
-*/
 /* ~PG_TARGET_SSE4_2 */
 
-/*
 #ifdef PG_FUNCTION_TARGET_SSE4_2
 #if !defined(__SSE4_2__) && !defined(PG_COMPILE_SSE4_2)
 #if defined(__x86_64__) || defined(__i386__)
@@ -72,7 +70,7 @@ intrinsics #define PG_FUNCTION_TARGET_SSE4_2 __attribute__((target("sse4.2")))
 #endif
 #endif
 #endif
-*/
+
 /* ~PG_TARGET_SSE4_2 */
 
 /* Fallback definition of target attribute */

--- a/src_c/include/pgplatform.h
+++ b/src_c/include/pgplatform.h
@@ -52,34 +52,4 @@
 #define WIN32
 #endif
 
-#ifndef PG_TARGET_SSE4_2
-#if defined(__clang__) || \
-    (defined(__GNUC__) && \
-     ((__GNUC__ == 4 && __GNUC_MINOR__ >= 9) || __GNUC__ >= 5))
-// The old gcc 4.8 on centos used by manylinux1 does not seem to get sse4.2
-#define PG_FUNCTION_TARGET_SSE4_2 __attribute__((target("sse4.2")))
-// No else; we define the fallback later
-#endif
-#endif
-/* ~PG_TARGET_SSE4_2 */
-
-#ifdef PG_FUNCTION_TARGET_SSE4_2
-#if !defined(__SSE4_2__) && !defined(PG_COMPILE_SSE4_2)
-#if defined(__x86_64__) || defined(__i386__)
-#define PG_COMPILE_SSE4_2 1
-#endif
-#endif
-#endif
-
-/* ~PG_TARGET_SSE4_2 */
-
-/* Fallback definition of target attribute */
-#ifndef PG_FUNCTION_TARGET_SSE4_2
-#define PG_FUNCTION_TARGET_SSE4_2
-#endif
-
-#ifndef PG_COMPILE_SSE4_2
-#define PG_COMPILE_SSE4_2 0
-#endif
-
 #endif /* ~PG_PLATFORM_H */

--- a/src_c/simd_shared.h
+++ b/src_c/simd_shared.h
@@ -37,7 +37,7 @@ pg_has_avx2();
  * at compile time. Since we do compile time translation of SSE2->NEON, they
  * have the same code paths, so this reduces code duplication of those paths.
  */
-#if defined(__SSE2__)
+#if defined(__SSE2__) || defined(__SSE3__)
 #define PG_ENABLE_SSE_NEON 1
 #elif PG_ENABLE_ARM_NEON
 #define PG_ENABLE_SSE_NEON 1
@@ -53,6 +53,8 @@ pg_HasSSE_NEON()
 {
 #if defined(__SSE2__)
     return SDL_HasSSE2();
+#elif defined(__SSE3__)
+    return SDL_HasSSE3();
 #elif PG_ENABLE_ARM_NEON
     return SDL_HasNEON();
 #else

--- a/src_c/simd_shared.h
+++ b/src_c/simd_shared.h
@@ -37,7 +37,7 @@ pg_has_avx2();
  * at compile time. Since we do compile time translation of SSE2->NEON, they
  * have the same code paths, so this reduces code duplication of those paths.
  */
-#if defined(__SSE2__) || defined(__SSE3__)
+#if defined(__SSE2__)
 #define PG_ENABLE_SSE_NEON 1
 #elif PG_ENABLE_ARM_NEON
 #define PG_ENABLE_SSE_NEON 1


### PR DESCRIPTION
This is a test PR to attempt compiling the SSE3 implementation of `image.tobytes`. I anticipate that it will take some time to get this working correctly. If you have any suggestions or better solutions, please share your thoughts. Your feedback is greatly appreciated.
Plus:
- Removed some debug stuff that's not needed/cluttered the code
- Removed a define for aligned simd that was unused
- Removed some asserts