### PR TITLE
Get rid of docscomments.js from docs

### DIFF
--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -107,5 +107,5 @@ We render three sets of items based on how useful to most apps.
 
 
 {%- block relbaritems %}
-    <script type="text/javascript" src="https://www.pygame.org/comment/jquery.plugin.docscomments.js"></script>
+
 {% endblock %}

--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -106,6 +106,4 @@ We render three sets of items based on how useful to most apps.
 {%- endblock %}
 
 
-{%- block relbaritems %}
 
-{% endblock %}


### PR DESCRIPTION
In `docs/reST/classic/elements.html` this element is included in the file: `<script type="text/javascript" src="https://www.pygame.org/comment/jquery.plugin.docscomments.js"></script>`. 

However this file isn't necessary and it is also fetched from the original pygame website. This was probably forgotten when the pygame-ce fork was made.

I ran `py -m setup.py docs` and can confirm that the documentation still works when the script is removed.

Here are some screenshots with the file removed:
![image](https://github.com/pygame-community/pygame-ce/assets/71970100/7e5ceb14-b8af-4402-a4c9-fb831d192153)
![image](https://github.com/pygame-community/pygame-ce/assets/71970100/f34d6614-f90a-4fed-bca0-f302fa457da9)
![image](https://github.com/pygame-community/pygame-ce/assets/71970100/6c309878-58d0-421a-abe5-6fa861dd30d5)


Credits to @mzivic7  from pygame community server for pointing this out and @oddbookworm for realizing that it's not needed.