### PR TITLE
Adjust tobytes premul formula

### DIFF
--- a/src_c/image.c
+++ b/src_c/image.c
@@ -495,6 +495,8 @@ tobytes_surf_32bpp(SDL_Surface *surf, int flipped, int hascolorkey,
     }
 }
 
+#define PREMUL_PIXEL_ALPHA(pixel, alpha) (char)((((pixel) + 1) * (alpha)) >> 8)
+
 PyObject *
 image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
 {
@@ -965,15 +967,12 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
                     for (w = 0; w < surf->w; ++w) {
                         color = *ptr++;
                         alpha = ((color & Amask) >> Ashift) << Aloss;
-                        data[0] =
-                            (char)((((color & Rmask) >> Rshift) << Rloss) *
-                                   alpha / 255);
-                        data[1] =
-                            (char)((((color & Gmask) >> Gshift) << Gloss) *
-                                   alpha / 255);
-                        data[2] =
-                            (char)((((color & Bmask) >> Bshift) << Bloss) *
-                                   alpha / 255);
+                        data[0] = PREMUL_PIXEL_ALPHA(
+                            ((color & Rmask) >> Rshift) << Rloss, alpha);
+                        data[1] = PREMUL_PIXEL_ALPHA(
+                            ((color & Gmask) >> Gshift) << Gloss, alpha);
+                        data[2] = PREMUL_PIXEL_ALPHA(
+                            ((color & Bmask) >> Bshift) << Bloss, alpha);
                         data[3] = (char)alpha;
                         data += 4;
                     }
@@ -992,15 +991,12 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
 #endif
                         ptr += 3;
                         alpha = ((color & Amask) >> Ashift) << Aloss;
-                        data[0] =
-                            (char)((((color & Rmask) >> Rshift) << Rloss) *
-                                   alpha / 255);
-                        data[1] =
-                            (char)((((color & Gmask) >> Gshift) << Gloss) *
-                                   alpha / 255);
-                        data[2] =
-                            (char)((((color & Bmask) >> Bshift) << Bloss) *
-                                   alpha / 255);
+                        data[0] = PREMUL_PIXEL_ALPHA(
+                            ((color & Rmask) >> Rshift) << Rloss, alpha);
+                        data[1] = PREMUL_PIXEL_ALPHA(
+                            ((color & Gmask) >> Gshift) << Gloss, alpha);
+                        data[2] = PREMUL_PIXEL_ALPHA(
+                            ((color & Bmask) >> Bshift) << Bloss, alpha);
                         data[3] = (char)alpha;
                         data += 4;
                     }
@@ -1018,15 +1014,12 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
                             data[0] = data[1] = data[2] = 0;
                         }
                         else {
-                            data[0] =
-                                (char)((((color & Rmask) >> Rshift) << Rloss) *
-                                       alpha / 255);
-                            data[1] =
-                                (char)((((color & Gmask) >> Gshift) << Gloss) *
-                                       alpha / 255);
-                            data[2] =
-                                (char)((((color & Bmask) >> Bshift) << Bloss) *
-                                       alpha / 255);
+                            data[0] = PREMUL_PIXEL_ALPHA(
+                                ((color & Rmask) >> Rshift) << Rloss, alpha);
+                            data[1] = PREMUL_PIXEL_ALPHA(
+                                ((color & Gmask) >> Gshift) << Gloss, alpha);
+                            data[2] = PREMUL_PIXEL_ALPHA(
+                                ((color & Bmask) >> Bshift) << Bloss, alpha);
                         }
                         data[3] = (char)alpha;
                         data += 4;
@@ -1047,15 +1040,12 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
                     for (w = 0; w < surf->w; ++w) {
                         color = *ptr++;
                         alpha = ((color & Amask) >> Ashift) << Aloss;
-                        data[1] =
-                            (char)((((color & Rmask) >> Rshift) << Rloss) *
-                                   alpha / 255);
-                        data[2] =
-                            (char)((((color & Gmask) >> Gshift) << Gloss) *
-                                   alpha / 255);
-                        data[3] =
-                            (char)((((color & Bmask) >> Bshift) << Bloss) *
-                                   alpha / 255);
+                        data[1] = PREMUL_PIXEL_ALPHA(
+                            ((color & Rmask) >> Rshift) << Rloss, alpha);
+                        data[2] = PREMUL_PIXEL_ALPHA(
+                            ((color & Gmask) >> Gshift) << Gloss, alpha);
+                        data[3] = PREMUL_PIXEL_ALPHA(
+                            ((color & Bmask) >> Bshift) << Bloss, alpha);
                         data[0] = (char)alpha;
                         data += 4;
                     }
@@ -1074,15 +1064,12 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
 #endif
                         ptr += 3;
                         alpha = ((color & Amask) >> Ashift) << Aloss;
-                        data[1] =
-                            (char)((((color & Rmask) >> Rshift) << Rloss) *
-                                   alpha / 255);
-                        data[2] =
-                            (char)((((color & Gmask) >> Gshift) << Gloss) *
-                                   alpha / 255);
-                        data[3] =
-                            (char)((((color & Bmask) >> Bshift) << Bloss) *
-                                   alpha / 255);
+                        data[1] = PREMUL_PIXEL_ALPHA(
+                            ((color & Rmask) >> Rshift) << Rloss, alpha);
+                        data[2] = PREMUL_PIXEL_ALPHA(
+                            ((color & Gmask) >> Gshift) << Gloss, alpha);
+                        data[3] = PREMUL_PIXEL_ALPHA(
+                            ((color & Bmask) >> Bshift) << Bloss, alpha);
                         data[0] = (char)alpha;
                         data += 4;
                     }
@@ -1100,15 +1087,12 @@ image_tobytes(PyObject *self, PyObject *arg, PyObject *kwarg)
                             data[1] = data[2] = data[3] = 0;
                         }
                         else {
-                            data[1] =
-                                (char)((((color & Rmask) >> Rshift) << Rloss) *
-                                       alpha / 255);
-                            data[2] =
-                                (char)((((color & Gmask) >> Gshift) << Gloss) *
-                                       alpha / 255);
-                            data[3] =
-                                (char)((((color & Bmask) >> Bshift) << Bloss) *
-                                       alpha / 255);
+                            data[1] = PREMUL_PIXEL_ALPHA(
+                                ((color & Rmask) >> Rshift) << Rloss, alpha);
+                            data[2] = PREMUL_PIXEL_ALPHA(
+                                ((color & Gmask) >> Gshift) << Gloss, alpha);
+                            data[3] = PREMUL_PIXEL_ALPHA(
+                                ((color & Bmask) >> Bshift) << Bloss, alpha);
                         }
                         data[0] = (char)alpha;
                         data += 4;

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -506,9 +506,9 @@ class ImageModuleTest(unittest.TestCase):
                 for y in range(surface_to_modify.get_height()):
                     color = surface_to_modify.get_at((x, y))
                     premult_color = (
-                        color[0] * color[3] / 255,
-                        color[1] * color[3] / 255,
-                        color[2] * color[3] / 255,
+                        ((color[0] + 1) * color[3]) >> 8,
+                        ((color[1] + 1) * color[3]) >> 8,
+                        ((color[2] + 1) * color[3]) >> 8,
                         color[3],
                     )
                     surface_to_modify.set_at((x, y), premult_color)


### PR DESCRIPTION
While I'm working on my `tobytes` improvement branch, I ported the code to use `Surface.premul_alpha` to handle `RGBA_PREMULT` and `ARGB_PREMULT`.

The problem is, `Surface.premul_alpha` uses a slightly different formula: `((pixel + 1) * alpha) >> 8` (which is equivalent to `((pixel + 1) * alpha) / 256`) instead of the classic `(pixel * alpha) / 255` formula, probably for performance reasons. I believe these two formulas are close enough to result in very similar looking outputs.

Hence this PR: I figured I should separate out the slight behaviour change into it's own PR and keep the refactor PR for later.