### PR TITLE
Make pyproject license consistent with `setup.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.5.1.dev1"
 description = "Python Game Development"
 readme = "README.rst" # for long description
 requires-python = ">=3.8"
-license = {file = "docs/LGPL.txt"}  # path to LGPL license
+license = {text = "LGPL"}
 authors = [{name = "A community project"}]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.5.1.dev1"
 description = "Python Game Development"
 readme = "README.rst" # for long description
 requires-python = ">=3.8"
-license = {text = "LGPL"}
+license = {text = "LGPL v2.1"}
 authors = [{name = "A community project"}]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ EXTRAS = {}
 METADATA = {
     "name": "pygame-ce",
     "version": pg_ver.version,
-    "license": "LGPL",
+    "license": "LGPL v2.1",
     "url": "https://pyga.me",
     "author": "A community project.",
     "description": "Python Game Development",


### PR DESCRIPTION
fixes #2970

Just like `setup.py`, now even `pyproject.toml` uses the string `"LGPL"` for the license field, instead of the whole license text.