### PR TITLE
Remove obsolete surflock functions

### DIFF
--- a/docs/reST/c_api/surflock.rst
+++ b/docs/reST/c_api/surflock.rst
@@ -15,33 +15,6 @@ This extension module implements SDL surface locking for the
 Header file: src_c/include/pygame.h
 
 
-.. c:type:: pgLifetimeLockObject
-
-   .. c:member:: PyObject *surface
-
-      An SDL locked pygame surface.
-
-   .. c:member:: PyObject *lockobj
-
-      The Python object which owns the lock on the surface.
-      This field does not own a reference to the object.
-
-   The lifetime lock type instance.
-   A lifetime lock pairs a locked pygame surface with
-   the Python object that locked the surface for modification.
-   The lock is removed automatically when the lifetime lock instance
-   is garbage collected.
-
-.. c:var:: PyTypeObject *pgLifetimeLock_Type
-
-   The pygame internal surflock lifetime lock object type.
-
-.. c:function:: int pgLifetimeLock_Check(PyObject *x)
-
-   Return true if Python object *x* is a :c:data:`pgLifetimeLock_Type` instance,
-   false otherwise.
-   This will return false on :c:data:`pgLifetimeLock_Type` subclass instances as well.
-
 .. c:function:: void pgSurface_Prep(pgSurfaceObject *surfobj)
 
    If *surfobj* is a subsurface, then lock the parent surface with *surfobj*
@@ -72,11 +45,3 @@ Header file: src_c/include/pygame.h
 .. c:function:: int pgSurface_UnLockBy(pgSurfaceObject *surfobj, PyObject *lockobj)
 
    Remove the lock on pygame surface *surfobj* owned by Python object *lockobj*.
-
-.. c:function:: PyObject *pgSurface_LockLifetime(PyObject *surfobj, PyObject *lockobj)
-
-   Lock pygame surface *surfobj* for Python object *lockobj* and return a
-   new :c:data:`pgLifetimeLock_Type` instance for the lock.
-
-   This function is not called anywhere within pygame.
-   It and pgLifetimeLock_Type are candidates for removal.

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -486,15 +486,6 @@ struct pgEventObject {
 };
 
 /*
- * surflock module internals
- */
-typedef struct {
-    PyObject_HEAD PyObject *surface;
-    PyObject *lockobj;
-    PyObject *weakrefs;
-} pgLifetimeLockObject;
-
-/*
  * surface module internals
  */
 struct pgSubSurface_Data {
@@ -542,7 +533,7 @@ typedef enum {
 #define PYGAMEAPI_JOYSTICK_NUMSLOTS 3
 #define PYGAMEAPI_DISPLAY_NUMSLOTS 2
 #define PYGAMEAPI_SURFACE_NUMSLOTS 4
-#define PYGAMEAPI_SURFLOCK_NUMSLOTS 8
+#define PYGAMEAPI_SURFLOCK_NUMSLOTS 6
 #define PYGAMEAPI_RWOBJECT_NUMSLOTS 5
 #define PYGAMEAPI_PIXELARRAY_NUMSLOTS 2
 #define PYGAMEAPI_COLOR_NUMSLOTS 5

--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -354,32 +354,25 @@ typedef struct {
  * auto imported/initialized by surface
  */
 #ifndef PYGAMEAPI_SURFLOCK_INTERNAL
-#define pgLifetimeLock_Type (*(PyTypeObject *)PYGAMEAPI_GET_SLOT(surflock, 0))
-
-#define pgLifetimeLock_Check(x) ((x)->ob_type == &pgLifetimeLock_Type)
-
 #define pgSurface_Prep(x) \
     if ((x)->subsurface)  \
-    (*(*(void (*)(pgSurfaceObject *))PYGAMEAPI_GET_SLOT(surflock, 1)))(x)
+    (*(*(void (*)(pgSurfaceObject *))PYGAMEAPI_GET_SLOT(surflock, 0)))(x)
 
 #define pgSurface_Unprep(x) \
     if ((x)->subsurface)    \
-    (*(*(void (*)(pgSurfaceObject *))PYGAMEAPI_GET_SLOT(surflock, 2)))(x)
+    (*(*(void (*)(pgSurfaceObject *))PYGAMEAPI_GET_SLOT(surflock, 1)))(x)
 
 #define pgSurface_Lock \
-    (*(int (*)(pgSurfaceObject *))PYGAMEAPI_GET_SLOT(surflock, 3))
+    (*(int (*)(pgSurfaceObject *))PYGAMEAPI_GET_SLOT(surflock, 2))
 
 #define pgSurface_Unlock \
-    (*(int (*)(pgSurfaceObject *))PYGAMEAPI_GET_SLOT(surflock, 4))
+    (*(int (*)(pgSurfaceObject *))PYGAMEAPI_GET_SLOT(surflock, 3))
 
 #define pgSurface_LockBy \
-    (*(int (*)(pgSurfaceObject *, PyObject *))PYGAMEAPI_GET_SLOT(surflock, 5))
+    (*(int (*)(pgSurfaceObject *, PyObject *))PYGAMEAPI_GET_SLOT(surflock, 4))
 
 #define pgSurface_UnlockBy \
-    (*(int (*)(pgSurfaceObject *, PyObject *))PYGAMEAPI_GET_SLOT(surflock, 6))
-
-#define pgSurface_LockLifetime \
-    (*(PyObject * (*)(PyObject *, PyObject *)) PYGAMEAPI_GET_SLOT(surflock, 7))
+    (*(int (*)(pgSurfaceObject *, PyObject *))PYGAMEAPI_GET_SLOT(surflock, 5))
 #endif
 
 /*

--- a/src_c/static.c
+++ b/src_c/static.c
@@ -334,8 +334,6 @@ PyInit_pygame_static()
 #undef pgSurface_UnlockBy
 #undef pgSurface_Prep
 #undef pgSurface_Unprep
-#undef pgLifetimeLock_Type
-#undef pgSurface_LockLifetime
 
 #include "surflock.c"
 

--- a/src_c/surflock.c
+++ b/src_c/surflock.c
@@ -40,9 +40,6 @@ static int
 pgSurface_UnlockBy(pgSurfaceObject *, PyObject *);
 
 static void
-_lifelock_dealloc(PyObject *);
-
-static void
 pgSurface_Prep(pgSurfaceObject *surfobj)
 {
     struct pgSubSurface_Data *data = ((pgSurfaceObject *)surfobj)->subsurface;
@@ -169,51 +166,6 @@ pgSurface_UnlockBy(pgSurfaceObject *surfobj, PyObject *lockobj)
     return noerror;
 }
 
-static PyTypeObject pgLifetimeLock_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "pygame.surflock.SurfLifeLock",
-    .tp_basicsize = sizeof(pgLifetimeLockObject),
-    .tp_dealloc = _lifelock_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    .tp_weaklistoffset = offsetof(pgLifetimeLockObject, weakrefs),
-};
-
-/* lifetimelock object internals */
-static void
-_lifelock_dealloc(PyObject *self)
-{
-    pgLifetimeLockObject *lifelock = (pgLifetimeLockObject *)self;
-
-    if (lifelock->weakrefs != NULL) {
-        PyObject_ClearWeakRefs(self);
-    }
-
-    pgSurface_UnlockBy((pgSurfaceObject *)lifelock->surface,
-                       lifelock->lockobj);
-    Py_DECREF(lifelock->surface);
-    Py_TYPE(self)->tp_free(self);
-}
-
-static PyObject *
-pgSurface_LockLifetime(PyObject *surfobj, PyObject *lockobj)
-{
-    pgLifetimeLockObject *life;
-    if (surfobj == NULL) {
-        return RAISE(pgExc_SDLError, SDL_GetError());
-    }
-
-    life = PyObject_New(pgLifetimeLockObject, &pgLifetimeLock_Type);
-    if (life != NULL) {
-        life->surface = surfobj;
-        life->lockobj = lockobj;
-        life->weakrefs = NULL;
-        Py_INCREF(surfobj);
-        if (!pgSurface_LockBy((pgSurfaceObject *)surfobj, lockobj)) {
-            return NULL;
-        }
-    }
-    return (PyObject *)life;
-}
-
 static PyMethodDef _surflock_methods[] = {{NULL, NULL, 0, NULL}};
 
 /*DOC*/ static char _surflock_doc[] =
@@ -234,10 +186,6 @@ MODINIT_DEFINE(surflock)
                                          NULL,
                                          NULL};
 
-    if (PyType_Ready(&pgLifetimeLock_Type) < 0) {
-        return NULL;
-    }
-
     /* Create the module and add the functions */
     module = PyModule_Create(&_module);
     if (module == NULL) {
@@ -245,14 +193,12 @@ MODINIT_DEFINE(surflock)
     }
 
     /* export the c api */
-    c_api[0] = &pgLifetimeLock_Type;
-    c_api[1] = pgSurface_Prep;
-    c_api[2] = pgSurface_Unprep;
-    c_api[3] = pgSurface_Lock;
-    c_api[4] = pgSurface_Unlock;
-    c_api[5] = pgSurface_LockBy;
-    c_api[6] = pgSurface_UnlockBy;
-    c_api[7] = pgSurface_LockLifetime;
+    c_api[0] = pgSurface_Prep;
+    c_api[1] = pgSurface_Unprep;
+    c_api[2] = pgSurface_Lock;
+    c_api[3] = pgSurface_Unlock;
+    c_api[4] = pgSurface_LockBy;
+    c_api[5] = pgSurface_UnlockBy;
     apiobj = encapsulate_api(c_api, "surflock");
     if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
         Py_XDECREF(apiobj);


### PR DESCRIPTION
In 2018, llindstrom wrote of pgSurface_LockLifetime in surflock.rst that "This function is not called anywhere within pygame. It and pgLifetimeLock_Type are candidates for removal."

In the intervening 6 years, the functions and documentation have not been meaningfully edited, and these systems are still not used anywhere.

So let's remove them.