### PR TITLE
Version-getters SDL2/SDL3

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -106,6 +106,10 @@ PG_UnlockMutex(SDL_mutex *mutex)
 #define PG_SetJoystickEventsEnabled(enabled) \
     SDL_SetJoystickEventsEnabled(enabled)
 
+#define PG_FIND_VNUM_MAJOR(ver) SDL_VERSIONNUM_MAJOR(ver)
+#define PG_FIND_VNUM_MINOR(ver) SDL_VERSIONNUM_MINOR(ver)
+#define PG_FIND_VNUM_MICRO(ver) SDL_VERSIONNUM_MICRO(ver)
+
 #else /* ~SDL_VERSION_ATLEAST(3, 0, 0)*/
 #define PG_ShowCursor() SDL_ShowCursor(SDL_ENABLE)
 #define PG_HideCursor() SDL_ShowCursor(SDL_DISABLE)
@@ -166,6 +170,10 @@ PG_UnlockMutex(SDL_mutex *mutex)
 #define PG_SetEventEnabled(type, enabled) SDL_EventState(type, enabled)
 #define PG_EventEnabled(type) SDL_EventState(type, SDL_QUERY)
 #define PG_SetJoystickEventsEnabled(enabled) SDL_JoystickEventState(enabled)
+
+#define PG_FIND_VNUM_MAJOR(ver) ver.major
+#define PG_FIND_VNUM_MINOR(ver) ver.minor
+#define PG_FIND_VNUM_MICRO(ver) ver.patch
 
 #if SDL_VERSION_ATLEAST(2, 0, 14)
 #define PG_SurfaceHasRLE SDL_HasSurfaceRLE

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -1233,6 +1233,12 @@ static PyObject *
 get_ttf_version(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     int linked = 1; /* Default is linked version. */
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    int version = SDL_TTF_VERSION;
+#else
+    SDL_version version;
+    TTF_VERSION(&version);
+#endif
 
     static char *keywords[] = {"linked", NULL};
 
@@ -1241,15 +1247,16 @@ get_ttf_version(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (linked) {
-        const SDL_version *v = TTF_Linked_Version();
-        return Py_BuildValue("iii", v->major, v->minor, v->patch);
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+        version = TTF_Version();
+#else
+        version = *TTF_Linked_Version();
+#endif
     }
-    else {
-        /* compiled version */
-        SDL_version v;
-        TTF_VERSION(&v);
-        return Py_BuildValue("iii", v.major, v.minor, v.patch);
-    }
+
+    return Py_BuildValue("iii", PG_FIND_VNUM_MAJOR(version),
+                         PG_FIND_VNUM_MINOR(version),
+                         PG_FIND_VNUM_MICRO(version));
 }
 
 static PyMethodDef _font_methods[] = {

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -272,6 +272,12 @@ imageext_get_sdl_image_version(PyObject *self, PyObject *args,
                                PyObject *kwargs)
 {
     int linked = 1;
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    int version = SDL_IMAGE_VERSION;
+#else
+    SDL_version version;
+    SDL_IMAGE_VERSION(&version);
+#endif
 
     static char *keywords[] = {"linked", NULL};
 
@@ -280,14 +286,16 @@ imageext_get_sdl_image_version(PyObject *self, PyObject *args,
     }
 
     if (linked) {
-        const SDL_version *v = IMG_Linked_Version();
-        return Py_BuildValue("iii", v->major, v->minor, v->patch);
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+        version = IMG_Version();
+#else
+        version = *IMG_Linked_Version();
+#endif
     }
-    else {
-        SDL_version v;
-        SDL_IMAGE_VERSION(&v);
-        return Py_BuildValue("iii", v.major, v.minor, v.patch);
-    }
+
+    return Py_BuildValue("iii", PG_FIND_VNUM_MAJOR(version),
+                         PG_FIND_VNUM_MINOR(version),
+                         PG_FIND_VNUM_MICRO(version));
 }
 
 /*

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1583,6 +1583,12 @@ static PyObject *
 mixer_get_sdl_mixer_version(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     int linked = 1; /* Default is linked version. */
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    int version = SDL_MIXER_VERSION;
+#else
+    SDL_version version;
+    SDL_MIXER_VERSION(&version);
+#endif
 
     static char *keywords[] = {"linked", NULL};
 
@@ -1593,16 +1599,16 @@ mixer_get_sdl_mixer_version(PyObject *self, PyObject *args, PyObject *kwargs)
     /* MIXER_INIT_CHECK() is not required for these methods. */
 
     if (linked) {
-        /* linked version */
-        const SDL_version *v = Mix_Linked_Version();
-        return Py_BuildValue("iii", v->major, v->minor, v->patch);
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+        version = Mix_Version();
+#else
+        version = *Mix_Linked_Version();
+#endif
     }
-    else {
-        /* compiled version */
-        SDL_version v;
-        SDL_MIXER_VERSION(&v);
-        return Py_BuildValue("iii", v.major, v.minor, v.patch);
-    }
+
+    return Py_BuildValue("iii", PG_FIND_VNUM_MAJOR(version),
+                         PG_FIND_VNUM_MINOR(version),
+                         PG_FIND_VNUM_MICRO(version));
 }
 
 static int


### PR DESCRIPTION
Continuing my SDL3 patch series.

This takes a look at all "version getters" from SDL and satellite libraries in one go, since they've all consistently updated.