### PR TITLE
Fix homepage and release notes link in pypi urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,11 @@ classifiers = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/pygame-community/pygame-ce"
+homepage = "https://pyga.me"
 "Bug Reports" = "https://github.com/pygame-community/pygame-ce/issues"
-"Source" = "https://github.com/pygame-community/pygame-ce"
 "Documentation" = "https://pyga.me/docs"
+"Release Notes" = "https://github.com/pygame-community/pygame-ce/releases"
+"Source" = "https://github.com/pygame-community/pygame-ce"
 
 [project.entry-points.pyinstaller40]
 hook-dirs = 'pygame.__pyinstaller:get_hook_dirs'

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ METADATA = {
         "Documentation": "https://pyga.me/docs",
         "Bug Tracker": "https://github.com/pygame-community/pygame-ce/issues",
         "Source": "https://github.com/pygame-community/pygame-ce",
+        "Release Notes": "https://github.com/pygame-community/pygame-ce/releases",
     },
     "classifiers": [
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Simple PR, makes sure our homepage url is https://pyga.me and also adds a link to our github releases, so people visiting our pypi page know where to find our changelog.