### PR TITLE
Restore inlining for `.fblits()` internal functionality

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2107,7 +2107,7 @@ bliterror:
 #define FBLITS_ERR_INCORRECT_ARGS_NUM 12
 #define FBLITS_ERR_FLAG_NOT_NUMERIC 13
 
-int
+static int PG_FORCEINLINE
 _surf_fblits_item_check_and_blit(pgSurfaceObject *self, PyObject *item,
                                  int blend_flags)
 {


### PR DESCRIPTION
A previous PR (#2679) improved the fblits function by condensing the core loop into a separate function. However, this change slightly impacted performance, particularly with small surfaces, which are the primary focus of the fblits function. This new PR aims to restore the original performance without significantly increasing the code size.

Interestingly, the results are as follows:

New: 234,496 bytes
Old: 235,008 bytes

This minor discrepancy of 512 bytes represents a 0.2% increase in code size, which is negligible.
![image](https://github.com/pygame-community/pygame-ce/assets/103119829/e1822e71-e000-4863-b09f-9106434df563)
The test demonstrates a 10x10 pixel surface being drawn onto a 1000x1000 screen, with the x-axis representing the number of surfaces drawn.