### PR TITLE
Condense `SDL_PixelFormat` copy code in `pgSurface_Blit()`

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -476,7 +476,7 @@ surface_str(PyObject *self)
 }
 
 static intptr_t
-surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds) c
+surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
 {
     Uint32 flags = 0;
     int width, height;

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3841,29 +3841,15 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
             result = pygame_Blit(src, srcrect, dst, dstrect, 0);
         }
         else {
-            SDL_PixelFormat *fmt = src->format;
             SDL_PixelFormat newfmt;
 
+            memcpy(&newfmt, src->format, sizeof(SDL_PixelFormat));
+
             newfmt.palette = 0; /* Set NULL (or SDL gets confused) */
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-            newfmt.bits_per_pixel = fmt->bits_per_pixel;
-            newfmt.bytes_per_pixel = fmt->bytes_per_pixel;
-#else
-            newfmt.BitsPerPixel = fmt->BitsPerPixel;
-            newfmt.BytesPerPixel = fmt->BytesPerPixel;
-#endif
             newfmt.Amask = 0;
-            newfmt.Rmask = fmt->Rmask;
-            newfmt.Gmask = fmt->Gmask;
-            newfmt.Bmask = fmt->Bmask;
             newfmt.Ashift = 0;
-            newfmt.Rshift = fmt->Rshift;
-            newfmt.Gshift = fmt->Gshift;
-            newfmt.Bshift = fmt->Bshift;
             newfmt.Aloss = 0;
-            newfmt.Rloss = fmt->Rloss;
-            newfmt.Gloss = fmt->Gloss;
-            newfmt.Bloss = fmt->Bloss;
+
             src = PG_ConvertSurface(src, &newfmt);
             if (src) {
                 result = SDL_BlitSurface(src, srcrect, dst, dstrect);

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -476,7 +476,7 @@ surface_str(PyObject *self)
 }
 
 static intptr_t
-surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
+surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds) c
 {
     Uint32 flags = 0;
     int width, height;
@@ -3843,7 +3843,8 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
         else {
             SDL_PixelFormat newfmt = *src->format;
 
-            newfmt.palette = 0; /* Set NULL (or SDL gets confused) */
+            newfmt.palette = NULL; /* Set NULL (or SDL gets confused) */
+            newfmt.next = NULL;
             newfmt.Amask = 0;
             newfmt.Ashift = 0;
             newfmt.Aloss = 0;

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3841,9 +3841,7 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
             result = pygame_Blit(src, srcrect, dst, dstrect, 0);
         }
         else {
-            SDL_PixelFormat newfmt;
-
-            memcpy(&newfmt, src->format, sizeof(SDL_PixelFormat));
+            SDL_PixelFormat newfmt = *src->format;
 
             newfmt.palette = 0; /* Set NULL (or SDL gets confused) */
             newfmt.Amask = 0;


### PR DESCRIPTION
This PR tries to make code more compact, legible and not dependant on SDL versions. Not completely sure this will work though.