### PR TITLE
Ensure `.premul_alpha_ip()` works with zero sized Surfaces

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3134,8 +3134,10 @@ surf_premul_alpha_ip(pgSurfaceObject *self, PyObject *_null)
     SDL_Surface *surf = pgSurface_AsSurface(self);
     SURF_INIT_CHECK(surf)
 
-    if (!surf->w || !surf->h)
-        Py_RETURN_NONE;
+    if (!surf->w || !surf->h) {
+        Py_INCREF(self);
+        return (PyObject *)self;
+    }
 
     pgSurface_Prep(self);
 

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -4114,7 +4114,6 @@ class SurfaceBlendTest(unittest.TestCase):
             self.assertIs(surf, surf.premul_alpha_ip())
 
 
-
 class SurfaceSelfBlitTest(unittest.TestCase):
     """Blit to self tests.
 

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -4108,6 +4108,12 @@ class SurfaceBlendTest(unittest.TestCase):
                         ),
                     )
 
+        for size in [(0, 0), (1, 0), (0, 1), (10, 10)]:
+            surf = pygame.Surface(size, pygame.SRCALPHA, 32)
+            surf.fill((32, 44, 4, 123))
+            self.assertIs(surf, surf.premul_alpha_ip())
+
+
 
 class SurfaceSelfBlitTest(unittest.TestCase):
     """Blit to self tests.


### PR DESCRIPTION
Before this change zero sized surfaces would return `None` instead of self. Now it correctly returns self. I also added a test to check for this.