### PR TITLE
python -m buildconfig now works again...

### DIFF
--- a/buildconfig/config.py
+++ b/buildconfig/config.py
@@ -167,8 +167,9 @@ Only SDL2 is supported now.""")
 
     kwds = {}
 
-    if sys.argv[1] == "docs":
-        sys.exit(docs_run())
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "docs":
+            sys.exit(docs_run())
 
     if sys.platform == 'win32':
         if sys.version_info >= (3, 8) and is_msys2():


### PR DESCRIPTION
Yeah, in #2942, I overlooked something silly and broke `python -m buildconfig` itself lol. This fixes that. Although, I have some ideas that might come in a PR soon that'll revamp this whole thing