### PR TITLE
Fix break when the OS resizes our window in `set_mode`

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1362,15 +1362,15 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
      */
     if (!state->using_gl && ((flags & (PGS_SCALED | PGS_FULLSCREEN)) == 0) &&
         !vsync) {
-        SDL_Surface *sdlSurf = SDL_GetWindowSurface(win);
-        if (((sdlSurf->w != w_actual) || (sdlSurf->h != h_actual)) &&
-            ((sdlSurf->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0)) {
+        if (((surface->surf->w != w_actual) ||
+             (surface->surf->h != h_actual)) &&
+            ((surface->surf->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0)) {
             char buffer[150];
-            char *formatString =
+            char *format_string =
                 "Requested window size was smaller than minimum supported "
                 "window size on platform. Using (%d, %d) instead.";
-            snprintf(buffer, sizeof(buffer), formatString, sdlSurf->w,
-                     sdlSurf->h);
+            snprintf(buffer, sizeof(buffer), format_string, surface->surf->w,
+                     surface->surf->h);
             if (PyErr_WarnEx(PyExc_RuntimeWarning, buffer, 1) != 0) {
                 return NULL;
             }

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -874,6 +874,9 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
         h = 0;
     }
 
+    h_actual = h;
+    w_actual = w;
+
     if (!SDL_WasInit(SDL_INIT_VIDEO)) {
         /* note SDL works special like this too */
         if (!pg_display_init(NULL, NULL))

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1321,7 +1321,6 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
 
         /* ensure window is always black after a set_mode call */
         SDL_FillRect(surf, NULL, SDL_MapRGB(surf->format, 0, 0, 0));
-        pg_flip_internal(state);
     }
 
     /*set the window icon*/

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -151,7 +151,11 @@ class DisplayModuleTest(unittest.TestCase):
         self.assertTrue(display.get_init())
 
     def test_get_surface(self):
-        """Ensures get_surface gets the current display surface."""
+        """Ensures get_surface gets the current display surface.
+        We can't guarantee small screen sizes get respected, so the
+        sizes of the surfaces returned from set_mode must be compared
+        to the size of the surface from get_surface.
+        """
         lengths = (1, 5, 100)
         correct_depth = pygame.display.Info().bitsize
 
@@ -169,7 +173,7 @@ class DisplayModuleTest(unittest.TestCase):
 
                 self.assertEqual(surface, expected_surface)
                 self.assertIsInstance(surface, pygame.Surface)
-                self.assertEqual(surface.get_size(), expected_size)
+                self.assertEqual(surface.get_size(), expected_surface.get_size())
                 self.assertEqual(surface.get_bitsize(), correct_depth)
 
     def test_get_surface__mode_not_set(self):


### PR DESCRIPTION
Hopefully fixes #2991. I suspect that there's a lot I missed, so @robertpfeiffer @ankith26 @Starbuck5 please take a long look at these changes.

I haven't found a reliable way we can predict what the size the OS will force small windows to is, so I resorted to seeing what SDL says it is. Maybe I could just manually go through the event queue instead of pumping and grabbing the size from there?