### PR TITLE
Use python 3.8 isms in the type stubs

### DIFF
--- a/buildconfig/stubs/pygame/_common.pyi
+++ b/buildconfig/stubs/pygame/_common.pyi
@@ -1,8 +1,5 @@
 from os import PathLike
-from typing import IO, Callable, Tuple, Union, TypeVar
-
-from typing_extensions import Literal as Literal, SupportsIndex as SupportsIndex
-from typing_extensions import Protocol
+from typing import IO, Callable, Tuple, Union, TypeVar, Protocol, SupportsIndex
 
 # For functions that take a file name
 AnyPath = Union[str, bytes, PathLike[str], PathLike[bytes]]

--- a/buildconfig/stubs/pygame/color.pyi
+++ b/buildconfig/stubs/pygame/color.pyi
@@ -1,7 +1,7 @@
 import sys
-from typing import Any, Dict, Iterator, Tuple, Union, overload
+from typing import Any, Dict, Iterator, SupportsIndex, Tuple, Union, overload
 
-from ._common import ColorValue, SupportsIndex
+from ._common import ColorValue
 
 if sys.version_info >= (3, 9):
     from collections.abc import Collection

--- a/buildconfig/stubs/pygame/cursors.pyi
+++ b/buildconfig/stubs/pygame/cursors.pyi
@@ -1,8 +1,8 @@
-from typing import Any, Iterator, Tuple, Union, overload
+from typing import Any, Iterator, Literal, Tuple, Union, overload
 
 from pygame.surface import Surface
 
-from ._common import FileArg, Literal, IntCoordinate, Sequence
+from ._common import FileArg, IntCoordinate, Sequence
 
 _Small_string = Tuple[
     str, str, str, str, str, str, str, str, str, str, str, str, str, str, str, str

--- a/buildconfig/stubs/pygame/font.pyi
+++ b/buildconfig/stubs/pygame/font.pyi
@@ -1,8 +1,8 @@
-from typing import Callable, Hashable, Iterable, List, Optional, Tuple, Union
+from typing import Callable, Hashable, Iterable, List, Literal, Optional, Tuple, Union
 
 from pygame.surface import Surface
 
-from ._common import ColorValue, FileArg, Literal
+from ._common import ColorValue, FileArg
 
 # TODO: Figure out a way to type this attribute such that mypy knows it's not
 # always defined at runtime

--- a/buildconfig/stubs/pygame/image.pyi
+++ b/buildconfig/stubs/pygame/image.pyi
@@ -1,9 +1,9 @@
-from typing import Optional, Tuple, Union
+from typing import Literal, Optional, Tuple, Union
 
 from pygame.bufferproxy import BufferProxy
 from pygame.surface import Surface
 
-from ._common import FileArg, Literal, IntCoordinate, Coordinate
+from ._common import FileArg, IntCoordinate, Coordinate
 
 _BufferStyle = Union[BufferProxy, bytes, bytearray, memoryview]
 _to_string_format = Literal[

--- a/buildconfig/stubs/pygame/math.pyi
+++ b/buildconfig/stubs/pygame/math.pyi
@@ -5,6 +5,7 @@ from typing import (
     Iterator,
     List,
     Literal,
+    SupportsIndex,
     Tuple,
     Type,
     TypeVar,
@@ -19,7 +20,7 @@ if sys.version_info >= (3, 9):
 else:
     from typing import Collection
 
-from ._common import SupportsIndex, Sequence
+from ._common import Sequence
 
 def clamp(value: float, min: float, max: float, /) -> float: ...
 

--- a/buildconfig/stubs/pygame/mouse.pyi
+++ b/buildconfig/stubs/pygame/mouse.pyi
@@ -1,5 +1,4 @@
-from typing import Tuple, overload
-from typing_extensions import Literal
+from typing import Literal, Tuple, overload
 from pygame.cursors import Cursor
 from pygame.surface import Surface
 

--- a/buildconfig/stubs/pygame/pixelcopy.pyi
+++ b/buildconfig/stubs/pygame/pixelcopy.pyi
@@ -1,8 +1,8 @@
+from typing import Literal
+
 import numpy
 
 from pygame.surface import Surface
-
-from ._common import Literal
 
 _kind = Literal["P", "p", "R", "r", "G", "g", "B", "b", "A", "a", "C", "c"]
 

--- a/buildconfig/stubs/pygame/rect.pyi
+++ b/buildconfig/stubs/pygame/rect.pyi
@@ -2,6 +2,8 @@ import sys
 from typing import (
     Dict,
     List,
+    Literal,
+    SupportsIndex,
     Tuple,
     TypeVar,
     Union,
@@ -10,7 +12,7 @@ from typing import (
     Optional,
 )
 
-from ._common import Coordinate, Literal, RectValue, SupportsIndex, Sequence
+from ._common import Coordinate, RectValue, Sequence
 
 if sys.version_info >= (3, 11):
     from typing import Self

--- a/buildconfig/stubs/pygame/sprite.pyi
+++ b/buildconfig/stubs/pygame/sprite.pyi
@@ -7,14 +7,12 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Protocol,
     SupportsFloat,
     Tuple,
     TypeVar,
     Union,
 )
-
-# Protocol added in python 3.8
-from typing_extensions import Protocol
 
 from pygame.rect import FRect, Rect
 from pygame.surface import Surface

--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, List, Optional, Tuple, Union, overload
+from typing import Any, Iterable, List, Literal, Optional, Tuple, Union, overload
 
 from pygame.bufferproxy import BufferProxy
 from pygame.color import Color
@@ -7,7 +7,6 @@ from pygame.rect import FRect, Rect
 from ._common import (
     ColorValue,
     Coordinate,
-    Literal,
     RectValue,
     RGBAOutput,
     Sequence,

--- a/buildconfig/stubs/pygame/system.pyi
+++ b/buildconfig/stubs/pygame/system.pyi
@@ -1,6 +1,4 @@
-from typing import List, Optional, final
-
-from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from pygame._data_classes import PowerState
 

--- a/buildconfig/stubs/pygame/version.pyi
+++ b/buildconfig/stubs/pygame/version.pyi
@@ -1,6 +1,4 @@
-from typing import Tuple
-
-from ._common import Literal
+from typing import Literal, Tuple
 
 class SoftwareVersion(Tuple[int, int, int]):
     def __new__(cls, major: int, minor: int, patch: int) -> SoftwareVersion: ...


### PR DESCRIPTION
`Protocol`, `SupportsIndex`, `Literal` and `TypedDict` were all added in Python 3.8

We can make use of these directly with a `typing` import as our minimum supported python version is 3.8