### PR TITLE
Fix editable install test fixtures logic

### DIFF
--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -3,8 +3,6 @@ import pygame
 import sys
 import tempfile
 
-is_pygame_pkg = __name__.startswith("pygame.tests.")
-
 ###############################################################################
 
 
@@ -22,11 +20,8 @@ def geterror():
 ###############################################################################
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
-trunk_dir = os.path.split(os.path.split(this_dir)[0])[0]
-if is_pygame_pkg:
-    test_module = "tests"
-else:
-    test_module = "test"
+this_dir_parent = os.path.split(this_dir)[0]
+trunk_dir = os.path.split(this_dir_parent)[0]
 
 
 def trunk_relative_path(relative):
@@ -34,7 +29,7 @@ def trunk_relative_path(relative):
 
 
 def fixture_path(path):
-    return trunk_relative_path(os.path.join(test_module, "fixtures", path))
+    return os.path.join(this_dir_parent, "fixtures", path)
 
 
 def example_path(path):


### PR DESCRIPTION
Simple PR to fix a small issue in our test runner script. With editable installs, the older path resolution logic didn't give correct paths anymore, resulting in a fail (issue discovered while working on #2990)
