### PR TITLE
Make deprecated API raise deprecation warnings

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -51,6 +51,8 @@ _ft_get_error(PyObject *, PyObject *);
 static PyObject *
 _ft_get_init(PyObject *, PyObject *);
 static PyObject *
+_ft_was_init(PyObject *, PyObject *);
+static PyObject *
 _ft_autoinit(PyObject *, PyObject *);
 static PyObject *
 _ft_get_cache_size(PyObject *, PyObject *);
@@ -495,7 +497,7 @@ static PyMethodDef _ft_methods[] = {
      DOC_FREETYPE_INIT},
     {"quit", (PyCFunction)_ft_quit, METH_NOARGS, DOC_FREETYPE_QUIT},
     {"get_init", _ft_get_init, METH_NOARGS, DOC_FREETYPE_GETINIT},
-    {"was_init", _ft_get_init, METH_NOARGS,
+    {"was_init", _ft_was_init, METH_NOARGS,
      DOC_FREETYPE_WASINIT},  // DEPRECATED
     {"get_error", _ft_get_error, METH_NOARGS, DOC_FREETYPE_GETERROR},
     {"get_version", (PyCFunction)_ft_get_version, METH_VARARGS | METH_KEYWORDS,
@@ -2228,6 +2230,19 @@ static PyObject *
 _ft_get_init(PyObject *self, PyObject *_null)
 {
     return PyBool_FromLong(FREETYPE_MOD_STATE(self)->freetype ? 1 : 0);
+}
+
+static PyObject *
+_ft_was_init(PyObject *self, PyObject *_null)
+{
+    if (PyErr_WarnEx(
+            PyExc_DeprecationWarning,
+            "was_init has been deprecated and may be removed in a future "
+            "version. Use the equivalent get_init function instead",
+            1) == -1) {
+        return NULL;
+    }
+    return _ft_get_init(self, _null);
 }
 
 static PyObject *

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -349,6 +349,11 @@ _scrap_lost_scrap(PyObject *self, PyObject *_null)
 {
     PYGAME_SCRAP_INIT_CHECK();
 
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "pygame.scrap.lost deprecated since 2.2.0", 1) == -1) {
+        return NULL;
+    }
+
     if (pygame_scrap_lost())
         Py_RETURN_TRUE;
     Py_RETURN_FALSE;

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1767,6 +1767,10 @@ class FreeTypeTest(unittest.TestCase):
         # Test if get_init() gets the init state.
         self.assertTrue(ft.get_init())
 
+    def test_was_init_deprecated(self):
+        with self.assertWarns(DeprecationWarning):
+            self.assertTrue(ft.was_init())
+
     def test_cache_size(self):
         DEFAULT_CACHE_SIZE = 64
         self.assertEqual(ft.get_cache_size(), DEFAULT_CACHE_SIZE)


### PR DESCRIPTION
While reviewing #2984 I was going over the code to see the deprecation warnings. I found 2 instances of deprecated API that do not raise the warning in code, so I fixed it in this PR