### PR TITLE
Port bezier from ``gfxdraw`` to ``draw`` + bring the same support like every ``draw`` function

### DIFF
--- a/buildconfig/stubs/pygame/draw.pyi
+++ b/buildconfig/stubs/pygame/draw.pyi
@@ -89,3 +89,9 @@ def aalines(
     closed: bool,
     points: Sequence[Coordinate],
 ) -> Rect: ...
+def bezier(
+    surface: Surface,
+    points: Sequence[Coordinate],
+    steps: int,
+    color: ColorValue,
+) -> None: ...

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -598,6 +598,37 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
    .. ## pygame.draw.aalines ##
 
+.. function:: bezier
+
+   | :sl:`draw a Bezier curve`
+   | :sg:`bezier(surface, points, steps, color) -> None`
+
+   Draws a Bézier curve on the given surface.
+
+   :param Surface surface: surface to draw on
+   :param points: a sequence of 3 or more (x, y) coordinates used to form a
+      curve, where each *coordinate* in the sequence must be a
+      tuple/list/:class:`pygame.math.Vector2` of 2 ints/floats (float values
+      will be truncated)
+   :type points: tuple(coordinate) or list(coordinate)
+   :param int steps: number of steps for the interpolation, the minimum is 2
+   :param color: color to draw with, the alpha value is optional if using a
+      tuple ``(RGB[A])``
+   :type color: Color or string (for :doc:`color_list`) or int or tuple(int, int, int, [int])
+
+   :returns: ``None``
+   :rtype: NoneType
+
+   :raises ValueError: if ``steps < 2``
+   :raises ValueError: if ``len(points) < 3`` (must have at least 3 points)
+   :raises IndexError: if ``len(coordinate) < 2`` (each coordinate must have
+      at least 2 items)
+
+   .. note:: This function supports up to around 150-200 points before the algorithm
+             breaks down.
+
+   .. ## pygame.draw.bezier ##
+
 .. ## pygame.draw ##
 
 .. figure:: code_examples/draw_module_example.png

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -10,3 +10,4 @@
 #define DOC_DRAW_LINES "lines(surface, color, closed, points) -> Rect\nlines(surface, color, closed, points, width=1) -> Rect\ndraw multiple contiguous straight line segments"
 #define DOC_DRAW_AALINE "aaline(surface, color, start_pos, end_pos) -> Rect\ndraw a straight antialiased line"
 #define DOC_DRAW_AALINES "aalines(surface, color, closed, points) -> Rect\ndraw multiple contiguous straight antialiased line segments"
+#define DOC_DRAW_BEZIER "bezier(surface, points, steps, color) -> None\ndraw a Bezier curve"

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -7074,6 +7074,115 @@ class DrawArcTest(DrawArcMixin, DrawTestCase):
     class to add any draw.arc specific tests to.
     """
 
+### Draw Bezier Testing #######################################################
+
+class DrawBezierTest(unittest.TestCase):
+
+    is_started = False
+
+    foreground_color = (128, 64, 8)
+    background_color = (255, 255, 255)
+
+    def make_palette(base_color):
+        """Return color palette that is various intensities of base_color"""
+        # Need this function for Python 3.x so the base_color
+        # is within the scope of the list comprehension.
+
+        palette = []
+        for i in range(0, 256):
+            r, g, b = base_color
+            if 0 <= i <= 127:
+                # Darken
+                palette.append(((r * i) // 127, (g * i) // 127, (b * i) // 127))
+            else:
+                # Lighten
+                palette.append((
+                    r + ((255 - r) * (255 - i)) // 127,
+                    g + ((255 - g) * (255 - i)) // 127,
+                    b + ((255 - b) * (255 - i)) // 127,
+                ))
+        return palette
+
+    default_palette = make_palette(foreground_color)
+
+    default_size = (100, 100)
+
+    def setUp(self):
+        # This makes sure pygame is always initialized before each test (in
+        # case a test calls pygame.quit()).
+        if not pygame.get_init():
+            pygame.init()
+
+        Surface = pygame.Surface
+        size = self.default_size
+        palette = self.default_palette
+        if not self.is_started:
+            # Create test surfaces
+            self.surfaces = [
+                Surface(size, 0, 8),
+                Surface(size, SRCALPHA, 16),
+                Surface(size, SRCALPHA, 32),
+            ]
+            self.surfaces[0].set_palette(palette)
+            nonpalette_fmts = (
+                # (8, (0xe0, 0x1c, 0x3, 0x0)),
+                (12, (0xF00, 0xF0, 0xF, 0x0)),
+                (15, (0x7C00, 0x3E0, 0x1F, 0x0)),
+                (15, (0x1F, 0x3E0, 0x7C00, 0x0)),
+                (16, (0xF00, 0xF0, 0xF, 0xF000)),
+                (16, (0xF000, 0xF00, 0xF0, 0xF)),
+                (16, (0xF, 0xF0, 0xF00, 0xF000)),
+                (16, (0xF0, 0xF00, 0xF000, 0xF)),
+                (16, (0x7C00, 0x3E0, 0x1F, 0x8000)),
+                (16, (0xF800, 0x7C0, 0x3E, 0x1)),
+                (16, (0x1F, 0x3E0, 0x7C00, 0x8000)),
+                (16, (0x3E, 0x7C0, 0xF800, 0x1)),
+                (16, (0xF800, 0x7E0, 0x1F, 0x0)),
+                (16, (0x1F, 0x7E0, 0xF800, 0x0)),
+                (24, (0xFF, 0xFF00, 0xFF0000, 0x0)),
+                (24, (0xFF0000, 0xFF00, 0xFF, 0x0)),
+                (32, (0xFF0000, 0xFF00, 0xFF, 0x0)),
+                (32, (0xFF000000, 0xFF0000, 0xFF00, 0x0)),
+                (32, (0xFF, 0xFF00, 0xFF0000, 0x0)),
+                (32, (0xFF00, 0xFF0000, 0xFF000000, 0x0)),
+                (32, (0xFF0000, 0xFF00, 0xFF, 0xFF000000)),
+                (32, (0xFF000000, 0xFF0000, 0xFF00, 0xFF)),
+                (32, (0xFF, 0xFF00, 0xFF0000, 0xFF000000)),
+                (32, (0xFF00, 0xFF0000, 0xFF000000, 0xFF)),
+            )
+            for bitsize, masks in nonpalette_fmts:
+                self.surfaces.append(Surface(size, 0, bitsize, masks))
+        for surf in self.surfaces:
+            surf.fill(self.background_color)
+
+    def check_at(self, surf, posn, color):
+        sc = surf.get_at(posn)
+        depth = surf.get_bitsize()
+        flags = surf.get_flags()
+        masks = surf.get_masks()
+        fail_msg = f"{sc} != {color} at {posn}, bitsize: {depth}, flags: {flags}, masks: {masks}"
+        self.assertEqual(sc, color, fail_msg)
+
+    def test_bezier(self):
+        """bezier(surface, points, steps, color): return None"""
+        fg = self.foreground_color
+        bg = self.background_color
+        points = [(10, 50), (25, 15), (60, 80), (92, 30)]
+        fg_test_points = [points[0], points[3]]
+        bg_test_points = [
+            (points[0][0] - 1, points[0][1]),
+            (points[3][0] + 1, points[3][1]),
+            (points[1][0], points[1][1] + 3),
+            (points[2][0], points[2][1] - 3),
+        ]
+        for surf in self.surfaces:
+            fg_adjusted = surf.unmap_rgb(surf.map_rgb(fg))
+            bg_adjusted = surf.unmap_rgb(surf.map_rgb(bg))
+            pygame.draw.bezier(surf, points, 30, fg)
+            for posn in fg_test_points:
+                self.check_at(surf, posn, fg_adjusted)
+            for posn in bg_test_points:
+                self.check_at(surf, posn, bg_adjusted)
 
 ### Draw Module Testing #######################################################
 


### PR DESCRIPTION
Hello, as part of #3005 plan, this PR moves ``pygame.gfxdraw.bezier`` to ``pygame.draw.bezier``.
Things remaining : 

- [ ] Deprecate ``pygame.gfxdraw.bezier``.
- [ ] Make ``pygame.draw.bezier`` returning the bounding rect like his fellow friends.