### PR TITLE
Deprecate `gfxdraw` but keep the functionality

### DIFF
--- a/buildconfig/stubs/pygame/gfxdraw.pyi
+++ b/buildconfig/stubs/pygame/gfxdraw.pyi
@@ -1,47 +1,64 @@
+
 from pygame.surface import Surface
+from typing_extensions import deprecated # added in 3.13
 
 from ._common import ColorValue, Coordinate, RectValue, Sequence
 
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.Surface.set_at` instead")
 def pixel(surface: Surface, x: int, y: int, color: ColorValue, /) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.line` instead")
 def hline(surface: Surface, x1: int, x2: int, y: int, color: ColorValue, /) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.line` instead")
 def vline(surface: Surface, x: int, y1: int, y2: int, color: ColorValue, /) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.line` instead")
 def line(
     surface: Surface, x1: int, y1: int, x2: int, y2: int, color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.rect` instead")
 def rectangle(surface: Surface, rect: RectValue, color: ColorValue, /) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.rect` instead")
 def box(surface: Surface, rect: RectValue, color: ColorValue, /) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.circle` instead")
 def circle(surface: Surface, x: int, y: int, r: int, color: ColorValue, /) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.aacircle` instead")
 def aacircle(surface: Surface, x: int, y: int, r: int, color: ColorValue, /) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.circle` instead")
 def filled_circle(
     surface: Surface, x: int, y: int, r: int, color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.ellipse` instead")
 def ellipse(
     surface: Surface, x: int, y: int, rx: int, ry: int, color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.aaellipse` instead")
 def aaellipse(
     surface: Surface, x: int, y: int, rx: int, ry: int, color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.ellipse` instead")
 def filled_ellipse(
     surface: Surface, x: int, y: int, rx: int, ry: int, color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.arc` instead")
 def arc(
     surface: Surface,
     x: int,
     y: int,
     r: int,
     start_angle: int,
-    atp_angle: int,
+    stop_angle: int,
     color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.arc` and `pygame.draw.line` instead")
 def pie(
     surface: Surface,
     x: int,
     y: int,
     r: int,
     start_angle: int,
-    atp_angle: int,
+    stop_angle: int,
     color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.polygon` instead")
 def trigon(
     surface: Surface,
     x1: int,
@@ -52,6 +69,7 @@ def trigon(
     y3: int,
     color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.aapolygon` instead")
 def aatrigon(
     surface: Surface,
     x1: int,
@@ -62,6 +80,7 @@ def aatrigon(
     y3: int,
     color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.polygon` instead")
 def filled_trigon(
     surface: Surface,
     x1: int,
@@ -72,18 +91,23 @@ def filled_trigon(
     y3: int,
     color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.polygon` instead")
 def polygon(
     surface: Surface, points: Sequence[Coordinate], color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.aapolygon` instead")
 def aapolygon(
     surface: Surface, points: Sequence[Coordinate], color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.polygon` instead")
 def filled_polygon(
     surface: Surface, points: Sequence[Coordinate], color: ColorValue, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION.")
 def textured_polygon(
     surface: Surface, points: Sequence[Coordinate], texture: Surface, tx: int, ty: int, /
 ) -> None: ...
+@deprecated("since GFX_DEPRECATED_VERSION. Use `pygame.draw.bezier` instead") # not implemented yet
 def bezier(
     surface: Surface, points: Sequence[Coordinate], steps: int, color: ColorValue, /
 ) -> None: ...

--- a/docs/reST/ref/gfxdraw.rst
+++ b/docs/reST/ref/gfxdraw.rst
@@ -8,8 +8,8 @@
 
 | :sl:`pygame module for drawing shapes`
 
-**EXPERIMENTAL!**: This API may change or disappear in later pygame releases. If
-you use this, your code may break with the next pygame release.
+**DEPRECATED!**: The gfxdraw module is now deprecated in favor of the draw module
+and all its functions are also deprecated.
 
 The pygame package does not import gfxdraw automatically when loaded, so it
 must imported explicitly to be used.
@@ -26,6 +26,7 @@ following formats:
    - a :mod:`pygame.Color` object
    - an ``(RGB)`` triplet (tuple/list)
    - an ``(RGBA)`` quadruplet (tuple/list)
+   - a ``"color"`` string
 
 The functions :meth:`rectangle` and :meth:`box` will accept any ``(x, y, w, h)``
 sequence for their ``rect`` argument, though :mod:`pygame.Rect` instances are
@@ -42,17 +43,6 @@ For example:
    pygame.gfxdraw.aacircle(surf, x, y, 30, col)
    pygame.gfxdraw.filled_circle(surf, x, y, 30, col)
 
-
-.. note::
-   For threading, each of the functions releases the GIL during the C part of
-   the call.
-
-.. note::
-   See the :mod:`pygame.draw` module for alternative draw methods.
-   The ``pygame.gfxdraw`` module differs from the :mod:`pygame.draw` module in
-   the API it uses and the different draw functions available.
-   ``pygame.gfxdraw`` wraps the primitives from the library called SDL_gfx,
-   rather than using modified versions.
 
 .. versionaddedold:: 1.9.0
 
@@ -73,6 +63,8 @@ For example:
 
    :returns: ``None``
    :rtype: NoneType
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.Surface.set_at` instead.
 
    .. ## pygame.gfxdraw.pixel ##
 
@@ -95,6 +87,8 @@ For example:
    :returns: ``None``
    :rtype: NoneType
 
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.line` instead.
+
    .. ## pygame.gfxdraw.hline ##
 
 .. function:: vline
@@ -115,6 +109,8 @@ For example:
 
    :returns: ``None``
    :rtype: NoneType
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.line` instead.
 
    .. ## pygame.gfxdraw.vline ##
 
@@ -137,6 +133,8 @@ For example:
 
    :returns: ``None``
    :rtype: NoneType
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.line` instead.
 
    .. ## pygame.gfxdraw.line ##
 
@@ -161,6 +159,8 @@ For example:
       The ``rect.bottom`` and ``rect.right`` attributes of a :mod:`pygame.Rect`
       always lie one pixel outside of its actual border. Therefore, these
       values will not be included as part of the drawing.
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.rect` instead.
 
    .. ## pygame.gfxdraw.rectangle ##
 
@@ -192,6 +192,8 @@ For example:
       accelerated on some platforms with both software and hardware display
       modes.
 
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.rect` instead.
+
    .. ## pygame.gfxdraw.box ##
 
 .. function:: circle
@@ -213,6 +215,8 @@ For example:
    :returns: ``None``
    :rtype: NoneType
 
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.circle` instead.
+
    .. ## pygame.gfxdraw.circle ##
 
 .. function:: aacircle
@@ -232,6 +236,8 @@ For example:
 
    :returns: ``None``
    :rtype: NoneType
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.aacircle` instead.
 
    .. ## pygame.gfxdraw.aacircle ##
 
@@ -253,6 +259,8 @@ For example:
 
    :returns: ``None``
    :rtype: NoneType
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.circle` instead.
 
    .. ## pygame.gfxdraw.filled_circle ##
 
@@ -276,6 +284,8 @@ For example:
    :returns: ``None``
    :rtype: NoneType
 
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.ellipse` instead.
+
    .. ## pygame.gfxdraw.ellipse ##
 
 .. function:: aaellipse
@@ -296,6 +306,8 @@ For example:
 
    :returns: ``None``
    :rtype: NoneType
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.aaellipse` instead.
 
    .. ## pygame.gfxdraw.aaellipse ##
 
@@ -318,6 +330,8 @@ For example:
 
    :returns: ``None``
    :rtype: NoneType
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.ellipse` instead.
 
    .. ## pygame.gfxdraw.filled_ellipse ##
 
@@ -346,6 +360,8 @@ For example:
 
    :returns: ``None``
    :rtype: NoneType
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.arc` instead.
 
    .. note::
       This function uses *degrees* while the :func:`pygame.draw.arc` function
@@ -380,6 +396,8 @@ For example:
    :returns: ``None``
    :rtype: NoneType
 
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.arc` and `pygame.draw.line` instead.
+
    .. ## pygame.gfxdraw.pie ##
 
 .. function:: trigon
@@ -407,6 +425,8 @@ For example:
    :returns: ``None``
    :rtype: NoneType
 
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.polygon` instead.
+
    .. ## pygame.gfxdraw.trigon ##
 
 .. function:: aatrigon
@@ -432,6 +452,8 @@ For example:
 
    :returns: ``None``
    :rtype: NoneType
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.aapolygon` instead.
 
    .. ## pygame.gfxdraw.aatrigon ##
 
@@ -459,6 +481,8 @@ For example:
 
    :returns: ``None``
    :rtype: NoneType
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.polygon` instead.
 
    .. ## pygame.gfxdraw.filled_trigon ##
 
@@ -493,6 +517,8 @@ For example:
    :raises IndexError: if ``len(coordinate) < 2`` (each coordinate must have
       at least 2 items)
 
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.polygon` instead.
+
    .. ## pygame.gfxdraw.polygon ##
 
 .. function:: aapolygon
@@ -524,6 +550,8 @@ For example:
    :raises ValueError: if ``len(points) < 3`` (must have at least 3 points)
    :raises IndexError: if ``len(coordinate) < 2`` (each coordinate must have
       at least 2 items)
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.aapolygon` instead.
 
    .. ## pygame.gfxdraw.aapolygon ##
 
@@ -557,6 +585,8 @@ For example:
    :raises ValueError: if ``len(points) < 3`` (must have at least 3 points)
    :raises IndexError: if ``len(coordinate) < 2`` (each coordinate must have
       at least 2 items)
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.polygon` instead.
 
    .. ## pygame.gfxdraw.filled_polygon ##
 
@@ -595,6 +625,8 @@ For example:
    :raises IndexError: if ``len(coordinate) < 2`` (each coordinate must have
       at least 2 items)
 
+   .. deprecated:: GFX_DEPRECATED_VERSION
+
    .. ## pygame.gfxdraw.textured_polygon ##
 
 .. function:: bezier
@@ -625,6 +657,8 @@ For example:
 
    .. note:: This function supports up to around 150-200 points before the algorithm
              breaks down.
+
+   .. deprecated:: GFX_DEPRECATED_VERSION Use :mod:`pygame.draw.bezier` instead.
 
    .. ## pygame.gfxdraw.bezier ##
 

--- a/docs/reST/ref/gfxdraw.rst
+++ b/docs/reST/ref/gfxdraw.rst
@@ -26,7 +26,6 @@ following formats:
    - a :mod:`pygame.Color` object
    - an ``(RGB)`` triplet (tuple/list)
    - an ``(RGBA)`` quadruplet (tuple/list)
-   - a ``"color"`` string
 
 The functions :meth:`rectangle` and :meth:`box` will accept any ``(x, y, w, h)``
 sequence for their ``rect`` argument, though :mod:`pygame.Rect` instances are

--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -39,8 +39,8 @@ We render three sets of items based on how useful to most apps.
 
 #}
 {%- set basic = ['Color', 'display', 'draw', 'event', 'font', 'image', 'key', 'locals', 'mixer', 'mouse', 'music', 'pygame', 'Rect', 'Surface', 'time'] %}
-{%- set advanced = ['BufferProxy', 'freetype', 'gfxdraw', 'midi', 'PixelArray', 'pixelcopy', 'sndarray', 'surfarray', 'cursors', 'joystick', 'mask', 'math', 'sprite', 'transform'] %}
-{%- set hidden = ['sdl2_video', 'sdl2_controller', 'geometry', 'Window'] %}
+{%- set advanced = ['BufferProxy', 'freetype', 'midi', 'PixelArray', 'pixelcopy', 'sndarray', 'surfarray', 'cursors', 'joystick', 'mask', 'math', 'sprite', 'transform'] %}
+{%- set hidden = ['sdl2_video', 'sdl2_controller', 'geometry', 'Window', 'gfxdraw'] %}
 {%-   if pyg_sections %}
 	  <p class="bottom"><b>Most useful stuff</b>:
 {%      set sep = joiner(" | \n") %}

--- a/src_c/gfxdraw.c
+++ b/src_c/gfxdraw.c
@@ -162,6 +162,14 @@ _gfx_pixelcolor(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "OhhO:pixel", &surface, &x, &y, &color))
         return NULL;
 
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.pixel` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.Surface.set_at` instead.",
+                     1) == -1) {
+        return NULL;
+    }
+
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
     }
@@ -187,6 +195,14 @@ _gfx_hlinecolor(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args, "OhhhO:hline", &surface, &x1, &x2, &y, &color))
         return NULL;
+
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.hline` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.line` instead.",
+                     1) == -1) {
+        return NULL;
+    }
 
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
@@ -215,6 +231,14 @@ _gfx_vlinecolor(PyObject *self, PyObject *args)
                           &color))
         return NULL;
 
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.vline` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.line` instead.",
+                     1) == -1) {
+        return NULL;
+    }
+
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
     }
@@ -241,6 +265,14 @@ _gfx_rectanglecolor(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args, "OOO:rectangle", &surface, &rect, &color)) {
         /* Exception already set */
+        return NULL;
+    }
+
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.rectangle` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.rect` instead.",
+                     1) == -1) {
         return NULL;
     }
 
@@ -283,6 +315,14 @@ _gfx_boxcolor(PyObject *self, PyObject *args)
         return NULL;
     }
 
+    if (PyErr_WarnEx(
+            PyExc_DeprecationWarning,
+            "`pygame.gfxdraw.box` is deprecated since GFX_DEPRECATED_VERSION."
+            "Use `pygame.draw.rect` instead.",
+            1) == -1) {
+        return NULL;
+    }
+
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
     }
@@ -319,6 +359,14 @@ _gfx_linecolor(PyObject *self, PyObject *args)
                           &color))
         return NULL;
 
+    if (PyErr_WarnEx(
+            PyExc_DeprecationWarning,
+            "`pygame.gfxdraw.line` is deprecated since GFX_DEPRECATED_VERSION."
+            "Use `pygame.draw.line` instead.",
+            1) == -1) {
+        return NULL;
+    }
+
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
     }
@@ -344,6 +392,14 @@ _gfx_circlecolor(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args, "OhhhO:circle", &surface, &x, &y, &r, &color))
         return NULL;
+
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.circle` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.circle` instead.",
+                     1) == -1) {
+        return NULL;
+    }
 
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
@@ -372,6 +428,14 @@ _gfx_arccolor(PyObject *self, PyObject *args)
                           &end, &color))
         return NULL;
 
+    if (PyErr_WarnEx(
+            PyExc_DeprecationWarning,
+            "`pygame.gfxdraw.arc` is deprecated since GFX_DEPRECATED_VERSION."
+            "Use `pygame.draw.arc` instead.",
+            1) == -1) {
+        return NULL;
+    }
+
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
     }
@@ -398,6 +462,14 @@ _gfx_aacirclecolor(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "OhhhO:aacircle", &surface, &x, &y, &r,
                           &color))
         return NULL;
+
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.aacircle` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.aacircle` instead.",
+                     1) == -1) {
+        return NULL;
+    }
 
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
@@ -426,6 +498,14 @@ _gfx_filledcirclecolor(PyObject *self, PyObject *args)
                           &color))
         return NULL;
 
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.filled_circle` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.circle` instead.",
+                     1) == -1) {
+        return NULL;
+    }
+
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
     }
@@ -452,6 +532,14 @@ _gfx_ellipsecolor(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "OhhhhO:ellipse", &surface, &x, &y, &rx, &ry,
                           &color))
         return NULL;
+
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.ellipse` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.ellipse` instead.",
+                     1) == -1) {
+        return NULL;
+    }
 
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
@@ -480,6 +568,14 @@ _gfx_aaellipsecolor(PyObject *self, PyObject *args)
                           &color))
         return NULL;
 
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.aaellipse` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.aaellipse` instead.",
+                     1) == -1) {
+        return NULL;
+    }
+
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
     }
@@ -506,6 +602,14 @@ _gfx_filledellipsecolor(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "OhhhhO:filled_ellipse", &surface, &x, &y, &rx,
                           &ry, &color))
         return NULL;
+
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.filled_ellipse` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.ellipse` instead.",
+                     1) == -1) {
+        return NULL;
+    }
 
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
@@ -534,6 +638,14 @@ _gfx_piecolor(PyObject *self, PyObject *args)
                           &end, &color))
         return NULL;
 
+    if (PyErr_WarnEx(
+            PyExc_DeprecationWarning,
+            "`pygame.gfxdraw.pie` is deprecated since GFX_DEPRECATED_VERSION."
+            "Use `pygame.draw.arc` and `pygame.draw.line` instead.",
+            1) == -1) {
+        return NULL;
+    }
+
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
     }
@@ -560,6 +672,14 @@ _gfx_trigoncolor(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "OhhhhhhO:trigon", &surface, &x1, &_y1, &x2,
                           &y2, &x3, &y3, &color))
         return NULL;
+
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.trigon` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.polygon` instead.",
+                     1) == -1) {
+        return NULL;
+    }
 
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
@@ -588,6 +708,14 @@ _gfx_aatrigoncolor(PyObject *self, PyObject *args)
                           &y2, &x3, &y3, &color))
         return NULL;
 
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.aatrigon` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.aapolygon` instead.",
+                     1) == -1) {
+        return NULL;
+    }
+
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
     }
@@ -614,6 +742,14 @@ _gfx_filledtrigoncolor(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "OhhhhhhO:filled_trigon", &surface, &x1, &_y1,
                           &x2, &y2, &x3, &y3, &color))
         return NULL;
+
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.filled_trigon` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.polygon` instead.",
+                     1) == -1) {
+        return NULL;
+    }
 
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
@@ -642,6 +778,14 @@ _gfx_polygoncolor(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args, "OOO:polygon", &surface, &points, &color))
         return NULL;
+
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.polygon` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.polygon` instead.",
+                     1) == -1) {
+        return NULL;
+    }
 
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
@@ -715,6 +859,14 @@ _gfx_aapolygoncolor(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args, "OOO:aapolygon", &surface, &points, &color))
         return NULL;
+
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.aapolygon` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.aapolygon` instead.",
+                     1) == -1) {
+        return NULL;
+    }
 
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
@@ -790,6 +942,14 @@ _gfx_filledpolygoncolor(PyObject *self, PyObject *args)
                           &color))
         return NULL;
 
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.filled_polygon` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.polygon` instead.",
+                     1) == -1) {
+        return NULL;
+    }
+
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
     }
@@ -863,6 +1023,13 @@ _gfx_texturedpolygon(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "OOOhh:textured_polygon", &surface, &points,
                           &texture, &tdx, &tdy))
         return NULL;
+
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.textured_polygon` is deprecated since "
+                     "GFX_DEPRECATED_VERSION.",
+                     1) == -1) {
+        return NULL;
+    }
 
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");
@@ -944,6 +1111,14 @@ _gfx_beziercolor(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "OOiO:bezier", &surface, &points, &steps,
                           &color))
         return NULL;
+
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "`pygame.gfxdraw.bezier` is deprecated since "
+                     "GFX_DEPRECATED_VERSION."
+                     "Use `pygame.draw.bezier` instead.",
+                     1) == -1) {
+        return NULL;
+    }
 
     if (!pgSurface_Check(surface)) {
         return RAISE(PyExc_TypeError, "surface must be a Surface");


### PR DESCRIPTION
This PR officially deprecates the gfxdraw module, but the functionality is intact. We can remove gfxdraw in pygame-3 or later.

The following features must be added for this PR to leave draft:
- `pygame.draw.aaellipse`
- `pygame.draw.aapolygon`

`pie` was deprecated with no replacement (but one can use arc+line) and so did `textured_polygon`. If you disagree, tell me about it.

`GFX_DEPRECATED_VERSION` will be replaced when this is ready to be reviewed.