### PR TITLE
Remove unnecessary pixeloffset member of subsurface data

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -478,7 +478,6 @@ struct pgEventObject {
  */
 struct pgSubSurface_Data {
     PyObject *owner;
-    int pixeloffset;
     int offsetx, offsety;
 };
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2557,8 +2557,6 @@ surf_subsurface(PyObject *self, PyObject *args)
     SDL_Rect *rect, temp;
     SDL_Surface *sub;
     PyObject *subobj;
-    int pixeloffset;
-    char *startpixel;
     struct pgSubSurface_Data *data;
     Uint8 alpha;
     Uint32 colorkey;
@@ -2575,9 +2573,9 @@ surf_subsurface(PyObject *self, PyObject *args)
 
     pgSurface_Lock((pgSurfaceObject *)self);
 
-    pixeloffset =
-        rect->x * PG_FORMAT_BytesPerPixel(format) + rect->y * surf->pitch;
-    startpixel = ((char *)surf->pixels) + pixeloffset;
+    char *startpixel = ((char *)surf->pixels) +
+                       rect->x * PG_FORMAT_BytesPerPixel(format) +
+                       rect->y * surf->pitch;
 
     sub = PG_CreateSurfaceFrom(startpixel, rect->w, rect->h, surf->pitch,
                                format->format);
@@ -2645,7 +2643,6 @@ surf_subsurface(PyObject *self, PyObject *args)
     }
     Py_INCREF(self);
     data->owner = self;
-    data->pixeloffset = pixeloffset;
     data->offsetx = rect->x;
     data->offsety = rect->y;
     ((pgSurfaceObject *)subobj)->subsurface = data;

--- a/src_c/surflock.c
+++ b/src_c/surflock.c
@@ -44,10 +44,7 @@ pgSurface_Prep(pgSurfaceObject *surfobj)
 {
     struct pgSubSurface_Data *data = ((pgSurfaceObject *)surfobj)->subsurface;
     if (data != NULL) {
-        SDL_Surface *surf = pgSurface_AsSurface(surfobj);
-        SDL_Surface *owner = pgSurface_AsSurface(data->owner);
         pgSurface_LockBy((pgSurfaceObject *)data->owner, (PyObject *)surfobj);
-        surf->pixels = ((char *)owner->pixels) + data->pixeloffset;
     }
 }
 


### PR DESCRIPTION
I was digging around our structs and found this member barely used anywhere. All it did was set the subsurf pixel pointer to the correct location when pgSurface_Prep is called. But the subsurf pixel pointer is set up to point at the right location in surface.subsurface already, and never changes from that position. So storing the offset and re-setting it occasionally is unnecessary effort.

How did I verify it was unnecessary?
- No other bits of code set `pixels` to something else on a surface. (So if nothing is messing it up, no need to reset it)
- I put in an assert in the previous prep code to fail if the current pixel pointer is different to the one it was being set to, and through the entire test suite that assertion held true.

This makes the subsurface code a tiny bit simpler and more memory efficient.