### PR TITLE
Fix midi timer reset when quit

### DIFF
--- a/src_c/cython/pygame/pypm.pyx
+++ b/src_c/cython/pygame/pypm.pyx
@@ -146,6 +146,7 @@ cdef extern from "porttime.h":
     ctypedef long PtTimestamp
     ctypedef void (* PtCallback)(PtTimestamp timestamp, void *userData)
     PtError Pt_Start(int resolution, PtCallback *callback, void *userData)
+    PtError Pt_Stop()
     PtTimestamp Pt_Time()
 
 cdef long _pypm_initialized
@@ -171,6 +172,7 @@ def Terminate():
     your system may crash.
 
     """
+    Pt_Stop()
     Pm_Terminate()
     _pypm_initialized = 0
 

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -1,5 +1,4 @@
 import unittest
-import sys
 
 
 import pygame
@@ -320,14 +319,8 @@ class MidiModuleTest(unittest.TestCase):
     def test_time(self):
         mtime = pygame.midi.time()
         self.assertIsInstance(mtime, int)
-        if "pytest" in sys.modules:
-            # under pytest the midi module takes a couple of seconds to init
-            # instead of milliseconds
-            self.assertGreaterEqual(mtime, 0)
-            self.assertLess(mtime, 3000)
-        else:
-            self.assertGreaterEqual(mtime, 0)
-            self.assertLess(mtime, 100)
+        # should be close to 2-3... since the timer is just init'd.
+        self.assertTrue(0 <= mtime < 100)
 
 
 class MidiModuleNonInteractiveTest(unittest.TestCase):

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 
 
 import pygame
@@ -319,8 +320,14 @@ class MidiModuleTest(unittest.TestCase):
     def test_time(self):
         mtime = pygame.midi.time()
         self.assertIsInstance(mtime, int)
-        # should be close to 2-3... since the timer is just init'd.
-        self.assertTrue(0 <= mtime < 100)
+        if "pytest" in sys.modules:
+            # under pytest the midi module takes a couple of seconds to init
+            # instead of milliseconds
+            self.assertGreaterEqual(mtime, 0)
+            self.assertLess(mtime, 3000)
+        else:
+            self.assertGreaterEqual(mtime, 0)
+            self.assertLess(mtime, 100)
 
 
 class MidiModuleNonInteractiveTest(unittest.TestCase):


### PR DESCRIPTION
A little while ago @ankith26 changed something to make pytest work better with out test suite. I like the output of pytest so I was trying it out today and, after a little fidddling I realised we need to run it with the `-s` flag, like so:

```
pytest test -s
```

to make all the command line unit tests work. 

Anyway, with that they all seem to work OK through pytest, bar two tests. This 'how much time has passed since `midi.init()` was called was one of them - for some reason it takes at least 10 times as long to go from `pygame.midi.init()` to `pygame.midi.time()` when running the test through pytest. I'm not sure if we want to cater to pytest by making a small change to this test or not, but anyway I though I'd submit a PR.

The test for `set_gamma_ramp()` also doesn't pass now - I think it should probably be removed as the function is deprecated in pygame, the corresponding SDL function is also deprecated and it doesn't work at all on my PC at all anymore - I expect windows has removed support for it.

The other thing running pytest does is show all the deprecated functions we are testing in the tests without supressing the generated warnings - this make the test output a bit messy and harder to spot deprecation warnings not coming from our test code.

<details>
  <summary>Warnings output from pytest test -s</summary>

```
..\..\AppData\Local\Programs\Python\Python311\Lib\site-packages\pygame\pkgdata.py:25
  C:\Users\dan\AppData\Local\Programs\Python\Python311\Lib\site-packages\pygame\pkgdata.py:25: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import resource_stream, resource_exists

..\..\AppData\Local\Programs\Python\Python311\Lib\site-packages\pkg_resources\__init__.py:2846
  C:\Users\dan\AppData\Local\Programs\Python\Python311\Lib\site-packages\pkg_resources\__init__.py:2846: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

..\..\AppData\Local\Programs\Python\Python311\Lib\site-packages\pygame\surfarray.py:408
test/surfarray_test.py::SurfarrayModuleTest::test_surf_lock
test/surfarray_test.py::SurfarrayModuleTest::test_use_arraytype
test/surfarray_test.py::SurfarrayModuleTest::test_use_arraytype
  C:\Users\dan\AppData\Local\Programs\Python\Python311\Lib\site-packages\pygame\surfarray.py:408: DeprecationWarning: only numpy arrays are now supported, this function will be removed in a future version of the module
    warnings.warn(

test\test_utils\test_machinery.py:47
  C:\Users\dan\Programming\pygame-ce\test\test_utils\test_machinery.py:47: PytestCollectionWarning: cannot collect test class 'TestTags' because it has a __init__ constructor (from: test/test_utils/test_machinery.py)
    class TestTags:

test/base_test.py::BaseModuleTest::test_init
test/base_test.py::BaseModuleTest::test_quit__and_init
test/base_test.py::BaseModuleTest::test_quit__and_init
  C:\Users\dan\AppData\Local\Programs\Python\Python311\Lib\unittest\case.py:237: DeprecationWarning: pygame.scrap.get deprecated since 2.2.0. Consider using pygame.scrap.get_text instead.
    callable_obj(*args, **kwargs)

test/color_test.py::ColorTypeTest::test_arraystruct
test/color_test.py::ColorTypeTest::test_arraystruct
test/color_test.py::ColorTypeTest::test_arraystruct
test/color_test.py::ColorTypeTest::test_arraystruct
  C:\Users\dan\Programming\pygame-ce\test\color_test.py:1112: DeprecationWarning: pygame.Color.set_length deprecated since 2.1.3
    c.set_length(i)

test/color_test.py::ColorTypeTest::test_init
  C:\Users\dan\Programming\pygame-ce\test\color_test.py:73: DeprecationWarning: pygame.Color.set_length deprecated since 2.1.3
    c.set_length(3)

test/color_test.py::ColorTypeTest::test_length
  C:\Users\dan\Programming\pygame-ce\test\color_test.py:282: DeprecationWarning: pygame.Color.set_length deprecated since 2.1.3
    c.set_length(3)

test/color_test.py::ColorTypeTest::test_length
  C:\Users\dan\Programming\pygame-ce\test\color_test.py:291: DeprecationWarning: pygame.Color.set_length deprecated since 2.1.3
    c.set_length(4)

test/color_test.py::ColorTypeTest::test_length
test/color_test.py::ColorTypeTest::test_length
test/color_test.py::ColorTypeTest::test_length
test/color_test.py::ColorTypeTest::test_length
  C:\Users\dan\AppData\Local\Programs\Python\Python311\Lib\unittest\case.py:237: DeprecationWarning: pygame.Color.set_length deprecated since 2.1.3
    callable_obj(*args, **kwargs)

test/color_test.py::ColorTypeTest::test_newbuf
test/color_test.py::ColorTypeTest::test_newbuf
test/color_test.py::ColorTypeTest::test_newbuf
test/color_test.py::ColorTypeTest::test_newbuf
  C:\Users\dan\Programming\pygame-ce\test\color_test.py:1195: DeprecationWarning: pygame.Color.set_length deprecated since 2.1.3
    c.set_length(i)

test/color_test.py::ColorTypeTest::test_unpack
  C:\Users\dan\Programming\pygame-ce\test\color_test.py:267: DeprecationWarning: pygame.Color.set_length deprecated since 2.1.3
    c.set_length(3)

test/color_test.py::ColorTypeTest::test_update
  C:\Users\dan\Programming\pygame-ce\test\color_test.py:1420: DeprecationWarning: pygame.Color.set_length deprecated since 2.1.3
    c.set_length(3)

test/color_test.py::ColorTypeTest::test_update
  C:\Users\dan\Programming\pygame-ce\test\color_test.py:1423: DeprecationWarning: pygame.Color.set_length deprecated since 2.1.3
    c.set_length(4)

test/color_test.py::ColorTypeTest::test_update
  C:\Users\dan\Programming\pygame-ce\test\color_test.py:1426: DeprecationWarning: pygame.Color.set_length deprecated since 2.1.3
    c.set_length(3)

test/display_test.py::DisplayModuleTest::test_set_gamma
test/display_test.py::DisplayModuleTest::test_set_gamma
test/display_test.py::DisplayModuleTest::test_set_gamma
test/display_test.py::DisplayModuleTest::test_set_gamma
  C:\Users\dan\Programming\pygame-ce\test\display_test.py:523: DeprecationWarning: pygame.display.set_gamma deprecated since 2.1.4
    self.assertEqual(pygame.display.set_gamma(gamma), True)

test/display_test.py::DisplayModuleTest::test_set_gamma__tuple
test/display_test.py::DisplayModuleTest::test_set_gamma__tuple
test/display_test.py::DisplayModuleTest::test_set_gamma__tuple
  C:\Users\dan\Programming\pygame-ce\test\display_test.py:535: DeprecationWarning: pygame.display.set_gamma deprecated since 2.1.4
    self.assertEqual(pygame.display.set_gamma(r, g, b), True)

test/display_test.py::DisplayModuleTest::test_set_gamma_ramp
  C:\Users\dan\Programming\pygame-ce\test\display_test.py:561: DeprecationWarning: pygame.display.set_gamma_ramp deprecated since 2.1.4
    self.assertTrue(pygame.display.set_gamma_ramp(r, g, b))

test/display_test.py::DisplayInteractiveTest::test_set_gamma_ramp
  C:\Users\dan\Programming\pygame-ce\test\display_test.py:885: DeprecationWarning: pygame.display.set_gamma_ramp deprecated since 2.1.4
    if pygame.display.set_gamma_ramp(normal_ramp, normal_ramp, blue_ramp):

test/font_test.py::FontModuleTest::test_SysFont
test/ftfont_test.py::FtFontModuleTest::test_SysFont
  C:\Users\dan\AppData\Local\Programs\Python\Python311\Lib\site-packages\pygame\sysfont.py:490: UserWarning: The system font 'thisisnotafont' couldn't be found. Using the default font instead.
    warnings.warn(

test/pixelcopy_test.py::PixelcopyModuleTest::test_map_array
  C:\Users\dan\Programming\pygame-ce\test\pixelcopy_test.py:215: DeprecationWarning: pygame.Color.set_length deprecated since 2.1.3
    color.set_length(3)

test/scrap_test.py::ScrapModuleTest::test_get__owned_empty_type
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:19: DeprecationWarning: pygame.scrap.init deprecated since 2.2.0
    scrap.init()

test/scrap_test.py::ScrapModuleTest::test_get__owned_empty_type
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:63: DeprecationWarning: pygame.scrap.lost deprecated since 2.2.0
    if scrap.lost():

test/scrap_test.py::ScrapModuleTest::test_get__owned_empty_type
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:65: DeprecationWarning: pygame.scrap.put deprecated since 2.2.0. Consider using pygame.scrap.put_text instead.
    scrap.put(pygame.SCRAP_TEXT, b"text to clipboard")

test/scrap_test.py::ScrapModuleTest::test_get__owned_empty_type
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:67: DeprecationWarning: pygame.scrap.lost deprecated since 2.2.0
    if scrap.lost():

test/scrap_test.py::ScrapModuleTest::test_get__owned_empty_type
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:70: DeprecationWarning: pygame.scrap.get deprecated since 2.2.0. Consider using pygame.scrap.get_text instead.
    data = scrap.get(DATA_TYPE)

test/scrap_test.py::ScrapModuleTest::test_get_init
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:45: DeprecationWarning: pygame.scrap.get_init deprecated since 2.2.0
    self.assertTrue(scrap.get_init())

test/scrap_test.py::ScrapModuleTest::test_init
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:28: DeprecationWarning: pygame.scrap.init deprecated since 2.2.0
    scrap.init()

test/scrap_test.py::ScrapModuleTest::test_init
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:29: DeprecationWarning: pygame.scrap.init deprecated since 2.2.0
    scrap.init()

test/scrap_test.py::ScrapModuleTest::test_init
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:31: DeprecationWarning: pygame.scrap.get_init deprecated since 2.2.0
    self.assertTrue(scrap.get_init())

test/scrap_test.py::ScrapModuleTest::test_init__reinit
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:37: DeprecationWarning: pygame.scrap.put deprecated since 2.2.0. Consider using pygame.scrap.put_text instead.
    scrap.put(data_type, expected_data)

test/scrap_test.py::ScrapModuleTest::test_init__reinit
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:39: DeprecationWarning: pygame.scrap.init deprecated since 2.2.0
    scrap.init()

test/scrap_test.py::ScrapModuleTest::test_init__reinit
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:41: DeprecationWarning: pygame.scrap.get deprecated since 2.2.0. Consider using pygame.scrap.get_text instead.
    self.assertEqual(scrap.get(data_type), expected_data)

test/scrap_test.py::ScrapModuleTest::test_put
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:114: DeprecationWarning: pygame.scrap.put deprecated since 2.2.0. Consider using pygame.scrap.put_text instead.
    scrap.put(DATA_TYPE, b"buf")

test/scrap_test.py::ScrapModuleTest::test_put
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:115: DeprecationWarning: pygame.scrap.get deprecated since 2.2.0. Consider using pygame.scrap.get_text instead.
    r = scrap.get(DATA_TYPE)

test/scrap_test.py::ScrapModuleTest::test_put__bmp_image
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:104: DeprecationWarning: pygame.scrap.put deprecated since 2.2.0. Consider using pygame.scrap.put_text instead.
    scrap.put(pygame.SCRAP_BMP, expected_bytes)

test/scrap_test.py::ScrapModuleTest::test_put__bmp_image
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:106: DeprecationWarning: pygame.scrap.get deprecated since 2.2.0. Consider using pygame.scrap.get_text instead.
    self.assertEqual(scrap.get(pygame.SCRAP_BMP), expected_bytes)

test/scrap_test.py::ScrapModuleTest::test_put__text
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:91: DeprecationWarning: pygame.scrap.put deprecated since 2.2.0. Consider using pygame.scrap.put_text instead.
    scrap.put(pygame.SCRAP_TEXT, b"Hello world")

test/scrap_test.py::ScrapModuleTest::test_put__text
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:93: DeprecationWarning: pygame.scrap.get deprecated since 2.2.0. Consider using pygame.scrap.get_text instead.
    self.assertEqual(scrap.get(pygame.SCRAP_TEXT), b"Hello world")

test/scrap_test.py::ScrapModuleTest::test_put__text
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:95: DeprecationWarning: pygame.scrap.put deprecated since 2.2.0. Consider using pygame.scrap.put_text instead.
    scrap.put(pygame.SCRAP_TEXT, b"Another String")

test/scrap_test.py::ScrapModuleTest::test_put__text
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:97: DeprecationWarning: pygame.scrap.get deprecated since 2.2.0. Consider using pygame.scrap.get_text instead.
    self.assertEqual(scrap.get(pygame.SCRAP_TEXT), b"Another String")

test/scrap_test.py::ScrapModuleTest::test_set_mode
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:84: DeprecationWarning: pygame.scrap.set_mode deprecated since 2.2.0
    scrap.set_mode(pygame.SCRAP_SELECTION)

test/scrap_test.py::ScrapModuleTest::test_set_mode
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:85: DeprecationWarning: pygame.scrap.set_mode deprecated since 2.2.0
    scrap.set_mode(pygame.SCRAP_CLIPBOARD)

test/scrap_test.py::ScrapModuleTest::test_set_mode
  C:\Users\dan\AppData\Local\Programs\Python\Python311\Lib\unittest\case.py:237: DeprecationWarning: pygame.scrap.set_mode deprecated since 2.2.0
    callable_obj(*args, **kwargs)

test/scrap_test.py::ScrapModuleClipboardNotOwnedTest::test_contains__not_owned
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:145: DeprecationWarning: pygame.scrap.init deprecated since 2.2.0
    scrap.init()

test/scrap_test.py::ScrapModuleClipboardNotOwnedTest::test_contains__not_owned
test/scrap_test.py::ScrapModuleClipboardNotOwnedTest::test_get__not_owned
test/scrap_test.py::ScrapModuleClipboardNotOwnedTest::test_get_types__not_owned
test/scrap_test.py::ScrapModuleClipboardNotOwnedTest::test_lost__not_owned
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:156: DeprecationWarning: pygame.scrap.lost deprecated since 2.2.0
    if not scrap.lost():

test/scrap_test.py::ScrapModuleClipboardNotOwnedTest::test_contains__not_owned
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:194: DeprecationWarning: pygame.scrap.contains deprecated since 2.2.0
    contains = scrap.contains(DATA_TYPE)

test/scrap_test.py::ScrapModuleClipboardNotOwnedTest::test_get__not_owned
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:170: DeprecationWarning: pygame.scrap.get deprecated since 2.2.0. Consider using pygame.scrap.get_text instead.
    data = scrap.get(DATA_TYPE)

test/scrap_test.py::ScrapModuleClipboardNotOwnedTest::test_get_types__not_owned
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:180: DeprecationWarning: pygame.scrap.get_types deprecated since 2.2.0
    data_types = scrap.get_types()

test/scrap_test.py::ScrapModuleClipboardNotOwnedTest::test_lost__not_owned
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:204: DeprecationWarning: pygame.scrap.lost deprecated since 2.2.0
    lost = scrap.lost()

test/scrap_test.py::X11InteractiveTest::test_issue_223
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:249: DeprecationWarning: pygame.scrap.init deprecated since 2.2.0
    scrap.init()

test/scrap_test.py::X11InteractiveTest::test_issue_223
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:250: DeprecationWarning: pygame.scrap.set_mode deprecated since 2.2.0
    scrap.set_mode(SCRAP_SELECTION)

test/scrap_test.py::X11InteractiveTest::test_issue_223
  C:\Users\dan\Programming\pygame-ce\test\scrap_test.py:251: DeprecationWarning: pygame.scrap.put deprecated since 2.2.0. Consider using pygame.scrap.put_text instead.
    scrap.put(SCRAP_TEXT, text.encode("UTF-8"))

test/sndarray_test.py::SndarrayTest::test_get_arraytype
test/sndarray_test.py::SndarrayTest::test_use_arraytype
  C:\Users\dan\AppData\Local\Programs\Python\Python311\Lib\site-packages\pygame\sndarray.py:117: DeprecationWarning: only numpy arrays are now supported, this function will be removed in a future version of the module
    warnings.warn(

test/sndarray_test.py::SndarrayTest::test_get_arraytypes
  C:\Users\dan\AppData\Local\Programs\Python\Python311\Lib\site-packages\pygame\sndarray.py:132: DeprecationWarning: only numpy arrays are now supported, this function will be removed in a future version of the module
    warnings.warn(

test/sndarray_test.py::SndarrayTest::test_use_arraytype
test/sndarray_test.py::SndarrayTest::test_use_arraytype
  C:\Users\dan\AppData\Local\Programs\Python\Python311\Lib\site-packages\pygame\sndarray.py:100: DeprecationWarning: only numpy arrays are now supported, this function will be removed in a future version of the module
    warnings.warn(

test/surfarray_test.py::SurfarrayModuleTest::test_get_arraytype
test/surfarray_test.py::SurfarrayModuleTest::test_use_arraytype
  C:\Users\dan\AppData\Local\Programs\Python\Python311\Lib\site-packages\pygame\surfarray.py:425: DeprecationWarning: only numpy arrays are now supported, this function will be removed in a future version of the module
    warnings.warn(

test/surfarray_test.py::SurfarrayModuleTest::test_get_arraytypes
test/surfarray_test.py::SurfarrayModuleTest::test_surf_lock
  C:\Users\dan\AppData\Local\Programs\Python\Python311\Lib\site-packages\pygame\surfarray.py:440: DeprecationWarning: only numpy arrays are now supported, this function will be removed in a future version of the module
    warnings.warn(

test/surfarray_test.py::SurfarrayModuleTest::test_pixels2d
  C:\Users\dan\Programming\pygame-ce\test\surfarray_test.py:117: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -16114116 to uint32 will fail in the future.
  For the old behavior, usually:
      np.array(value).astype(dtype)
  will give the desired result (the cast overflows).
    arr[:5, :6] = surf.map_rgb(palette[1])

test/surfarray_test.py::SurfarrayModuleTest::test_pixels2d
  C:\Users\dan\Programming\pygame-ce\test\surfarray_test.py:118: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -15119516 to uint32 will fail in the future.
  For the old behavior, usually:
      np.array(value).astype(dtype)
  will give the desired result (the cast overflows).
    arr[5:, :6] = surf.map_rgb(palette[2])

test/surfarray_test.py::SurfarrayModuleTest::test_pixels2d
  C:\Users\dan\Programming\pygame-ce\test\surfarray_test.py:119: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -10185016 to uint32 will fail in the future.
  For the old behavior, usually:
      np.array(value).astype(dtype)
  will give the desired result (the cast overflows).
    arr[:5, 6:] = surf.map_rgb(palette[3])

test/surfarray_test.py::SurfarrayModuleTest::test_pixels2d
  C:\Users\dan\Programming\pygame-ce\test\surfarray_test.py:120: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -16751416 to uint32 will fail in the future.
  For the old behavior, usually:
      np.array(value).astype(dtype)
  will give the desired result (the cast overflows).
    arr[5:, 6:] = surf.map_rgb(palette[4])

test/window_test.py::WindowTypeTest::test_from_display_module
  C:\Users\dan\Programming\pygame-ce\test\window_test.py:323: DeprecationWarning: Please use Window.get_surface and Window.flip to use surface-rendering with Window. This method will be removed in a future version.
    win1 = Window.from_display_module()

test/window_test.py::WindowTypeTest::test_from_display_module
  C:\Users\dan\Programming\pygame-ce\test\window_test.py:324: DeprecationWarning: Please use Window.get_surface and Window.flip to use surface-rendering with Window. This method will be removed in a future version.
    win2 = Window.from_display_module()

test/window_test.py::WindowTypeTest::test_window_object_repr
  C:\Users\dan\Programming\pygame-ce\test\window_test.py:314: DeprecationWarning: Please use Window.get_surface and Window.flip to use surface-rendering with Window. This method will be removed in a future version.
    win = Window.from_display_module()

test/window_test.py::WindowTypeTest::test_window_opengl
  C:\Users\dan\Programming\pygame-ce\test\window_test.py:400: DeprecationWarning: Please use Window.get_surface and Window.flip to use surface-rendering with Window. This method will be removed in a future version.
    win = Window.from_display_module()

test/window_test.py::WindowTypeTest::test_window_subclassable
  C:\Users\dan\Programming\pygame-ce\test\window_test.py:420: DeprecationWarning: Please use Window.get_surface and Window.flip to use surface-rendering with Window. This method will be removed in a future version.
    window = WindowSubclass.from_display_module()

test/window_test.py::WindowTypeTest::test_window_surface_with_display_module
  C:\Users\dan\Programming\pygame-ce\test\window_test.py:353: DeprecationWarning: Please use Window.get_surface and Window.flip to use surface-rendering with Window. This method will be removed in a future version.
    win1 = Window.from_display_module()

test/window_test.py::WindowTypeTest::test_window_surface_with_display_module
  C:\Users\dan\Programming\pygame-ce\test\window_test.py:361: DeprecationWarning: Please use Window.get_surface and Window.flip to use surface-rendering with Window. This method will be removed in a future version.
    win2 = Window.from_display_module()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

```

</details>
