### PR TITLE
Use PyObject_CallNoArgs where applicable

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -270,7 +270,7 @@ pg_mod_autoinit(const char *modname)
     }
 
     if (funcobj) {
-        temp = PyObject_CallObject(funcobj, NULL);
+        temp = PyObject_CallNoArgs(funcobj);
         if (temp) {
             Py_DECREF(temp);
             ret = 1;
@@ -305,7 +305,7 @@ pg_mod_autoquit(const char *modname)
         PyErr_Clear();
 
     if (funcobj) {
-        temp = PyObject_CallObject(funcobj, NULL);
+        temp = PyObject_CallNoArgs(funcobj);
         Py_XDECREF(temp);
     }
 
@@ -429,7 +429,7 @@ _pg_quit(void)
             }
 
             if (PyCallable_Check(quit)) {
-                temp = PyObject_CallObject(quit, NULL);
+                temp = PyObject_CallNoArgs(quit);
                 if (temp)
                     Py_DECREF(temp);
                 else

--- a/src_c/geometry_common.c
+++ b/src_c/geometry_common.c
@@ -108,7 +108,7 @@ pgCircle_FromObject(PyObject *obj, pgCircleBase *out)
 
     if (PyCallable_Check(circleattr)) /*call if it's a method*/
     {
-        PyObject *circleresult = PyObject_CallObject(circleattr, NULL);
+        PyObject *circleresult = PyObject_CallNoArgs(circleattr);
         Py_DECREF(circleattr);
         if (!circleresult) {
             PyErr_Clear();

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -748,7 +748,7 @@ RectExport_RectFromObject(PyObject *obj, InnerRect *temp)
     InnerRect *returnrect;
     /*call if it's a method*/
     if (PyCallable_Check(rectattr)) {
-        PyObject *rectresult = PyObject_CallObject(rectattr, NULL);
+        PyObject *rectresult = PyObject_CallNoArgs(rectattr);
         Py_DECREF(rectattr);
         if (rectresult == NULL) {
             PyErr_Clear();

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -310,7 +310,7 @@ _pg_rw_size(SDL_RWops *context)
 
     /* Current file position; need to restore it later.
      */
-    pos = PyObject_CallFunction(helper->tell, NULL);
+    pos = PyObject_CallNoArgs(helper->tell);
     if (!pos) {
         PyErr_Print();
         goto end;
@@ -327,7 +327,7 @@ _pg_rw_size(SDL_RWops *context)
 
     /* Record file size.
      */
-    tmp = PyObject_CallFunction(helper->tell, NULL);
+    tmp = PyObject_CallNoArgs(helper->tell);
     if (!tmp) {
         PyErr_Print();
         goto end;
@@ -398,7 +398,7 @@ _pg_rw_close(SDL_RWops *context)
     PyGILState_STATE state = PyGILState_Ensure();
 
     if (helper->close) {
-        result = PyObject_CallFunction(helper->close, NULL);
+        result = PyObject_CallNoArgs(helper->close);
         if (!result) {
             PyErr_Print();
             retval = -1;
@@ -479,7 +479,7 @@ _pg_rw_seek(SDL_RWops *context, Sint64 offset, int whence)
         Py_DECREF(result);
     }
 
-    result = PyObject_CallFunction(helper->tell, NULL);
+    result = PyObject_CallNoArgs(helper->tell);
     if (!result) {
         PyErr_Print();
         retval = -1;


### PR DESCRIPTION
* PyObject_CallNoArgs was added in 3.9, pythoncapi_compat.h enables support for 3.8.
* Docs say it's the "most efficient way to call a callable Python object without any argument"

This is not a performance PR, but a "use the modern thing" PR. The Python API now has this function we can use, lets use it. It's in the stable ABI, and it's a bit more explicit than the previous uses.