### PR TITLE
draw.c: better strategy for 24bpp writes

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1213,7 +1213,6 @@ set_at(SDL_Surface *surf, int x, int y, Uint32 color)
 {
     SDL_PixelFormat *format = surf->format;
     Uint8 *pixels = (Uint8 *)surf->pixels;
-    Uint8 *byte_buf, rgb[4];
 
     if (x < surf->clip_rect.x || x >= surf->clip_rect.x + surf->clip_rect.w ||
         y < surf->clip_rect.y || y >= surf->clip_rect.y + surf->clip_rect.h)
@@ -1230,17 +1229,11 @@ set_at(SDL_Surface *surf, int x, int y, Uint32 color)
             *((Uint32 *)(pixels + y * surf->pitch) + x) = color;
             break;
         default: /*case 3:*/
-            SDL_GetRGB(color, format, rgb, rgb + 1, rgb + 2);
-            byte_buf = (Uint8 *)(pixels + y * surf->pitch) + x * 3;
-#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-            *(byte_buf + (format->Rshift >> 3)) = rgb[0];
-            *(byte_buf + (format->Gshift >> 3)) = rgb[1];
-            *(byte_buf + (format->Bshift >> 3)) = rgb[2];
-#else
-            *(byte_buf + 2 - (format->Rshift >> 3)) = rgb[0];
-            *(byte_buf + 2 - (format->Gshift >> 3)) = rgb[1];
-            *(byte_buf + 2 - (format->Bshift >> 3)) = rgb[2];
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+            color <<= 8;
 #endif
+            memcpy((pixels + y * surf->pitch) + x * 3, &color,
+                   3 * sizeof(Uint8));
             break;
     }
     return 1;
@@ -1805,7 +1798,6 @@ unsafe_set_at(SDL_Surface *surf, int x, int y, Uint32 color)
 {
     SDL_PixelFormat *format = surf->format;
     Uint8 *pixels = (Uint8 *)surf->pixels;
-    Uint8 *byte_buf, rgb[4];
 
     switch (PG_FORMAT_BytesPerPixel(format)) {
         case 1:
@@ -1818,17 +1810,11 @@ unsafe_set_at(SDL_Surface *surf, int x, int y, Uint32 color)
             *((Uint32 *)(pixels + y * surf->pitch) + x) = color;
             break;
         default: /*case 3:*/
-            SDL_GetRGB(color, format, rgb, rgb + 1, rgb + 2);
-            byte_buf = (Uint8 *)(pixels + y * surf->pitch) + x * 3;
-#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-            *(byte_buf + (format->Rshift >> 3)) = rgb[0];
-            *(byte_buf + (format->Gshift >> 3)) = rgb[1];
-            *(byte_buf + (format->Bshift >> 3)) = rgb[2];
-#else
-            *(byte_buf + 2 - (format->Rshift >> 3)) = rgb[0];
-            *(byte_buf + 2 - (format->Gshift >> 3)) = rgb[1];
-            *(byte_buf + 2 - (format->Bshift >> 3)) = rgb[2];
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+            color <<= 8;
 #endif
+            memcpy((pixels + y * surf->pitch) + x * 3, &color,
+                   3 * sizeof(Uint8));
             break;
     }
 }


### PR DESCRIPTION
This is simpler code and better performance for `set_at` and `unsafe_set_at`.

We don't want to have to go out and call an SDL function in any sort of hot loop.

`drawhorzline` and `drawvertline` already do their writes this way, so it's already proven out in the world.

In this performance test (a width=1 line uses set_at), I saw a 20% performance increase:
```py
import random
import time

import pygame

random.seed(36)

WIDTH, HEIGHT = 200, 200

NUM_LINES = 50000
NUM_REPS = 10

lines = [
    (
        (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255)),
        (random.randint(0, WIDTH), random.randint(0, HEIGHT)),
        (random.randint(0, WIDTH), random.randint(0, HEIGHT)),
    )
    for _ in range(NUM_LINES)
]

surf = pygame.Surface((100, 100), depth=24)

start = time.time()
for _ in range(NUM_REPS):
    for line in lines:
        pygame.draw.line(surf, line[0], line[1], line[2], 1)
print(time.time() - start)
```