### PR TITLE
release machinery: fix attestation and circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,5 +52,15 @@ jobs:
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
   build-arm:
+    when:
+      equal: [ "", << pipeline.parameters.GHA_Actor >> ]
+    jobs:
+      - linux-arm-wheels
+
+  # run a separate, identical release job only if triggered
+  build-arm-release:
+    when:
+      not:
+        equal: [ "", << pipeline.parameters.GHA_Actor >> ]
     jobs:
       - linux-arm-wheels

--- a/.github/workflows/release-gh-draft.yml
+++ b/.github/workflows/release-gh-draft.yml
@@ -32,6 +32,11 @@ jobs:
   draft-release:
     needs: [manylinux-aarch64, manylinux, macos, windows, sdist]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
+
     steps:
       - uses: actions/checkout@v4.1.7
 
@@ -55,13 +60,10 @@ jobs:
         id: ver
         run: echo "VER=${GITHUB_REF_NAME#'release/'}" >> $GITHUB_OUTPUT
 
-      # First generate release.sha512sum which contains hashes of all release files, then
-      # encrypt these hashes so that the hash file itself cannot be tampered with.
-      - name: Generate release hashes (encrypted)
-        run: |
-          cd pygame-wheels
-          sha512sum * > release.sha512sum
-          gpg --batch --output release.sha512sum.gpg --passphrase ${{ secrets.GITHUB_TOKEN }} --symmetric release.sha512sum
+      - name: Generate release attestation
+        uses: actions/attest-build-provenance@v1.4.0
+        with:
+          subject-path: "pygame-wheels/*"
 
       - name: Draft a release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -23,16 +23,18 @@ jobs:
           zipBall: false
           out-file-path: "dist"
 
-      # Check that all the files that successfully uploaded from the release-gh-draft
-      # action have not been tampered with. This however ignores any extra files that
-      # were manually added.
-      - name: Verify release hashes
+      - name: Verify release attestation
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          cd dist
-          gpg --batch --output release.decrypted.sha512sum --passphrase ${{ secrets.GITHUB_TOKEN }} --decrypt release.sha512sum.gpg
-          diff -s release.sha512sum release.decrypted.sha512sum
-          sha512sum -c release.decrypted.sha512sum
-          rm release.*
+          for fname in dist/*; do
+            if gh attestation verify $fname -R ${{ github.repository }}; then
+              echo "[ALLOWED] $fname"
+            else
+              rm $fname
+              echo "[DELETED] $fname"
+            fi
+          done
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
In the latest 2.5.1dev2 release we hit a few hiccups with the release machinery

1. The old circleci auto-cancel issue: I have implemented a workaround this time that should (hopefully) work.
2. A new issue where the pypi uploader failed: this is a result of #2941 not working as I had expected it to. I have now implemented a new strategy that should serve the same purpose, but works differently. It uses the new github attestations thingy. This time, I'm gonna test out this approach in a separate repo first before merging this PR (I will post links to the status here)