### PR TITLE
Use PyObject_Vectorcall in rect

### DIFF
--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -1525,8 +1525,8 @@ RectExport_RectFromObjectAndKeyFunc(PyObject *obj, PyObject *keyfunc,
                                     InnerRect *temp)
 {
     if (keyfunc) {
-        PyObject *obj_with_rect =
-            PyObject_CallFunctionObjArgs(keyfunc, obj, NULL);
+        PyObject *obj_with_rect = PyObject_Vectorcall(keyfunc, &obj, 1, NULL);
+
         if (!obj_with_rect) {
             return NULL;
         }


### PR DESCRIPTION
This speeds up Rect.collideobjects and Rect.collideobjectsall.

See https://docs.python.org/3/c-api/call.html#c.PyObject_Vectorcall

This function is new in Python 3.9, but we get support for it on lower versions automatically using the recently vendored pythoncapi-compat header.

Performance testing script:
```py
from pygame import Rect
import random
import time

random.seed(36)


class Obj:
    def __init__(self, x, y, w, h):
        self.xa = Rect(x, y, w, h)


r = Rect(-20, -20, 100, 100)
objs = [
    Obj(
        random.randint(-100, -100),
        random.randint(-100, 100),
        random.randint(-100, 100),
        random.randint(-100, 100),
    )
    for _ in range(5000)
]

start = time.time()

for _ in range(1000):
    colliding_objs = r.collideobjectsall(objs, key=lambda e: e.xa)

print(time.time() - start)
print(len(colliding_objs))

# Sort list so rects that actually collide are at the end of the list,
# so collideobjects below takes significant time.
objs.sort(key=lambda e: int(r.colliderect(e.xa)))

start = time.time()

for _ in range(1000):
    colliding_obj = r.collideobjects(objs, key=lambda e: e.xa)

print(time.time() - start)
print(colliding_obj.xa)
```

I see collideobjectsall going from 0.32 seconds to 0.25 seconds (22% improvement), and collideobjects going from 0.26 seconds to 0.22 seconds (15% improvement).

That's a pretty good improvement given this PR only changes one C-API function call!