### PR TITLE
Fix imposter opengl

### DIFF
--- a/src_c/window.c
+++ b/src_c/window.c
@@ -995,7 +995,7 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
     self->_is_borrowed = SDL_FALSE;
     self->surf = NULL;
 
-    if (SDL_GetWindowFlags(self->_win) & SDL_WINDOW_OPENGL) {
+    if (flags & SDL_WINDOW_OPENGL) {
         SDL_GLContext context = SDL_GL_CreateContext(self->_win);
         if (context == NULL) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());


### PR DESCRIPTION
Fixes #3056

I can't actually test this on Windows because it's impossible to get framebuffer acceleration on Windows in SDL2:
```c
#if defined(__WIN32__) || defined(__WINGDK__) /* GDI BitBlt() is way faster than Direct3D dynamic textures right now. (!!! FIXME: is this still true?) */
        if (_this->CreateWindowFramebuffer && (SDL_strcmp(_this->name, "windows") == 0)) {
            attempt_texture_framebuffer = SDL_FALSE;
        }
#endif
```