### PR TITLE
migrate importlib to resolve warning about pkg_resources

### DIFF
--- a/src_py/pkgdata.py
+++ b/src_py/pkgdata.py
@@ -22,23 +22,29 @@ import sys
 import os
 
 try:
-    import importlib_resources
+    if sys.version_info[:2] > (3, 8):
+        import importlib_resources
 
-    def resource_exists(_package_or_requirement, _resource_name):
-        return (
-            importlib_resources.files(_package_or_requirement)
-            .joinpath(_resource_name)
-            .is_file()
-        )
+        def resource_exists(_package_or_requirement, _resource_name):
+            return (
+                importlib_resources.files(_package_or_requirement)
+                .joinpath(_resource_name)
+                .is_file()
+            )
 
-    def resource_stream(_package_or_requirement, _resource_name):
-        ref = (
-            importlib_resources.files(_package_or_requirement)
-            .joinpath(_resource_name)
-            .is_file()
-        )
-        return ref.open('rb')
+        def resource_stream(_package_or_requirement, _resource_name):
+            ref = importlib_resources.files(_package_or_requirement).joinpath(
+                _resource_name
+            )
+            return ref.open('rb')
+    else:
+        from importlib import resources
 
+        def resource_exists(_package_or_requirement, _resource_name):
+            return resources.is_resource(_package_or_requirement, _resource_name)
+
+        def resource_stream(_package_of_requirement, _resource_name):
+            return resources.read_binary(_package_of_requirement, _resource_name)
 
 except ImportError:
 

--- a/src_py/pkgdata.py
+++ b/src_py/pkgdata.py
@@ -38,11 +38,11 @@ try:
 
         def resource_exists(_package_or_requirement, _resource_name):
             _package_or_requirement = _package_or_requirement.split(".")[0]
-            return resources.is_resource(_package_or_requirement, _resource_name)
+            return resources.is_resource(_package_or_requirement, _resource_name)  # pylint: disable=deprecated-method
 
         def resource_stream(_package_or_requirement, _resource_name):
             _package_or_requirement = _package_or_requirement.split(".")[0]
-            return resources.open_binary(_package_or_requirement, _resource_name)
+            return resources.open_binary(_package_or_requirement, _resource_name)  # pylint: disable=deprecated-method
 
 except ImportError:
 

--- a/src_py/pkgdata.py
+++ b/src_py/pkgdata.py
@@ -22,13 +22,23 @@ import sys
 import os
 
 try:
-    from importlib import resources
+    import importlib_resources
 
     def resource_exists(_package_or_requirement, _resource_name):
-        return resources.is_resource(_package_or_requirement, _resource_name)
+        return (
+            importlib_resources.files(_package_or_requirement)
+            .joinpath(_resource_name)
+            .is_file()
+        )
 
-    def resource_stream(_package_of_requirement, _resource_name):
-        return resources.read_binary(_package_of_requirement, _resource_name)
+    def resource_stream(_package_or_requirement, _resource_name):
+        ref = (
+            importlib_resources.files(_package_or_requirement)
+            .joinpath(_resource_name)
+            .is_file()
+        )
+        return ref.open('rb')
+
 
 except ImportError:
 

--- a/src_py/pkgdata.py
+++ b/src_py/pkgdata.py
@@ -22,7 +22,14 @@ import sys
 import os
 
 try:
-    from pkg_resources import resource_stream, resource_exists
+    from importlib import resources
+
+    def resource_exists(_package_or_requirement, _resource_name):
+        return resources.is_resource(_package_or_requirement, _resource_name)
+
+    def resource_stream(_package_of_requirement, _resource_name):
+        return resources.read_binary(_package_of_requirement, _resource_name)
+
 except ImportError:
 
     def resource_exists(_package_or_requirement, _resource_name):

--- a/src_py/pkgdata.py
+++ b/src_py/pkgdata.py
@@ -23,19 +23,13 @@ import os
 
 try:
     if sys.version_info[:2] > (3, 8):
-        import importlib_resources
+        from importlib.resources import files
 
         def resource_exists(_package_or_requirement, _resource_name):
-            return (
-                importlib_resources.files(_package_or_requirement)
-                .joinpath(_resource_name)
-                .is_file()
-            )
+            return files(_package_or_requirement).joinpath(_resource_name).is_file()
 
         def resource_stream(_package_or_requirement, _resource_name):
-            ref = importlib_resources.files(_package_or_requirement).joinpath(
-                _resource_name
-            )
+            ref = files(_package_or_requirement).joinpath(_resource_name)
             return ref.open('rb')
     else:
         from importlib import resources

--- a/src_py/pkgdata.py
+++ b/src_py/pkgdata.py
@@ -26,19 +26,23 @@ try:
         from importlib.resources import files
 
         def resource_exists(_package_or_requirement, _resource_name):
+            _package_or_requirement = _package_or_requirement.split(".")[0]
             return files(_package_or_requirement).joinpath(_resource_name).is_file()
 
         def resource_stream(_package_or_requirement, _resource_name):
+            _package_or_requirement = _package_or_requirement.split(".")[0]
             ref = files(_package_or_requirement).joinpath(_resource_name)
             return ref.open('rb')
     else:
         from importlib import resources
 
         def resource_exists(_package_or_requirement, _resource_name):
+            _package_or_requirement = _package_or_requirement.split(".")[0]
             return resources.is_resource(_package_or_requirement, _resource_name)
 
-        def resource_stream(_package_of_requirement, _resource_name):
-            return resources.open_binary(_package_of_requirement, _resource_name)
+        def resource_stream(_package_or_requirement, _resource_name):
+            _package_or_requirement = _package_or_requirement.split(".")[0]
+            return resources.open_binary(_package_or_requirement, _resource_name)
 
 except ImportError:
 
@@ -50,7 +54,7 @@ except ImportError:
         """
         return False
 
-    def resource_stream(_package_of_requirement, _resource_name):
+    def resource_stream(_package_or_requirement, _resource_name):
         """
         A stub for when we fail to import this function.
 

--- a/src_py/pkgdata.py
+++ b/src_py/pkgdata.py
@@ -38,7 +38,7 @@ try:
             return resources.is_resource(_package_or_requirement, _resource_name)
 
         def resource_stream(_package_of_requirement, _resource_name):
-            return resources.read_binary(_package_of_requirement, _resource_name)
+            return resources.open_binary(_package_of_requirement, _resource_name)
 
 except ImportError:
 


### PR DESCRIPTION
I came across this warning when running pytest. I wondered if this fix would be appropriate.
At least on my machine the warning goes away and satisfies the deprecation warning from https://setuptools.pypa.io/en/latest/pkg_resources.html

I think I'm only using this feature for Fonts, so don't know how to check if I have broken anything with this change.