### PR TITLE
Add alias `pygame.Sound`

### DIFF
--- a/buildconfig/stubs/gen_stubs.py
+++ b/buildconfig/stubs/gen_stubs.py
@@ -68,7 +68,7 @@ PG_AUTOIMPORT_CLASSES = {
     "_debug": ["print_debug_info"],
     "event": ["Event"],
     "font": ["Font"],
-    "mixer": ["Channel"],
+    "mixer": ["Sound", "Channel"],
     "time": ["Clock"],
     "joystick": ["Joystick"],
     "window": ["Window"],

--- a/buildconfig/stubs/pygame/__init__.pyi
+++ b/buildconfig/stubs/pygame/__init__.pyi
@@ -52,7 +52,7 @@ from .mask import Mask as Mask
 from ._debug import print_debug_info as print_debug_info
 from .event import Event as Event
 from .font import Font as Font
-from .mixer import Channel as Channel
+from .mixer import Sound as Sound, Channel as Channel
 from .time import Clock as Clock
 from .joystick import Joystick as Joystick
 from .window import Window as Window

--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -375,6 +375,9 @@ The following file formats are supported
       :class:`pygame.mixer.Sound` keyword arguments and array interface support
    .. versionaddedold:: 2.0.1 pathlib.Path support on Python 3.
 
+   .. versionchanged:: 2.5.2 This class is also available through the ``pygame.Sound``
+      alias.
+
    .. method:: play
 
       | :sl:`begin sound playback`
@@ -619,7 +622,7 @@ The following file formats are supported
 
       ::
 
-          sound = pygame.mixer.Sound("s.wav")
+          sound = pygame.Sound("s.wav")
           channel = s.play()      # Sound plays at full volume by default
           sound.set_volume(0.9)   # Now plays at 90% of full volume.
           sound.set_volume(0.6)   # Now plays at 60% (previous value replaced).

--- a/examples/aliens.py
+++ b/examples/aliens.py
@@ -61,7 +61,7 @@ def load_sound(file):
         return None
     file = os.path.join(main_dir, "data", file)
     try:
-        sound = pygame.mixer.Sound(file)
+        sound = pygame.Sound(file)
         return sound
     except pygame.error:
         print(f"Warning, unable to load, {file}")

--- a/examples/audiocapture.py
+++ b/examples/audiocapture.py
@@ -70,8 +70,8 @@ print(f"recording with '{names[0]}'")
 time.sleep(5)
 
 
-print("Turning data into a pygame.mixer.Sound")
-sound = pygame.mixer.Sound(buffer=b"".join(sound_chunks))
+print("Turning data into a pygame.Sound")
+sound = pygame.Sound(buffer=b"".join(sound_chunks))
 
 print("playing back recorded sound")
 sound.play()

--- a/examples/chimp.py
+++ b/examples/chimp.py
@@ -44,7 +44,7 @@ def load_sound(name):
         return NoneSound()
 
     fullname = os.path.join(data_dir, name)
-    sound = pygame.mixer.Sound(fullname)
+    sound = pygame.Sound(fullname)
 
     return sound
 

--- a/examples/sound.py
+++ b/examples/sound.py
@@ -25,7 +25,7 @@ def main(file_path=None):
     pygame.mixer.init(11025)  # raises exception on fail
 
     # load the sound
-    sound = pygame.mixer.Sound(file_path)
+    sound = pygame.Sound(file_path)
 
     # start playing
     print("Playing Sound...")

--- a/examples/sound_array_demos.py
+++ b/examples/sound_array_demos.py
@@ -141,7 +141,7 @@ def main():
 
     print(("-" * 30) + "\n")
     print("loading sound")
-    sound = pygame.mixer.Sound(os.path.join(main_dir, "data", "car_door.wav"))
+    sound = pygame.Sound(os.path.join(main_dir, "data", "car_door.wav"))
 
     print("-" * 30)
     print("start positions")
@@ -195,7 +195,7 @@ def main():
     while pygame.mixer.get_busy():
         pygame.time.wait(200)
 
-    sound = pygame.mixer.Sound(os.path.join(main_dir, "data", "secosmic_lo.wav"))
+    sound = pygame.Sound(os.path.join(main_dir, "data", "secosmic_lo.wav"))
 
     t1 = time.time()
     sound3 = make_echo(sound, samples_per_second)

--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -273,6 +273,7 @@ except (ImportError, OSError):
 
 try:
     import pygame.mixer
+    from pygame.mixer import Sound
     from pygame.mixer import Channel
 except (ImportError, OSError):
     mixer = MissingModule("mixer", urgent=0)

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -933,7 +933,7 @@ class ChannelTypeTest(unittest.TestCase):
         # If the channel is playing a Sound on which set_volume() has also
         # been called, both calls are taken into account. For example:
         #
-        #     sound = pygame.mixer.Sound("s.wav")
+        #     sound = pygame.Sound("s.wav")
         #     channel = s.play()      # Sound plays at full volume by default
         #     sound.set_volume(0.9)   # Now plays at 90% of full volume.
         #     sound.set_volume(0.6)   # Now plays at 60% (previous value replaced).

--- a/test/sndarray_test.py
+++ b/test/sndarray_test.py
@@ -102,7 +102,7 @@ class SndarrayTest(unittest.TestCase):
                 __, sz, __ = pygame.mixer.get_init()
                 if sz == size:
                     zeroed = null_byte * ((abs(size) // 8) * len(test_data) * channels)
-                    snd = pygame.mixer.Sound(buffer=zeroed)
+                    snd = pygame.Sound(buffer=zeroed)
                     samples = pygame.sndarray.samples(snd)
                     self._assert_compatible(samples, size)
                     ##print('X %s' % (samples.shape,))
@@ -146,7 +146,7 @@ class SndarrayTest(unittest.TestCase):
             self.skipTest("unsupported mixer configuration")
 
         arr = array([[0.0, -1.0], [-1.0, 0], [1.0, 0], [0, 1.0]], float32)
-        newsound = pygame.mixer.Sound(array=arr)
+        newsound = pygame.Sound(array=arr)
         pygame.mixer.quit()
 
 


### PR DESCRIPTION
It has been enough time for the Sound class to get its alias!
I don't recall the last time I used a Channel object but somehow that has the alias and not Sound, which is more common.

I also slightly changed the examples to use the alias, if you prefer how it was previously just say so and I'll revert at the speed of light.