### PR TITLE
Optimized `Rect.clipline()`

### DIFF
--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -152,6 +152,7 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
 #define RectImport_TypeObject pgRect_Type
 #define RectImport_IntersectRectAndLine SDL_IntersectRectAndLine
 #define RectImport_PyBuildValueFormat "i"
+#define RectImport_TupleFromTwoPrimitives pg_tuple_couple_from_values_int
 #define RectImport_ObjectName "pygame.rect.Rect"
 #define RectImport_PythonNumberCheck PyLong_Check
 #define RectImport_PythonNumberAsPrimitiveType PyLong_AsLong
@@ -268,6 +269,7 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
 #define RectImport_IntersectRectAndLine PG_IntersectFRectAndLine
 #define RectImport_TypeObject pgFRect_Type
 #define RectImport_PyBuildValueFormat "f"
+#define RectImport_TupleFromTwoPrimitives pg_tuple_couple_from_values_double
 #define RectImport_ObjectName "pygame.rect.FRect"
 #define RectImport_PythonNumberCheck PyFloat_Check
 #define RectImport_PythonNumberAsPrimitiveType PyFloat_AsDouble

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -359,6 +359,9 @@
 #ifndef RectImport_PyBuildValueFormat
 #error RectImport_PyBuildValueFormat needs to be defined
 #endif
+#ifndef RectImport_TupleFromTwoPrimitives
+#error RectImport_TupleFromTwoPrimitives needs to be defined
+#endif
 // #endregion
 
 // #region RectOptional
@@ -399,6 +402,7 @@
 #define fourPrimivitesFromObj RectImport_fourPrimiviteFromObj
 #define PrimitiveFromObj RectImport_PrimitiveFromObj
 #define TypeFMT RectImport_PyBuildValueFormat
+#define TupleFromTwoPrimitives RectImport_TupleFromTwoPrimitives
 #define ObjectName RectImport_ObjectName
 #define PythonNumberCheck RectImport_PythonNumberCheck
 #define PythonNumberAsPrimitiveType RectImport_PythonNumberAsPrimitiveType
@@ -1915,8 +1919,29 @@ RectExport_clipline(RectObject *self, PyObject *const *args, Py_ssize_t nargs)
     }
 
     Py_XDECREF(rect_copy);
-    return Py_BuildValue("((" TypeFMT "" TypeFMT ")(" TypeFMT "" TypeFMT "))",
-                         x1, y1, x2, y2);
+
+    PyObject *subtup1, *subtup2;
+    subtup1 = TupleFromTwoPrimitives(x1, y1);
+    if (!subtup1)
+        return NULL;
+
+    subtup2 = TupleFromTwoPrimitives(x2, y2);
+    if (!subtup2) {
+        Py_DECREF(subtup1);
+        return NULL;
+    }
+
+    PyObject *tup = PyTuple_New(2);
+    if (!tup) {
+        Py_DECREF(subtup1);
+        Py_DECREF(subtup2);
+        return NULL;
+    }
+
+    PyTuple_SET_ITEM(tup, 0, subtup1);
+    PyTuple_SET_ITEM(tup, 1, subtup2);
+
+    return tup;
 }
 
 static int
@@ -2964,6 +2989,7 @@ RectExport_iterator(RectObject *self)
 #undef RectImport_TypeObject
 #undef RectImport_PrimitiveFromObj
 #undef RectImport_PyBuildValueFormat
+#undef TupleFromTwoPrimitives
 #undef RectImport_ObjectName
 
 #undef PrimitiveType

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -2989,7 +2989,7 @@ RectExport_iterator(RectObject *self)
 #undef RectImport_TypeObject
 #undef RectImport_PrimitiveFromObj
 #undef RectImport_PyBuildValueFormat
-#undef TupleFromTwoPrimitives
+#undef RectImport_TupleFromTwoPrimitives
 #undef RectImport_ObjectName
 
 #undef PrimitiveType


### PR DESCRIPTION
This PR improves the speed of `Rect.clipline()` by 45-50% when the line intersects the rectangle, with no noticeable change when there's no intersection. The optimization comes from replacing `PyBuildValue` with a custom implementation to construct the return tuple.

I've also added a new macro that enables easy dispatching between the double/int custom tuple packing function we have.

I got these results:
**Old**
```
Colliding
2.2999593056738377e-06 2.571070200065151e-06
2.3999600671231747e-06 2.5393099116627127e-06
2.2999593056738377e-06 2.440720208687708e-06
2.2999593056738377e-06 2.4487898976076393e-06
2.3999600671231747e-06 2.4846897984389216e-06
Non Colliding
8.999486453831196e-07 1.0697301593609154e-06
8.999486453831196e-07 9.743399394210428e-07
8.999486453831196e-07 9.719599853269757e-07
8.999486453831196e-07 9.75440168986097e-07
8.999486453831196e-07 1.03677986189723e-06
```

**New**
```
Colliding
1.5999539755284786e-06 1.6530799737665803e-06
1.5999539755284786e-06 1.7165300087071954e-06
1.5999539755284786e-06 1.801859913393855e-06
1.5999539755284786e-06 1.6924298892263323e-06
1.5999539755284786e-06 1.8196600314695388e-06
Non Colliding
8.999486453831196e-07 1.036960061173886e-06
8.999486453831196e-07 1.0293898812960834e-06
8.999486453831196e-07 1.0853600455448032e-06
8.999486453831196e-07 1.0411400173325092e-06
8.999486453831196e-07 1.0053500125650316e-06

```

Using this test program:
```Py
from timeit import repeat
from statistics import fmean

from pygame import Rect

r = Rect(100, 100, 100, 100)

G = globals()

print("Colliding")
for _ in range(5):
    data = repeat("r.clipline(0, 0, 105, 150)", number=10, repeat=10000, globals=G)
    print(f"{min(data)} {fmean(data)}")

print("Non Colliding")
for _ in range(5):
    data = repeat("r.clipline(0, 0, 1000, 10)", number=10, repeat=10000, globals=G)
    print(f"{min(data)} {fmean(data)}")
```