### PR TITLE
Make experimental API not hidden in the docs anymore

### DIFF
--- a/docs/reST/index.rst
+++ b/docs/reST/index.rst
@@ -38,6 +38,26 @@ section below, check out a video tutorial (`I'm a fan of this one
 <https://www.youtube.com/watch?v=AY9MnQ4x3zk>`_), or reference the API
 documentation by module.
 
+Experimental modules
+--------------------
+
+Experimental modules are work in progress, this is why you should refrain from relying on any features 
+provided by these modules, as they are subject to change or removal without prior notice. 
+If you want to test these experimental modules, you might want to understand how you import 
+them, this is how you can do it:
+
+.. code-block:: python
+
+  from pygame import experimental_module
+  # Or for specific modules like _sdl2.controller
+  from pygame._sdl2 import controller
+
+
+Don't forget to report us any problem with the experimental features on `github`_ so we can easily 
+turn them to stable API in the future ^^.
+
+.. _github: https://github.com/pygame-community/pygame-ce
+
 Documents
 ---------
 

--- a/docs/reST/index.rst
+++ b/docs/reST/index.rst
@@ -51,7 +51,8 @@ them, this is how you can do it:
   from pygame import experimental_module
   # Or for specific modules like _sdl2.controller
   from pygame._sdl2 import controller
-
+  # Or
+  import pygame.experimental_module
 
 Don't forget to report us any problem with the experimental features on `github`_ so we can easily 
 turn them to stable API in the future ^^.

--- a/docs/reST/index.rst
+++ b/docs/reST/index.rst
@@ -57,6 +57,20 @@ them, this is how you can do it:
 Don't forget to report us any problem with the experimental features on `github`_ so we can easily 
 turn them to stable API in the future ^^.
 
+**Below is currently the list of experimental modules :**
+
+:doc:`ref/geometry`
+  Pygame module for the Circle, Line, and Polygon objects.
+
+:doc:`ref/window`
+  Pygame object that handles a window.
+
+:doc:`ref/sdl2_controller`
+  Pygame module to work with controllers.
+
+:doc:`ref/sdl2_video`
+  Pygame module for porting new SDL video systems.
+
 .. _github: https://github.com/pygame-community/pygame-ce
 
 Documents

--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -41,7 +41,7 @@ We render three sets of items based on how useful to most apps.
 {%- set basic = ['Color', 'display', 'draw', 'event', 'font', 'image', 'key', 'locals', 'mixer', 'mouse', 'music', 'pygame', 'Rect', 'Surface', 'time'] %}
 {%- set experimental = ['sdl2_video', 'controller', 'geometry', 'Window'] %}
 {%- set advanced = ['BufferProxy', 'freetype', 'gfxdraw', 'midi', 'PixelArray', 'pixelcopy', 'sndarray', 'surfarray', 'cursors', 'joystick', 'mask', 'math', 'sprite', 'transform'] %}
-{%- set hidden = [] %}
+{%- set hidden = ['sdl2_video', 'geometry', 'Window'] %}
 {%-   if pyg_sections %}
 	  <p class="bottom"><b>Most useful stuff</b>:
 {%      set sep = joiner(" | \n") %}
@@ -75,22 +75,6 @@ We render three sets of items based on how useful to most apps.
 {%-     endfor %}
 	  </p>
 
-	  <p class="bottom"><b>Experimental stuff</b>:
-{%      set sep = joiner(" | \n") %}
-{%-     for section in pyg_sections %}
-{%-       set docname = section['docname'] %}
-{%-       set simpledocname = docname.split('/')[-1] %}
-{%-       set name = section['fullname'].split('.')[-1] %}
-{%-       set uri = pathto(docname, 1) + file_suffix -%}
-{%-       if name|lower != simpledocname %}
-{%-         set uri = uri + '#' + section['refid'] %}
-{%-       endif %}
-{%-       if name in experimental %}
-{{- sep() }}	    <a href="{{ uri }}">{{ name }}</a>
-{%-       endif %}
-{%-     endfor %}
-		</p>
-
 	  <p class="bottom"><b>Other</b>:
 {%      set sep = joiner(" | \n") %}
 {%-     for section in pyg_sections %}
@@ -101,7 +85,7 @@ We render three sets of items based on how useful to most apps.
 {%-       if name|lower != simpledocname %}
 {%-         set uri = uri + '#' + section['refid'] %}
 {%-       endif %}
-{%-       if name not in basic and name not in advanced and name not in hidden and name not in experimental %}
+{%-       if name not in basic and name not in advanced and name not in hidden %}
 {{- sep() }}	    <a href="{{ uri }}">{{ name }}</a>
 {%-       endif %}
 {%-     endfor %}

--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -39,8 +39,9 @@ We render three sets of items based on how useful to most apps.
 
 #}
 {%- set basic = ['Color', 'display', 'draw', 'event', 'font', 'image', 'key', 'locals', 'mixer', 'mouse', 'music', 'pygame', 'Rect', 'Surface', 'time'] %}
+{%- set experimental = ['sdl2_video', 'controller', 'geometry', 'Window', 'camera', 'scrap'] %}
 {%- set advanced = ['BufferProxy', 'freetype', 'gfxdraw', 'midi', 'PixelArray', 'pixelcopy', 'sndarray', 'surfarray', 'cursors', 'joystick', 'mask', 'math', 'sprite', 'transform'] %}
-{%- set hidden = ['sdl2_video', 'sdl2_controller', 'geometry', 'Window'] %}
+{%- set hidden = [] %}
 {%-   if pyg_sections %}
 	  <p class="bottom"><b>Most useful stuff</b>:
 {%      set sep = joiner(" | \n") %}
@@ -74,6 +75,22 @@ We render three sets of items based on how useful to most apps.
 {%-     endfor %}
 	  </p>
 
+	  <p class="bottom"><b>Experimental stuff</b>:
+{%      set sep = joiner(" | \n") %}
+{%-     for section in pyg_sections %}
+{%-       set docname = section['docname'] %}
+{%-       set simpledocname = docname.split('/')[-1] %}
+{%-       set name = section['fullname'].split('.')[-1] %}
+{%-       set uri = pathto(docname, 1) + file_suffix -%}
+{%-       if name|lower != simpledocname %}
+{%-         set uri = uri + '#' + section['refid'] %}
+{%-       endif %}
+{%-       if name in experimental %}
+{{- sep() }}	    <a href="{{ uri }}">{{ name }}</a>
+{%-       endif %}
+{%-     endfor %}
+		</p>
+
 	  <p class="bottom"><b>Other</b>:
 {%      set sep = joiner(" | \n") %}
 {%-     for section in pyg_sections %}
@@ -84,7 +101,7 @@ We render three sets of items based on how useful to most apps.
 {%-       if name|lower != simpledocname %}
 {%-         set uri = uri + '#' + section['refid'] %}
 {%-       endif %}
-{%-       if name not in basic and name not in advanced and name not in hidden %}
+{%-       if name not in basic and name not in advanced and name not in hidden and name not in experimental %}
 {{- sep() }}	    <a href="{{ uri }}">{{ name }}</a>
 {%-       endif %}
 {%-     endfor %}

--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -39,7 +39,7 @@ We render three sets of items based on how useful to most apps.
 
 #}
 {%- set basic = ['Color', 'display', 'draw', 'event', 'font', 'image', 'key', 'locals', 'mixer', 'mouse', 'music', 'pygame', 'Rect', 'Surface', 'time'] %}
-{%- set experimental = ['sdl2_video', 'controller', 'geometry', 'Window', 'camera', 'scrap'] %}
+{%- set experimental = ['sdl2_video', 'controller', 'geometry', 'Window'] %}
 {%- set advanced = ['BufferProxy', 'freetype', 'gfxdraw', 'midi', 'PixelArray', 'pixelcopy', 'sndarray', 'surfarray', 'cursors', 'joystick', 'mask', 'math', 'sprite', 'transform'] %}
 {%- set hidden = [] %}
 {%-   if pyg_sections %}


### PR DESCRIPTION
This PR aims to make experimental API not hidden anymore for pygame users, the only thing changed is this :
![image](https://github.com/user-attachments/assets/b4075c8d-49af-42bd-a24f-a79f0aca0a84)

Original message from @itzpr3d4t0r on discord : 

> I mean the thing is:
> - We already state that experimental modules are subject to change and tell people to not rely on them for any big project
> - It is well known that experimental means it's subject to change
> - If we keep stuff hidden with no specific mentions other than sporadically inside changelogs (which not a lot of people ever read) very few people will actually try the experimental api and fewer bugs or ideas will be found

> So yeah I'm for updating that. I don't think something like that would damage us or people in any way really (realistically speaking). Big question is who are we really hiding these from?

This is something I fully support, why should we hide experimental API from users ? How can we expect good and continuous reviews, and bug reports ?