### PR TITLE
Update `FRect` repr to handle larger values

### DIFF
--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -615,11 +615,11 @@ pg_rect_repr(pgRectObject *self)
 static PyObject *
 pg_frect_repr(pgFRectObject *self)
 {
-    char str[64];
+    char str[256];
 
-    int ret = PyOS_snprintf(str, 64, "FRect(%f, %f, %f, %f)", self->r.x,
+    int ret = PyOS_snprintf(str, 256, "FRect(%f, %f, %f, %f)", self->r.x,
                             self->r.y, self->r.w, self->r.h);
-    if (ret < 0 || ret >= 64) {
+    if (ret < 0 || ret >= 256) {
         return RAISE(PyExc_RuntimeError,
                      "Internal PyOS_snprintf call failed!");
     }

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -2877,6 +2877,9 @@ class FRectTypeTest(RectTypeTest):
             repr(rect), "FRect(12.345679, 34.000000, 56.000000, 78.000000)"
         )
 
+        # test that a large rect repr doesn't error
+        self.assertIsInstance(repr(Rect(-2e38, -2e38, -2e38, -2e38)), str)
+
     def test_clipline__equal_endpoints_no_overlap(self):
         """Ensures clipline handles lines with both endpoints the same.
 


### PR DESCRIPTION
Before this PR
```
>>> pygame.FRect(-2e38, -2e38, -2e38, -2e38)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Internal PyOS_snprintf call failed!
```

After this PR
```
>>> pygame.FRect(-2e38, -2e38, -2e38, -2e38)
FRect(-199999993605713849301312521538346418176.000000, -199999993605713849301312521538346418176.000000, -199999993605713849301312521538346418176.000000, -199999993605713849301312521538346418176.000000)
```