### PR TITLE
Bump build dependencies

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Install uv for speed
         uses: yezz123/setup-uv@v4
         with:
-          uv-version: "0.2.22"
+          uv-version: "0.4.10"
 
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.20.0

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install uv for speed
         uses: yezz123/setup-uv@v4
         with:
-          uv-version: "0.2.22"
+          uv-version: "0.4.10"
 
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,9 +55,9 @@ pygame_ce = 'pygame.__briefcase.pygame_ce:PygameCEGuiBootstrap'
 [build-system]
 requires = [
   "meson-python<=0.16.0",
-  "meson<=1.5.0",
+  "meson<=1.5.1",
   "ninja<=1.11.1.1",
-  "cython<=3.0.10",
+  "cython<=3.0.11",
   "sphinx<=7.2.6",
 ]
 build-backend = 'mesonpy'
@@ -109,8 +109,6 @@ only-binary = ["numpy"]
 
 # 1. skip all 32-bit manylinux (i686) 
 # 2. skip all pypy+arm combinations
-# 3. skip all pypy 310 because it is so new numpy does not have wheels for it
-# 4. skip all python 313 because numpy doesn't have wheels for it yet
 [[tool.cibuildwheel.overrides]]
-select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp310-*,*p313-*}"
+select = "{*-manylinux_i686,pp*-*{arm64,aarch64}}"
 test-requires = []


### PR DESCRIPTION
Simple PR to build a couple of build dependencies.

Also gets us using numpy on more of our builds since numpy recently added support for cpython 3.13 and pypy 3.10