### PR TITLE
Drop MSYS2 clang32 from our CI

### DIFF
--- a/.github/workflows/build-on-msys2.yml
+++ b/.github/workflows/build-on-msys2.yml
@@ -44,7 +44,6 @@ jobs:
           - { sys: mingw64, env: x86_64 }
           - { sys: mingw32, env: i686 }
           - { sys: ucrt64,  env: ucrt-x86_64 }
-          - { sys: clang32, env: clang-i686 }
           - { sys: clang64, env: clang-x86_64 }
           # - { sys: clangarm64, env: clang-aarch64 }
 


### PR DESCRIPTION
ref: https://github.com/msys2/msys2.github.io/commit/89521b9f8d43b6ebf4a4f4a51c912066ab5f5b50

basically MSYS2 is removing clang32 (i686) support, so one of our builds has started to fail. We can safely remove this on our end as well, because this build doesn't do release wheels.