### PR TITLE
Fix editable install on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ dist
 *.so
 __pycache__
 _headers/*
+buildconfig/win_dll_dirs.json
 
 # cython generated files
 src_c/_sdl2/*.c

--- a/buildconfig/_meson_win_dll.py
+++ b/buildconfig/_meson_win_dll.py
@@ -1,0 +1,14 @@
+"""
+A helper file invoked by the meson buildconfig to write DLL paths to a json file
+"""
+
+import json
+import sys
+
+from pathlib import Path
+
+dll_parents = {str(Path(i).parent) for i in sys.argv[1:]}
+win_dll_dirs_file = Path(__file__).parent / "win_dll_dirs.json"
+
+if __name__ == "__main__":
+    win_dll_dirs_file.write_text(json.dumps(list(dll_parents)), encoding="utf-8")

--- a/meson.build
+++ b/meson.build
@@ -167,6 +167,15 @@ if plat == 'win' and host_machine.cpu_family().startswith('x86')
         )
     endif
 
+    run_command(
+        [
+            find_program('python3', 'python'),
+            base_dir / 'buildconfig' / '_meson_win_dll.py',
+            dlls,
+        ],
+        check: true,
+    )
+
     # put dlls in root of install
     install_data(dlls, install_dir: pg_dir, install_tag: 'pg-tag')
 else

--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -30,16 +30,32 @@ import platform
 # Choose Windows display driver
 if os.name == "nt":
     pygame_dir = os.path.split(__file__)[0]
+    dll_parents = {pygame_dir}
+    try:
+        # For editable support, add some more folders where DLLs are available.
+        # This block only executes under an editable install. In a "normal"
+        # install, the json file will not be installed at the supplied path.
+        with open(
+            os.path.join(
+                os.path.dirname(pygame_dir), "buildconfig", "win_dll_dirs.json"
+            ),
+            encoding="utf-8",
+        ) as f:
+            import json
 
-    # pypy does not find the dlls, so we add package folder to PATH.
-    os.environ["PATH"] = os.environ["PATH"] + ";" + pygame_dir
+            dll_parents.update(json.load(f))
+            del json
+    except (FileNotFoundError, ValueError):
+        pass
 
-    # Windows store python does not find the dlls, so we run this
-    if sys.version_info > (3, 8):
-        os.add_dll_directory(pygame_dir)  # only available in 3.8+
+    for d in dll_parents:
+        # adding to PATH is the legacy way, os.add_dll_directory is the new
+        # and recommended method. For extra safety we do both
+        os.environ["PATH"] = os.environ["PATH"] + ";" + d
+        os.add_dll_directory(d)
 
     # cleanup namespace
-    del pygame_dir
+    del pygame_dir, dll_parents
 
 # when running under X11, always set the SDL window WM_CLASS to make the
 #   window managers correctly match the pygame window.


### PR DESCRIPTION
An (untested) attempt to making editable installs work on windows.

Basically the idea is to special case the DLL handling code which already exists, to handle editable installs differently. With an editable install no DLL moving happens, so we just have to hunt for the DLLs in the source tree and track the folders.