### PR TITLE
Bump ubuntu to 24.04 on CI, fix cppcheck

### DIFF
--- a/.github/workflows/build-debian-multiarch.yml
+++ b/.github/workflows/build-debian-multiarch.yml
@@ -49,7 +49,7 @@ env:
 jobs:
   build-multiarch:
     name: Debian (Bookworm - 12) [${{ matrix.arch }}]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
@@ -120,7 +120,7 @@ jobs:
   test-armv7-on-armv6:
     needs: build-multiarch
     name: Debian (Bookworm - 12) [build - armv7, test - armv6]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Download all multiarch artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.arch }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-ubuntu-coverage.yml
+++ b/.github/workflows/build-ubuntu-coverage.yml
@@ -48,7 +48,12 @@ jobs:
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
+
+    env:
+      # Pip now forces us to either make a venv or set this flag, so we will do
+      # this
+      PIP_BREAK_SYSTEM_PACKAGES: 1
 
     steps:
     - uses: actions/checkout@v4.1.7

--- a/.github/workflows/build-ubuntu-coverage.yml
+++ b/.github/workflows/build-ubuntu-coverage.yml
@@ -54,6 +54,8 @@ jobs:
       # Pip now forces us to either make a venv or set this flag, so we will do
       # this
       PIP_BREAK_SYSTEM_PACKAGES: 1
+      # We are using dependencies installed from apt
+      PG_DEPS_FROM_SYSTEM: 1
 
     steps:
     - uses: actions/checkout@v4.1.7

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -48,7 +48,12 @@ jobs:
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
+
+    env:
+      # Pip now forces us to either make a venv or set this flag, so we will do
+      # this
+      PIP_BREAK_SYSTEM_PACKAGES: 1
 
     steps:
     - uses: actions/checkout@v4.1.7
@@ -76,14 +81,13 @@ jobs:
       run: python3 -m pygame.tests -v --exclude opengl,music,timing --time_out 300
 
     - name: Test typestubs
-      if: matrix.os == 'ubuntu-22.04' # run stubtest only once
       run: |
         pip3 install mypy
         python3 buildconfig/stubs/stubcheck.py
 
     # We upload the generated files under github actions assets
     - name: Upload sdist
-      if: matrix.os == 'ubuntu-20.04' # upload sdist only once
+      if: matrix.os == 'ubuntu-24.04' # upload sdist only once
       uses: actions/upload-artifact@v4
       with:
         name: pygame-wheels-sdist

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -54,6 +54,8 @@ jobs:
       # Pip now forces us to either make a venv or set this flag, so we will do
       # this
       PIP_BREAK_SYSTEM_PACKAGES: 1
+      # We are using dependencies installed from apt
+      PG_DEPS_FROM_SYSTEM: 1
 
     steps:
     - uses: actions/checkout@v4.1.7

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -19,7 +19,7 @@ concurrency:
 # TODO: Any more static checkers can be added here
 jobs:
   run-cppcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4.1.7
@@ -32,6 +32,10 @@ jobs:
           sudo apt install cppcheck
 
       - name: Run Static Checker
-        # skip cppcheck on SDL_gfx and scrap for now
-        run: cppcheck src_c --force --enable=performance,portability,warning \
-          --suppress=*:src_c/SDL_gfx/* --suppress=*:src_c/scrap*
+        # skip cppcheck on SDL_gfx, scrap, scale_mm* and ft_cache for now
+        # suppress missingReturn and syntaxError because it gives many false positives
+        run: cppcheck src_c --enable=performance,portability,warning \
+          --suppress=*:src_c/freetype/ft_cache.c --suppress=*:src_c/scrap* \
+          --suppress=*:src_c/scale_mmx*.c --suppress=*:src_c/SDL_gfx/* \
+          --suppress=missingReturn --suppress=syntaxError -DWITH_THREAD -j $(nproc) \
+          -DPG_MAJOR_VERSION -DPG_MINOR_VERSION -DPG_PATCH_VERSION -DPG_VERSION_TAG

--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -37,7 +37,12 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
   format-lint-code-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+
+    env:
+      # Pip now forces us to either make a venv or set this flag, so we will do
+      # this
+      PIP_BREAK_SYSTEM_PACKAGES: 1
 
     steps:
       - uses: actions/checkout@v4.1.7

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -47,12 +47,16 @@
 
 #include <ctype.h>
 
+static inline double
+pg_round(double d)
+{
 #if (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L) && \
     !defined(round)
-#define pg_round(d) (((d < 0) ? (ceil((d) - 0.5)) : (floor((d) + 0.5))))
+    return (((d < 0) ? (ceil((d)-0.5)) : (floor((d) + 0.5))));
 #else
-#define pg_round(d) round(d)
+    return round(d);
 #endif
+}
 
 typedef enum { TRISTATE_SUCCESS, TRISTATE_FAIL, TRISTATE_ERROR } tristate;
 
@@ -813,10 +817,10 @@ _color_lerp(pgColorObject *self, PyObject *args, PyObject *kw)
         return RAISE(PyExc_ValueError, "Argument 2 must be in range [0, 1]");
     }
 
-    new_rgba[0] = (Uint8)pg_round(self->data[0] * (1 - amt) + rgba[0] * amt);
-    new_rgba[1] = (Uint8)pg_round(self->data[1] * (1 - amt) + rgba[1] * amt);
-    new_rgba[2] = (Uint8)pg_round(self->data[2] * (1 - amt) + rgba[2] * amt);
-    new_rgba[3] = (Uint8)pg_round(self->data[3] * (1 - amt) + rgba[3] * amt);
+    for (int i = 0; i < 4; i++) {
+        new_rgba[i] =
+            (Uint8)pg_round(self->data[i] * (1 - amt) + rgba[i] * amt);
+    }
 
     return (PyObject *)_color_new_internal(Py_TYPE(self), new_rgba);
 }

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -40,8 +40,10 @@ class MixerMusicModuleTest(unittest.TestCase):
         "|tags:music|"
         self.music_load("house_lo.flac")
 
+    # system installed SDL_mixer may not support wavpack
     @unittest.skipIf(
-        pygame.mixer.get_sdl_mixer_version() < (2, 8, 0),
+        pygame.mixer.get_sdl_mixer_version() < (2, 8, 0)
+        or "PG_DEPS_FROM_SYSTEM" in os.environ,
         "WavPack support added in SDL_mixer 2.8.0",
     )
     def test_load_wv(self):
@@ -85,7 +87,10 @@ class MixerMusicModuleTest(unittest.TestCase):
         if pygame.mixer.get_sdl_mixer_version() >= (2, 6, 0):
             filenames.append("house_lo.mp3")
 
-        if pygame.mixer.get_sdl_mixer_version() >= (2, 8, 0):
+        if (
+            pygame.mixer.get_sdl_mixer_version() >= (2, 8, 0)
+            and "PG_DEPS_FROM_SYSTEM" not in os.environ
+        ):
             filenames.append("house_lo.wv")
 
         if pygame.mixer.get_soundfont() is not None:
@@ -113,7 +118,10 @@ class MixerMusicModuleTest(unittest.TestCase):
         if pygame.mixer.get_sdl_mixer_version() >= (2, 6, 0):
             filenames.append("house_lo.mp3")
 
-        if pygame.mixer.get_sdl_mixer_version() >= (2, 8, 0):
+        if (
+            pygame.mixer.get_sdl_mixer_version() >= (2, 8, 0)
+            and "PG_DEPS_FROM_SYSTEM" not in os.environ
+        ):
             filenames.append("house_lo.wv")
 
         if pygame.mixer.get_soundfont() is not None:
@@ -208,8 +216,10 @@ class MixerMusicModuleTest(unittest.TestCase):
         filename = example_path(os.path.join("data", "house_lo.flac"))
         pygame.mixer.music.queue(filename)
 
+    # system installed SDL_mixer may not support wavpack
     @unittest.skipIf(
-        pygame.mixer.get_sdl_mixer_version() < (2, 8, 0),
+        pygame.mixer.get_sdl_mixer_version() < (2, 8, 0)
+        or "PG_DEPS_FROM_SYSTEM" in os.environ,
         "WavPack support added in SDL_mixer 2.8.0",
     )
     def test_queue_wv(self):


### PR DESCRIPTION
Ubuntu 24.04 has been declared as generally available on github actions. At the same time, Ubuntu 20.04 is being phased out and will be removed soon.

This PR makes a couple of changes to accommodate for 24.04 in our code. Most notably, the `cppcheck` version change has made me do a couple of changes to the test command as well as the code in one instance (the new version did not like something in `color.c`)

This PR is also a prerequisite for dropping Python 3.8 support because Ubuntu 20.04 is on Python 3.8