### PR TITLE
Fix a compiler warning in debug mode

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3495,8 +3495,8 @@ _get_buffer_colorplane(PyObject *obj, Py_buffer *view_p, int flags, char *name,
             /* Should not be here */
             PyErr_Format(PyExc_SystemError,
                          "Pygame bug caught at line %i in file %s: "
-                         "unknown mask value %p. Please report",
-                         (int)__LINE__, __FILE__, (void *)mask);
+                         "unknown mask value %X. Please report",
+                         (int)__LINE__, __FILE__, mask);
             return -1;
 #endif
     }


### PR DESCRIPTION
Currently I am facing a compiler warning because a 32-bit integer is being casted to a pointer type.

This PR has 0 impact for user facing releases, but this is needed for debug builds compiling without warnings.