### PR TITLE
Set error when too many numbers of argument in ``pygame.Color.from_colorspace``

### DIFF
--- a/src_c/color.c
+++ b/src_c/color.c
@@ -1008,19 +1008,10 @@ _color_set_hsva(pgColorObject *color, PyObject *value, void *closure)
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("hsva", value);
 
-    if (!PySequence_Check(value) || PySequence_Size(value) < 3) {
+    if (!PySequence_Check(value) || PySequence_Size(value) < 3 ||
+        PySequence_Size(value) > 4) {
         PyErr_SetString(PyExc_ValueError, "invalid HSVA value");
         return -1;
-    }
-
-    if (PySequence_Size(value) > 4) {
-        if (PyErr_WarnEx(
-                PyExc_DeprecationWarning,
-                "Passing sequences of size larger than 4 is deprecated, doing "
-                "this will error in a future version",
-                1) == -1) {
-            return -1;
-        }
     }
 
     /* H */
@@ -1183,19 +1174,10 @@ _color_set_hsla(pgColorObject *color, PyObject *value, void *closure)
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("hsla", value);
 
-    if (!PySequence_Check(value) || PySequence_Size(value) < 3) {
+    if (!PySequence_Check(value) || PySequence_Size(value) < 3 ||
+        PySequence_Size(value) > 4) {
         PyErr_SetString(PyExc_ValueError, "invalid HSLA value");
         return -1;
-    }
-
-    if (PySequence_Size(value) > 4) {
-        if (PyErr_WarnEx(
-                PyExc_DeprecationWarning,
-                "Passing sequences of size larger than 4 is deprecated, doing "
-                "this will error in a future version",
-                1) == -1) {
-            return -1;
-        }
     }
 
     /* H */
@@ -1358,19 +1340,9 @@ _color_set_i1i2i3(pgColorObject *color, PyObject *value, void *closure)
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("i1i2i3", value);
 
-    if (!PySequence_Check(value) || PySequence_Size(value) < 3) {
+    if (!PySequence_Check(value) || PySequence_Size(value) != 3) {
         PyErr_SetString(PyExc_ValueError, "invalid I1I2I3 value");
         return -1;
-    }
-
-    if (PySequence_Size(value) > 3) {
-        if (PyErr_WarnEx(
-                PyExc_DeprecationWarning,
-                "Passing sequences of size larger than 3 is deprecated, doing "
-                "this will error in a future version",
-                1) == -1) {
-            return -1;
-        }
     }
 
     /* I1 */
@@ -1440,19 +1412,9 @@ _color_set_cmy(pgColorObject *color, PyObject *value, void *closure)
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("cmy", value);
 
-    if (!PySequence_Check(value) || PySequence_Size(value) < 3) {
+    if (!PySequence_Check(value) || PySequence_Size(value) != 3) {
         PyErr_SetString(PyExc_ValueError, "invalid CMY value");
         return -1;
-    }
-
-    if (PySequence_Size(value) > 3) {
-        if (PyErr_WarnEx(
-                PyExc_DeprecationWarning,
-                "Passing sequences of size larger than 3 is deprecated, doing "
-                "this will error in a future version",
-                1) == -1) {
-            return -1;
-        }
     }
 
     /* I1 */
@@ -1510,19 +1472,10 @@ _color_set_normalized(pgColorObject *color, PyObject *value, void *closure)
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("normalized", value);
 
-    if (!PySequence_Check(value) || PySequence_Size(value) < 3) {
+    if (!PySequence_Check(value) || PySequence_Size(value) < 3 ||
+        PySequence_Size(value) > 4) {
         PyErr_SetString(PyExc_ValueError, "invalid normalized value");
         return -1;
-    }
-
-    if (PySequence_Size(value) > 4) {
-        if (PyErr_WarnEx(
-                PyExc_DeprecationWarning,
-                "Passing sequences of size larger than 4 is deprecated, doing "
-                "this will error in a future version",
-                1) == -1) {
-            return -1;
-        }
     }
 
     item = PySequence_GetItem(value, 0);

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -830,9 +830,10 @@ class ColorTypeTest(unittest.TestCase):
         self.assertEqual(expected_i1i2i3, i1i2i3)
         self.assertEqual(expected_i1i2i3, i1i2i3_tuple)
 
-        with self.assertRaises(ValueError):
-            pygame.Color.from_i1i2i3(0, 0, 0, "lel", "foo")
-            pygame.Color.from_i1i2i3((0, 0, 0, 0))
+        self.assertRaises(
+            ValueError, lambda: pygame.Color.from_i1i2i3(0, 0, 0, "lel", "foo")
+        )
+        self.assertRaises(ValueError, lambda: pygame.Color.from_i1i2i3((0, 0, 0, 0)))
 
     def test_from_normalized(self):
         normal = pygame.Color.from_normalized(1, 1, 1, 1)

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -782,13 +782,9 @@ class ColorTypeTest(unittest.TestCase):
         self.assertEqual(expected_cmy, cmy)
         self.assertEqual(expected_cmy, cmy_tuple)
 
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(
-                expected_cmy, pygame.Color.from_cmy(0.5, 0.5, 0.5, "lel", "foo")
-            )
-
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(expected_cmy, pygame.Color.from_cmy((0.5, 0.5, 0.5, 0.5)))
+        with self.assertRaises(ValueError):
+            pygame.Color.from_cmy(0.5, 0.5, 0.5, "lel", "foo")
+            pygame.Color.from_cmy((0.5, 0.5, 0.5, 0.5))
 
     def test_from_hsva(self):
         hsva = pygame.Color.from_hsva(0, 100, 100, 100)
@@ -799,15 +795,9 @@ class ColorTypeTest(unittest.TestCase):
         self.assertEqual(expected_hsva, hsva)
         self.assertEqual(expected_hsva, hsva_tuple)
 
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(
-                expected_hsva, pygame.Color.from_hsva(0, 100, 100, 100, "lel", "foo")
-            )
-
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(
-                expected_hsva, pygame.Color.from_hsva((0, 100, 100, 100, "lel"))
-            )
+        with self.assertRaises(ValueError):
+            pygame.Color.from_hsva(0, 100, 100, 100, "lel", "foo")
+            pygame.Color.from_hsva((0, 100, 100, 100, "lel"))
 
     def test_from_hsla(self):
         hsla = pygame.Color.from_hsla(0, 100, 100, 100)
@@ -818,15 +808,9 @@ class ColorTypeTest(unittest.TestCase):
         self.assertEqual(expected_hsla, hsla)
         self.assertEqual(expected_hsla, hsla_tuple)
 
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(
-                expected_hsla, pygame.Color.from_hsla(0, 100, 100, 100, "lel")
-            )
-
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(
-                expected_hsla, pygame.Color.from_hsla((0, 100, 100, 100, "lel", "foo"))
-            )
+        with self.assertRaises(ValueError):
+            pygame.Color.from_hsla(0, 100, 100, 100, "lel")
+            pygame.Color.from_hsla((0, 100, 100, 100, "lel", "foo"))
 
     def test_from_i1i2i3(self):
         i1i2i3 = pygame.Color.from_i1i2i3(0, 0, 0)
@@ -837,13 +821,9 @@ class ColorTypeTest(unittest.TestCase):
         self.assertEqual(expected_i1i2i3, i1i2i3)
         self.assertEqual(expected_i1i2i3, i1i2i3_tuple)
 
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(
-                expected_i1i2i3, pygame.Color.from_i1i2i3(0, 0, 0, "lel", "foo")
-            )
-
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(expected_i1i2i3, pygame.Color.from_i1i2i3((0, 0, 0, 0)))
+        with self.assertRaises(ValueError):
+            pygame.Color.from_i1i2i3(0, 0, 0, "lel", "foo")
+            pygame.Color.from_i1i2i3((0, 0, 0, 0))
 
     def test_from_normalized(self):
         normal = pygame.Color.from_normalized(1, 1, 1, 1)
@@ -854,16 +834,9 @@ class ColorTypeTest(unittest.TestCase):
         self.assertEqual(expected_normal, normal)
         self.assertEqual(expected_normal, normal_tuple)
 
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(
-                expected_normal, pygame.Color.from_normalized(1, 1, 1, 1, "lel")
-            )
-
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(
-                expected_normal,
-                pygame.Color.from_normalized((1, 1, 1, 1, "lel", "foo")),
-            )
+        self.assertRaises(
+            ValueError, lambda: pygame.Color.from_normalized(1, 1, 1, 1, "lel")
+        )
 
     def test_normalize(self):
         c = pygame.Color(204, 38, 194, 55)
@@ -1062,8 +1035,10 @@ class ColorTypeTest(unittest.TestCase):
     def test_colorspaces_deprecated_large_sequence(self):
         c = pygame.Color("black")
         for space in ("hsla", "hsva", "i1i2i3", "cmy", "normalized"):
-            with self.assertWarns(DeprecationWarning):
-                setattr(c, space, (0, 0, 0, 0, "hehe 5th ignored member"))
+            with self.assertRaises(ValueError):
+                setattr(
+                    c, space, (0, 0, 0, 0, "HAHAHAHAHAHA, don't ignore 5th member :)")
+                )
 
     ################################################################################
 

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -782,9 +782,12 @@ class ColorTypeTest(unittest.TestCase):
         self.assertEqual(expected_cmy, cmy)
         self.assertEqual(expected_cmy, cmy_tuple)
 
-        with self.assertRaises(ValueError):
-            pygame.Color.from_cmy(0.5, 0.5, 0.5, "lel", "foo")
-            pygame.Color.from_cmy((0.5, 0.5, 0.5, 0.5))
+        self.assertRaises(
+            ValueError, lambda: pygame.Color.from_cmy(0.5, 0.5, 0.5, "lel", "foo")
+        )
+        self.assertRaises(
+            ValueError, lambda: pygame.Color.from_cmy((0.5, 0.5, 0.5, 0.5))
+        )
 
     def test_from_hsva(self):
         hsva = pygame.Color.from_hsva(0, 100, 100, 100)
@@ -795,9 +798,12 @@ class ColorTypeTest(unittest.TestCase):
         self.assertEqual(expected_hsva, hsva)
         self.assertEqual(expected_hsva, hsva_tuple)
 
-        with self.assertRaises(ValueError):
-            pygame.Color.from_hsva(0, 100, 100, 100, "lel", "foo")
-            pygame.Color.from_hsva((0, 100, 100, 100, "lel"))
+        self.assertRaises(
+            ValueError, lambda: pygame.Color.from_hsva(0, 100, 100, 100, "lel", "foo")
+        )
+        self.assertRaises(
+            ValueError, lambda: pygame.Color.from_hsva((0, 100, 100, 100, "lel"))
+        )
 
     def test_from_hsla(self):
         hsla = pygame.Color.from_hsla(0, 100, 100, 100)
@@ -808,9 +814,12 @@ class ColorTypeTest(unittest.TestCase):
         self.assertEqual(expected_hsla, hsla)
         self.assertEqual(expected_hsla, hsla_tuple)
 
-        with self.assertRaises(ValueError):
-            pygame.Color.from_hsla(0, 100, 100, 100, "lel")
-            pygame.Color.from_hsla((0, 100, 100, 100, "lel", "foo"))
+        self.assertRaises(
+            ValueError, lambda: pygame.Color.from_hsla(0, 100, 100, 100, "lel")
+        )
+        self.assertRaises(
+            ValueError, lambda: pygame.Color.from_hsla((0, 100, 100, 100, "lel", "foo"))
+        )
 
     def test_from_i1i2i3(self):
         i1i2i3 = pygame.Color.from_i1i2i3(0, 0, 0)


### PR DESCRIPTION
Final step of @ankith26 's tasks in #2386 .
A year after ankith deprecated the use of this implementation, we can finally set an error for these.

Closes #2386