### PR TITLE
wasm: controller is not multiphase init + workaround for wasm 313t

### DIFF
--- a/src_c/_sdl2/controller.c
+++ b/src_c/_sdl2/controller.c
@@ -544,6 +544,15 @@ static PyTypeObject pgController_Type = {
     .tp_members = controller_members,
 };
 
+/* TODO: multiphase init
+#if PY_VERSION_HEX >= 0x030D0000
+static struct PyModuleDef_Slot mod_controller_slots[] = {
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+    {0, NULL}
+};
+#endif
+*/
+
 MODINIT_DEFINE(controller)
 {
     PyObject *module;
@@ -553,7 +562,13 @@ MODINIT_DEFINE(controller)
         .m_name = "controller",
         .m_doc = DOC_SDL2_CONTROLLER,
         .m_size = -1,
-        .m_methods = _controller_module_methods};
+        .m_methods = _controller_module_methods,
+/*
+#if PY_VERSION_HEX >= 0x030D0000
+        .m_slots = mod_controller_slots,
+#endif
+*/
+    };
 
     import_pygame_base();
     if (PyErr_Occurred()) {
@@ -566,7 +581,11 @@ MODINIT_DEFINE(controller)
     }
 
     module = PyModule_Create(&_module);
-
+#if Py_GIL_DISABLED
+#if (defined(__EMSCRIPTEN__) || defined(__wasi__))
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+#endif
     if (!module) {
         return NULL;
     }

--- a/src_c/static.c
+++ b/src_c/static.c
@@ -1,5 +1,7 @@
 #define NO_PYGAME_C_API
 
+#define CONTROLLER_NOPYX
+
 #define PYGAMEAPI_RECT_INTERNAL
 #define PYGAMEAPI_EVENT_INTERNAL
 #define PYGAMEAPI_JOYSTICK_INTERNAL
@@ -150,11 +152,13 @@ PyInit_mixer(void);
 PyMODINIT_FUNC
 PyInit_system(void);
 
+#if defined(CONTROLLER_NOPYX)
 PyMODINIT_FUNC
 PyInit_controller(void);
-
+#else
 PyMODINIT_FUNC
 PyInit_controller_old(void);
+#endif
 
 PyMODINIT_FUNC
 PyInit_transform(void);
@@ -216,36 +220,30 @@ load_submodule_mphase(const char *parent, PyObject *mdef, PyObject *spec,
 {
     char fqn[1024];
     snprintf(fqn, sizeof(fqn), "%s.%s", parent, alias);
-
     PyObject *modules = PyImport_GetModuleDict();
 
     Py_DECREF(PyObject_GetAttrString(spec, "name"));
-
     PyObject_SetAttrString(spec, "name", PyUnicode_FromString(alias));
-
     PyObject *pmod = PyDict_GetItemString(modules, parent);
-
     PyObject *mod = PyModule_FromDefAndSpec((PyModuleDef *)mdef, spec);
-
     PyDict_SetItemString(PyModule_GetDict(mod), "__package__",
                          PyUnicode_FromString(parent));
-
     // TODO SET PACKAGE
-
     PyModule_ExecDef(mod, (PyModuleDef *)mdef);
 
-    if (!pmod) {
-        snprintf(fqn, sizeof(fqn), "ERROR: %s.%s", parent, alias);
-        puts(fqn);
-        PyErr_Print();
-        PyErr_Clear();
-    }
-    else {
+    if (pmod) {
         PyDict_SetItemString(modules, fqn, mod);
         PyDict_SetItemString(PyModule_GetDict(mod), "__name__",
                              PyUnicode_FromString(fqn));
         PyModule_AddObjectRef(pmod, alias, mod);
         Py_XDECREF(mod);
+    }
+    if (!pmod || PyErr_Occurred()) {
+        snprintf(fqn, sizeof(fqn), "Error after init in : %s.%s\n", parent,
+                 alias);
+        fputs(fqn, stderr);
+        PyErr_Print();
+        PyErr_Clear();
     }
 }
 
@@ -254,10 +252,12 @@ mod_pygame_import_cython(PyObject *self, PyObject *spec)
 {
     load_submodule_mphase("pygame._sdl2", PyInit_sdl2(), spec, "sdl2");
     load_submodule_mphase("pygame._sdl2", PyInit_mixer(), spec, "mixer");
+#if defined(CONTROLLER_NOPYX)
+    load_submodule("pygame._sdl2", PyInit_controller(), "controller");
+#else
     load_submodule_mphase("pygame._sdl2", PyInit_controller_old(), spec,
                           "controller_old");
-    load_submodule_mphase("pygame._sdl2", PyInit_controller(), spec,
-                          "controller");
+#endif
     load_submodule_mphase("pygame._sdl2", PyInit_audio(), spec, "audio");
     load_submodule_mphase("pygame._sdl2", PyInit_video(), spec, "video");
 


### PR DESCRIPTION
also only controller.c is needed, the cython based controller_old is redundant here. Still fence possible use of cython code for future cpython versions.