### PR TITLE
Fix handling all color types in `pygame.transform.threshold`

### DIFF
--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1830,7 +1830,7 @@ _color_from_obj(PyObject *color_obj, SDL_PixelFormat *format,
 {
     if (color_obj) {
         if (!pg_MappedColorFromObj(color_obj, format, color,
-                                   PG_COLOR_HANDLE_INT)) {
+                                   PG_COLOR_HANDLE_ALL)) {
             return -1;
         }
     }

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1147,6 +1147,13 @@ class TransformModuleTest(unittest.TestCase):
         self.assertEqual(dest_surface.get_size(), expected_size)
         self.assertEqual(dest_surface.get_flags(), expected_flags)
 
+    def test_threshold_all_color_types(self):
+        s1 = pygame.Surface((32, 32), SRCALPHA, 32)
+        s2 = pygame.Surface((32, 32), SRCALPHA, 32)
+
+        for color in [(0, 255, 0), (255, 0, 0, 0), 0, "blue", pygame.Color("#FFFFFF")]:
+            pygame.transform.threshold(s1, s2, color, set_behavior=1)
+
     def test_laplacian(self):
         """ """
 

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1152,7 +1152,7 @@ class TransformModuleTest(unittest.TestCase):
         s2 = pygame.Surface((32, 32), SRCALPHA, 32)
 
         for color in [(0, 255, 0), (255, 0, 0, 0), 0, "blue", pygame.Color("#FFFFFF")]:
-            pygame.transform.threshold(s1, s2, color, set_behavior=1)
+            pygame.transform.threshold(s1, s2, color, color, color)
 
     def test_laplacian(self):
         """ """


### PR DESCRIPTION
The c internal function `_color_from_obj` only allows mapped colors for some reason, but all color arguments in the stubs for `pygame.transform.threshold` pretend to allow `ColorLike` which also allows strings. My modification makes sure all the promised color types are allowed and add a test to make sure it doesn't break in the future.

`pygame.transform.threshold` should be the only function using the internal c function because all new api coming for transform is going to use the pygame C api function by default.