### PR TITLE
Add ability to normalize a Vector of length zero

### DIFF
--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -237,6 +237,11 @@ Multiple coordinates can be set using slices or swizzling
       Returns a new vector that has ``length`` equal to ``1`` and the same
       direction as self.
 
+      .. versionchanged:: 2.5.2 It is now possible to use ``normalize`` on a zero-vector.
+
+      .. note::
+         Before pygame-ce 2.5.2, attempting to normalize a zero vector would always raise a ``ValueError``
+
       .. ## Vector2.normalize ##
 
    .. method:: normalize_ip
@@ -246,6 +251,11 @@ Multiple coordinates can be set using slices or swizzling
 
       Normalizes the vector so that it has ``length`` equal to ``1``.
       The direction of the vector is not changed.
+
+      .. versionchanged:: 2.5.2 It is now possible to use ``normalize_ip`` on a zero-vector.
+
+      .. note::
+         Before pygame-ce 2.5.2, attempting to normalize a zero vector would always raise a ``ValueError``
 
       .. ## Vector2.normalize_ip ##
 

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -1368,8 +1368,7 @@ vector_normalize_ip(pgVector *self, PyObject *_null)
     length = sqrt(_scalar_product(self->coords, self->coords, self->dim));
 
     if (length == 0) {
-        return RAISE(PyExc_ValueError,
-                     "Can't normalize Vector of length zero");
+        Py_RETURN_NONE;
     }
 
     for (i = 0; i < self->dim; ++i)

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -742,7 +742,8 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertEqual(self.v1.y, self.l1[1])
         # v2 is parallel to v1
         self.assertAlmostEqual(self.v1.x * v.y - self.v1.y * v.x, 0.0)
-        self.assertRaises(ValueError, lambda: self.zeroVec.normalize())
+        # 0 vector
+        self.assertEqual(self.zeroVec.normalize(), Vector2())
 
     def test_normalize_ip(self):
         v = +self.v1
@@ -750,11 +751,11 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertNotEqual(v.x * v.x + v.y * v.y, 1.0)
         # inplace operations should return None
         self.assertEqual(v.normalize_ip(), None)
+        self.assertEqual(self.zeroVec.normalize_ip(), None)
         # length is 1
         self.assertAlmostEqual(v.x * v.x + v.y * v.y, 1.0)
         # v2 is parallel to v1
         self.assertAlmostEqual(self.v1.x * v.y - self.v1.y * v.x, 0.0)
-        self.assertRaises(ValueError, lambda: self.zeroVec.normalize_ip())
 
     def test_is_normalized(self):
         self.assertEqual(self.v1.is_normalized(), False)


### PR DESCRIPTION
In issue #2269, it's been decided that pygame-ce should follow game engines such as Unity and Godot in allowing users to normalize zero-vectors for convenience.

Update the function in `math_test.c`, tests in `math_test.py`, and documentation in `math.rst` accordingly.