### PR TITLE
Add warning when using negative dimensions in draw.ellipse

### DIFF
--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -276,8 +276,8 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
    :type color: Color or string (for :doc:`color_list`) or int or tuple(int, int, int, [int])
    :param Rect rect: rectangle to indicate the position and dimensions of the
       ellipse, the ellipse will be centered inside the rectangle and bounded
-      by it. Negative dimension and position values smaller than negated dimension are deprecated,
-      and will raise an exception in future versions on pygame-ce.
+      by it. Negative rect dimension values are deprecated, and will raise an exception
+      in a future versions on pygame-ce.
    :param int width: (optional) used for line thickness or to indicate that
       the ellipse is to be filled (not to be confused with the width value
       of the ``rect`` parameter)
@@ -297,7 +297,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
    :rtype: Rect
 
    .. versionchangedold:: 2.0.0 Added support for keyword arguments.
-   .. versionchanged:: 2.5.2 Negative values in rect will raise a deprecation warning
+   .. versionchanged:: 2.5.2 Negative rect dimension values will raise a deprecation warning
 
    .. ## pygame.draw.ellipse ##
 

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -276,7 +276,8 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
    :type color: Color or string (for :doc:`color_list`) or int or tuple(int, int, int, [int])
    :param Rect rect: rectangle to indicate the position and dimensions of the
       ellipse, the ellipse will be centered inside the rectangle and bounded
-      by it
+      by it. Negative dimension and position values smaller than negated dimension are deprecated,
+      and will raise an exception in future versions on pygame-ce.
    :param int width: (optional) used for line thickness or to indicate that
       the ellipse is to be filled (not to be confused with the width value
       of the ``rect`` parameter)
@@ -296,6 +297,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
    :rtype: Rect
 
    .. versionchangedold:: 2.0.0 Added support for keyword arguments.
+   .. versionchanged:: 2.5.2 Negative values in rect will raise a deprecation warning
 
    .. ## pygame.draw.ellipse ##
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -706,6 +706,17 @@ ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
                             PG_SURF_BytesPerPixel(surf));
     }
 
+    if (drawn_area[0] - drawn_area[2] < 0 || drawn_area[2] < 0 ||
+        drawn_area[1] - drawn_area[3] < 0 || drawn_area[3] < 0) {
+        if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "Negative values in position and dimension rect are "
+                         "deprecated and have no functionality. This will "
+                         "cause an error in a future version of pygame-ce.",
+                         1) == -1) {
+            return pgRect_New4(0, 0, 0, 0);
+        }
+    }
+
     CHECK_LOAD_COLOR(colorobj)
 
     if (width < 0) {

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -706,17 +706,6 @@ ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
                             PG_SURF_BytesPerPixel(surf));
     }
 
-    if (drawn_area[0] - drawn_area[2] < 0 || drawn_area[2] < 0 ||
-        drawn_area[1] - drawn_area[3] < 0 || drawn_area[3] < 0) {
-        if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                         "Negative values in position and dimension rect are "
-                         "deprecated and have no functionality. This will "
-                         "cause an error in a future version of pygame-ce.",
-                         1) == -1) {
-            return pgRect_New4(0, 0, 0, 0);
-        }
-    }
-
     CHECK_LOAD_COLOR(colorobj)
 
     if (width < 0) {
@@ -727,14 +716,25 @@ ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
         return RAISE(PyExc_RuntimeError, "error locking surface");
     }
 
-    if (!width ||
-        width >= MIN(rect->w / 2 + rect->w % 2, rect->h / 2 + rect->h % 2)) {
-        draw_ellipse_filled(surf, rect->x, rect->y, rect->w, rect->h, color,
-                            drawn_area);
+    if (rect->w < 0 || rect->h < 0) {
+        if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "Negative rect dimension values are deprecated and "
+                         "have no functionality. This will cause an error in "
+                         "a future version of pygame-ce.",
+                         1) == -1) {
+            return pgRect_New4(0, 0, 0, 0);
+        }
     }
     else {
-        draw_ellipse_thickness(surf, rect->x, rect->y, rect->w, rect->h,
-                               width - 1, color, drawn_area);
+        if (!width || width >= MIN(rect->w / 2 + rect->w % 2,
+                                   rect->h / 2 + rect->h % 2)) {
+            draw_ellipse_filled(surf, rect->x, rect->y, rect->w, rect->h,
+                                color, drawn_area);
+        }
+        else {
+            draw_ellipse_thickness(surf, rect->x, rect->y, rect->w, rect->h,
+                                   width - 1, color, drawn_area);
+        }
     }
 
     if (!pgSurface_Unlock(surfobj)) {

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -411,13 +411,7 @@ class DrawEllipseMixin:
     def test_ellipse__negative_rect_warning(self):
         """Ensures draw ellipse shows DeprecationWarning for rect with negative values"""
         # Generate few faulty rects.
-        faulty_rects = []
-        for i in range(4):
-            faulty_rect = [0, 0, 0, 0]
-            faulty_rect[i] = -15
-            if i < 2:
-                faulty_rect[i + 2] = -5
-            faulty_rects.append(faulty_rect)
+        faulty_rects = ((10, 10, -5, 3), (10, 10, 5, -3))
         with warnings.catch_warnings(record=True) as w:
             for count, rect in enumerate(faulty_rects):
                 # Cause all warnings to always be triggered.

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -408,6 +408,26 @@ class DrawEllipseMixin:
             self.assertEqual(surface.get_at(pos), expected_color)
             self.assertIsInstance(bounds_rect, pygame.Rect)
 
+    def test_ellipse__negative_rect_warning(self):
+        """Ensures draw ellipse shows DeprecationWarning for rect with negative values"""
+        # Generate few faulty rects.
+        faulty_rects = []
+        for i in range(4):
+            faulty_rect = [0, 0, 0, 0]
+            faulty_rect[i] = -15
+            if i < 2:
+                faulty_rect[i + 2] = -5
+            faulty_rects.append(faulty_rect)
+        with warnings.catch_warnings(record=True) as w:
+            for count, rect in enumerate(faulty_rects):
+                # Cause all warnings to always be triggered.
+                warnings.simplefilter("always")
+                # Trigger DeprecationWarning.
+                self.draw_ellipse(pygame.Surface((6, 6)), (255, 255, 255), rect)
+                # Check if there is only one warning and is a DeprecationWarning.
+                self.assertEqual(len(w), count + 1)
+                self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
     def test_ellipse__valid_rect_formats(self):
         """Ensures draw ellipse accepts different rect formats."""
         pos = (1, 1)


### PR DESCRIPTION
Using negative rect dimension values have some undesirable results as shown in #2727.
This PR adds deprecation warning to `draw.ellipse` when using negative value for rect width and height.
And prevents ellipse from being drawn at wrong position. Nothing is drawn instead.
Warning is also added to docs, and is tested for in tests.
<details>
  <summary>Sample code</summary>

  ```py
  import pygame
pygame.init()
screen = pygame.display.set_mode((300, 300))
clock = pygame.time.Clock()
run = True
while run:
    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            run = False
    screen.fill((0, 0, 0))
    pygame.draw.ellipse(screen, "white", (150, 150, -50, 30), 0)
    pygame.display.flip()
    clock.tick(60)
pygame.quit()
  ```
</details>