### PR TITLE
Publicize window docs

### DIFF
--- a/docs/reST/index.rst
+++ b/docs/reST/index.rst
@@ -62,9 +62,6 @@ turn them to stable API in the future ^^.
 :doc:`ref/geometry`
   Pygame module for the Circle, Line, and Polygon objects.
 
-:doc:`ref/window`
-  Pygame object that handles a window.
-
 :doc:`ref/sdl2_controller`
   Pygame module to work with controllers.
 
@@ -243,6 +240,9 @@ Reference
 
 :doc:`ref/typing`
   Provide common typehints
+
+:doc:`ref/window`
+  Pygame object that handles a window.
 
 :doc:`pygame C API <c_api>`
   The C api shared amongst pygame extension modules.

--- a/docs/reST/ref/window.rst
+++ b/docs/reST/ref/window.rst
@@ -10,10 +10,10 @@
    | :sl:`pygame object that represents a window`
    | :sg:`Window(title='pygame window', size=(640, 480), position=None, fullscreen=False, fullscreen_desktop=False, **kwargs) -> Window`
 
-   The Window class (formerly known as _sdl2.video.Window), is an experimental
-   feature of pygame-ce. This class allows for programs to drive multiple
-   Windows on-screen at once, something not possible with the
-   :func:`pygame.display.set_mode` API. Not everything possible with
+   The Window class (formerly known as _sdl2.video.Window), is a newly
+   published feature of pygame-ce 2.5.2. This class allows for programs
+   to drive multiple Windows on-screen at once, something not possible with
+   the :func:`pygame.display.set_mode` API. Not everything possible with
    :mod:`pygame.display` is possible yet in the Window API, but the new
    window class will continue to be developed, and we're excited to share
    the new functionality this class offers.

--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -41,7 +41,7 @@ We render three sets of items based on how useful to most apps.
 {%- set basic = ['Color', 'display', 'draw', 'event', 'font', 'image', 'key', 'locals', 'mixer', 'mouse', 'music', 'pygame', 'Rect', 'Surface', 'time'] %}
 {%- set experimental = ['sdl2_video', 'controller', 'geometry', 'Window'] %}
 {%- set advanced = ['BufferProxy', 'freetype', 'gfxdraw', 'midi', 'PixelArray', 'pixelcopy', 'sndarray', 'surfarray', 'cursors', 'joystick', 'mask', 'math', 'sprite', 'transform'] %}
-{%- set hidden = ['sdl2_video', 'geometry', 'Window'] %}
+{%- set hidden = ['sdl2_video', 'geometry'] %}
 {%-   if pyg_sections %}
 	  <p class="bottom"><b>Most useful stuff</b>:
 {%      set sep = joiner(" | \n") %}


### PR DESCRIPTION
This PR represents the transition of the Window API to the pygame-ce public API.

I left it in the "other" category in the top bar in the docs, as it's not quite experimental not quite advanced, hopefully it's useful! It can be recategorized later of course.

I also expect lots of API additions later, as we see how people use this and what stuff we've missed.

I would also like to get some more in depth examples on how to use this in before 2.5.2-final, but that doesn't block a dev release necessarily.

I know there's still debate about features of this, and I don't want to clobber that, but I feel that getting this functionality available to our users will be valuable. We don't want to let the perfect be the enemy of the good, and this module has been in the oven for a long time. There's still lots of room for iteration after it becomes a public API.