### PR TITLE
Include the explicit type in `ColorLike` and `RectLike`

### DIFF
--- a/buildconfig/stubs/pygame/typing.pyi
+++ b/buildconfig/stubs/pygame/typing.pyi
@@ -57,7 +57,7 @@ Point = SequenceLike[float]
 # This is used where ints are strictly required
 IntPoint = SequenceLike[int]
 
-ColorLike = Union[Color, int, str, SequenceLike[int]]
+ColorLike = Union[Color, SequenceLike[int], str, int]
 
 
 class _HasRectAttribute(Protocol):

--- a/buildconfig/stubs/pygame/typing.pyi
+++ b/buildconfig/stubs/pygame/typing.pyi
@@ -16,6 +16,10 @@ import sys
 from abc import abstractmethod
 from typing import IO, Callable, Tuple, Union, TypeVar, Protocol
 
+from pygame.color import Color
+from pygame.rect import Rect, FRect
+
+
 if sys.version_info >= (3, 9):
     from os import PathLike as _PathProtocol
 else:
@@ -53,7 +57,7 @@ Point = SequenceLike[float]
 # This is used where ints are strictly required
 IntPoint = SequenceLike[int]
 
-ColorLike = Union[int, str, SequenceLike[int]]
+ColorLike = Union[Color, int, str, SequenceLike[int]]
 
 
 class _HasRectAttribute(Protocol):
@@ -63,8 +67,22 @@ class _HasRectAttribute(Protocol):
     def rect(self) -> Union["RectLike", Callable[[], "RectLike"]]: ...
 
 
-RectLike = Union[SequenceLike[float], SequenceLike[Point], _HasRectAttribute]
+RectLike = Union[
+    Rect, FRect, SequenceLike[float], SequenceLike[Point], _HasRectAttribute
+]
 
 
 # cleanup namespace
-del sys, abstractmethod, IO, Callable, Tuple, Union, TypeVar, Protocol
+del (
+    sys,
+    abstractmethod,
+    Color,
+    Rect,
+    FRect,
+    IO,
+    Callable,
+    Tuple,
+    Union,
+    TypeVar,
+    Protocol,
+)

--- a/src_py/typing.py
+++ b/src_py/typing.py
@@ -57,7 +57,7 @@ Point = SequenceLike[float]
 # This is used where ints are strictly required
 IntPoint = SequenceLike[int]
 
-ColorLike = Union[Color, int, str, SequenceLike[int]]
+ColorLike = Union[Color, SequenceLike[int], str, int]
 
 
 class _HasRectAttribute(Protocol):

--- a/src_py/typing.py
+++ b/src_py/typing.py
@@ -16,6 +16,10 @@ import sys
 from abc import abstractmethod
 from typing import IO, Callable, Tuple, Union, TypeVar, Protocol
 
+from pygame.color import Color
+from pygame.rect import Rect, FRect
+
+
 if sys.version_info >= (3, 9):
     from os import PathLike as _PathProtocol
 else:
@@ -53,7 +57,7 @@ Point = SequenceLike[float]
 # This is used where ints are strictly required
 IntPoint = SequenceLike[int]
 
-ColorLike = Union[int, str, SequenceLike[int]]
+ColorLike = Union[Color, int, str, SequenceLike[int]]
 
 
 class _HasRectAttribute(Protocol):
@@ -63,8 +67,22 @@ class _HasRectAttribute(Protocol):
     def rect(self) -> Union["RectLike", Callable[[], "RectLike"]]: ...
 
 
-RectLike = Union[SequenceLike[float], SequenceLike[Point], _HasRectAttribute]
+RectLike = Union[
+    Rect, FRect, SequenceLike[float], SequenceLike[Point], _HasRectAttribute
+]
 
 
 # cleanup namespace
-del sys, abstractmethod, IO, Callable, Tuple, Union, TypeVar, Protocol
+del (
+    sys,
+    abstractmethod,
+    Color,
+    Rect,
+    FRect,
+    IO,
+    Callable,
+    Tuple,
+    Union,
+    TypeVar,
+    Protocol,
+)


### PR DESCRIPTION

Add the concrete classes to the `ColorLike` and `RectLike` type unions.
They are already implied by the other types, but should be added for clarity.

Since they are only type aliases to unions, their variable name is not always given, so what they represent might not be entirely obvious to users.

Bonus: Sort types in `ColorLike` by how often they are used.

Example mypy error message, before:
```
$ mypy test.py
test.py:38: error: Incompatible types in assignment (expression has type "float", variable has type "int | str | SequenceLike[int]")  [assignment]
test.py:39: error: Incompatible types in assignment (expression has type "int", variable has type "SequenceLike[float] | SequenceLike[SequenceLike[float]] | _HasRectAttribute")  [assignment]
```
After (much more clear!):
```
$ mypy test.py
test.py:38: error: Incompatible types in assignment (expression has type "float", variable has type "Color | SequenceLike[int] | str | int")  [assignment]
test.py:39: error: Incompatible types in assignment (expression has type "int", variable has type "Rect | FRect | SequenceLike[float] | SequenceLike[SequenceLike[float]] | _HasRectAttribute")  [assignment]
```
Note:
`typing.py` now imports things from pygame. I don't think there is any risk of circular imports though.

Note 2:
The `_<Shape>Like` type unions in `geometry.pyi` include their concrete classes already.