### PR TITLE
Ignore new gcc version mask array bounds warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -399,6 +399,7 @@ else
             '-Wno-error=unused-but-set-variable',
             '-Wno-error=array-bounds',
         ]
+        warnings_temp_mask += '-Wno-error=array-bounds'
     endif
 
     if cc.sizeof('long') != 8


### PR DESCRIPTION
Compiler: `gcc version 14.2.0 (Ubuntu 14.2.0-4ubuntu2)`

A new warning popped up in `mask.c`. Seems like a bit of a false positive, but the code is doing weird stuff anyways, so taking the easiest way out by silencing that warning on `mask.c`