### PR TITLE
Do regular install where possible on CI

### DIFF
--- a/.github/workflows/build-debian-multiarch.yml
+++ b/.github/workflows/build-debian-multiarch.yml
@@ -40,11 +40,10 @@ env:
   INSTALL_CMD: |
     apt-get update --fix-missing
     apt-get upgrade -y
-    apt-get install build-essential meson cython3 -y
+    apt-get install build-essential -y
     apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev -y
     apt-get install libfreetype6-dev libportmidi-dev fontconfig -y
-    apt-get install python3-dev python3-pip python3-wheel python3-sphinx -y
-    pip3 install meson-python --break-system-packages
+    apt-get install python3-dev python3-pip python3-wheel -y
 
 jobs:
   build-multiarch:
@@ -96,11 +95,9 @@ jobs:
         install: ${{ env.INSTALL_CMD }}
 
         # Build a wheel, install it for running unit tests.
-        # --no-build-isolation is passed so that preinstalled meson-python can be used
-        # (done for optimization reasons)
         run: |
           echo "\nBuilding pygame wheel\n"
-          pip3 wheel . --no-build-isolation --wheel-dir /artifacts -vvv
+          pip3 wheel . --wheel-dir /artifacts -vvv
           echo "\nInstalling wheel\n"
           pip3 install --no-index --pre --break-system-packages --find-links /artifacts pygame-ce
           echo "\nRunning tests\n"

--- a/.github/workflows/build-on-msys2.yml
+++ b/.github/workflows/build-on-msys2.yml
@@ -58,9 +58,6 @@ jobs:
             mingw-w64-${{ matrix.env }}-pkg-config
             mingw-w64-${{ matrix.env }}-python
             mingw-w64-${{ matrix.env }}-python-pip
-            mingw-w64-${{ matrix.env }}-python-sphinx
-            mingw-w64-${{ matrix.env }}-meson-python
-            mingw-w64-${{ matrix.env }}-cython
 
           # mingw-w64-${{ matrix.env }}-SDL2
           # mingw-w64-${{ matrix.env }}-SDL2_image
@@ -71,7 +68,7 @@ jobs:
 
       - name: Building pygame wheel
         run: |
-          pip3 wheel . --wheel-dir /artifacts -vvv --no-build-isolation
+          pip3 wheel . --wheel-dir /artifacts -vvv
 
       - name: Installing wheel
         run: pip3 install --no-index --pre --find-links /artifacts pygame-ce


### PR DESCRIPTION
Earlier we were doing `--no-build-isolation` in some places where a regular install would work, for CI time optimisation reasons. But those were probably premature optimisations, and doing things the "regular way" has the advantages of not having to update the CI script for changes in build dependencies