### PR TITLE
Fix latest SDL3 and MSYS2 fails

### DIFF
--- a/.github/workflows/build-on-msys2.yml
+++ b/.github/workflows/build-on-msys2.yml
@@ -42,7 +42,6 @@ jobs:
       matrix:
         include:
           - { sys: mingw64, env: x86_64 }
-          - { sys: mingw32, env: i686 }
           - { sys: ucrt64,  env: ucrt-x86_64 }
           - { sys: clang64, env: clang-x86_64 }
           # - { sys: clangarm64, env: clang-aarch64 }

--- a/.github/workflows/build-sdl3.yml
+++ b/.github/workflows/build-sdl3.yml
@@ -54,13 +54,23 @@ jobs:
     steps:
     - uses: actions/checkout@v4.2.1
 
-    - name: Install deps (linux)
+    - name: Install pygame deps (linux)
       if: matrix.os == 'ubuntu-24.04'
       run: sudo apt-get install libfreetype6-dev libportmidi-dev python3-dev
 
-    - name: Install deps (mac)
+    - name: Install pygame deps (mac)
       if: matrix.os == 'macos-14'
       run: brew install freetype portmidi
+
+    # taken from dependencies of the 'libsdl2-dev' package
+    - name: Install SDL deps (linux)
+      if: matrix.os == 'ubuntu-24.04'
+      run: >
+        sudo apt-get install libasound2-dev libdbus-1-dev libdecor-0-dev libdrm-dev
+        libegl-dev libgbm-dev libgl-dev libgles-dev libibus-1.0-dev libpulse-dev
+        libsamplerate0-dev libsndio-dev libudev-dev libwayland-dev libx11-dev
+        libxcursor-dev libxext-dev libxfixes-dev libxi-dev libxinerama-dev
+        libxkbcommon-dev libxrandr-dev libxss-dev libxt-dev libxv-dev libxxf86vm-dev
 
     # taken from https://wiki.libsdl.org/SDL3/Installation
     - name: Install SDL3
@@ -74,7 +84,7 @@ jobs:
         cmake --build . --config Release --parallel
         sudo cmake --install . --config Release
 
-    - name: Make sdist and install it
+    - name: Build with SDL3
       run: >
         python3 -m pip install . -v -Csetup-args=-Dsdl_api=3
         -Csetup-args=-Dimage=disabled


### PR DESCRIPTION
These are actually two independent issues that somehow popped up at the exact same time, hence the common PR fixing both as the fixes are trivial.

- Added a command installing SDL3 dependencies on our SDL3 build
- mingw32 support is being gradually dropped (ref: https://github.com/msys2/MINGW-packages/issues/22327) and therefore our build has failed here. I simply removed the mingw32 run.