### PR TITLE
Fix window docs

### DIFF
--- a/docs/reST/ref/window.rst
+++ b/docs/reST/ref/window.rst
@@ -59,10 +59,10 @@
              pygame.quit()
              raise SystemExit
 
-   Event behavior if multiple ``Window``s are created: When the close button is
+   Event behavior if multiple ``Window``\ s are created: When the close button is
    pressed, a ``WINDOWCLOSE`` event is sent. You need to explicitly destroy
-   the window. Note that the event ``QUIT`` will only be sent if all ``Window``s
-   have been destroyed.
+   the window. Note that the event ``QUIT`` will only be sent if all
+   ``Window``\ s have been destroyed.
 
    .. code-block:: python
 


### PR DESCRIPTION
After https://github.com/pygame-community/pygame-ce/pull/3194 it looks like 
![image](https://github.com/user-attachments/assets/e81345d9-7d47-4229-aeb2-b35016a9d8b2)

This fixes that. Had to read the docs on the docs system to figure out how to end a inline markup without a space.