### PR TITLE
Port joystick to SDL3

### DIFF
--- a/src_c/joystick.c
+++ b/src_c/joystick.c
@@ -112,7 +112,17 @@ static PyObject *
 get_count(PyObject *self, PyObject *_null)
 {
     JOYSTICK_INIT_CHECK();
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    int ret;
+    SDL_JoystickID *joysticks = SDL_GetJoysticks(&ret);
+    if (!joysticks) {
+        return RAISE(pgExc_SDLError, SDL_GetError());
+    }
+    SDL_free(joysticks);
+    return PyLong_FromLong(ret);
+#else
     return PyLong_FromLong(SDL_NumJoysticks());
+#endif
 }
 
 static PyObject *
@@ -200,18 +210,53 @@ joy_get_guid(PyObject *self, PyObject *_null)
         guid = SDL_JoystickGetGUID(joy);
     }
     else {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+        return RAISE(pgExc_SDLError, "Invalid/closed joystick object");
+#else
         guid = SDL_JoystickGetDeviceGUID(pgJoystick_AsID(self));
+#endif
     }
 
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    SDL_GUIDToString(guid, strguid, 33);
+#else
     SDL_JoystickGetGUIDString(guid, strguid, 33);
+#endif
 
     return PyUnicode_FromString(strguid);
 }
 
 const char *
-_pg_powerlevel_string(SDL_JoystickPowerLevel level)
+_pg_powerlevel_string(SDL_Joystick *joy)
 {
-    switch (level) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    int percent = -1;
+    SDL_PowerState state = SDL_GetJoystickPowerInfo(joy, &percent);
+    if (state == SDL_POWERSTATE_ON_BATTERY) {
+        /* These percentages are based on SDL_JoystickCurrentPowerLevel defined
+         * in sdl2-compat */
+        if (percent > 70) {
+            return "full";
+        }
+        else if (percent > 20) {
+            return "medium";
+        }
+        else if (percent > 5) {
+            return "low";
+        }
+        else {
+            return "empty";
+        }
+    }
+    else if (state == SDL_POWERSTATE_UNKNOWN ||
+             state == SDL_POWERSTATE_ERROR) {
+        return "unknown";
+    }
+    else {
+        return "wired";
+    }
+#else
+    switch (SDL_JoystickCurrentPowerLevel(joy)) {
         case SDL_JOYSTICK_POWER_EMPTY:
             return "empty";
         case SDL_JOYSTICK_POWER_LOW:
@@ -227,12 +272,12 @@ _pg_powerlevel_string(SDL_JoystickPowerLevel level)
         default:
             return "unknown";
     }
+#endif
 }
 
 static PyObject *
 joy_get_power_level(PyObject *self, PyObject *_null)
 {
-    SDL_JoystickPowerLevel level;
     const char *leveltext;
     SDL_Joystick *joy = pgJoystick_AsSDL(self);
 
@@ -241,8 +286,7 @@ joy_get_power_level(PyObject *self, PyObject *_null)
         return RAISE(pgExc_SDLError, "Joystick not initialized");
     }
 
-    level = SDL_JoystickCurrentPowerLevel(joy);
-    leveltext = _pg_powerlevel_string(level);
+    leveltext = _pg_powerlevel_string(joy);
 
     return PyUnicode_FromString(leveltext);
 }
@@ -287,7 +331,11 @@ joy_rumble(pgJoystickObject *self, PyObject *args, PyObject *kwargs)
     low = (Uint32)(lowf * 0xFFFF);
     high = (Uint32)(highf * 0xFFFF);
 
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    if (!SDL_JoystickRumble(joy, low, high, duration)) {
+#else
     if (SDL_JoystickRumble(joy, low, high, duration) == -1) {
+#endif
         Py_RETURN_FALSE;
     }
     Py_RETURN_TRUE;
@@ -545,9 +593,13 @@ pgJoystick_New(int id)
     JOYSTICK_INIT_CHECK();
 
     /* Open the SDL device */
+#if !SDL_VERSION_ATLEAST(3, 0, 0)
+    /* This check should be redundant because SDL_JoystickOpen already checks
+     * and errors if id is out of bounds on SDL3 */
     if (id >= SDL_NumJoysticks()) {
         return RAISE(pgExc_SDLError, "Invalid joystick device number");
     }
+#endif
     joy = SDL_JoystickOpen(id);
     if (!joy) {
         return RAISE(pgExc_SDLError, SDL_GetError());

--- a/src_c/meson.build
+++ b/src_c/meson.build
@@ -152,8 +152,6 @@ time = py.extension_module(
     subdir: pg,
 )
 
-# TODO: support SDL3
-if sdl_api != 3
 joystick = py.extension_module(
     'joystick',
     'joystick.c',
@@ -162,7 +160,6 @@ joystick = py.extension_module(
     install: true,
     subdir: pg,
 )
-endif
 
 draw = py.extension_module(
     'draw',


### PR DESCRIPTION
This PR ports joystick ~~and scrap~~ to SDL3.

~~Porting scrap turned out to be surprisingly trivial, but it makes sense given that we are using like 3 functions of the SDL API, and the rest are custom implementations.~~ UPDATE: that has been moved to a separate PR now.
EDIT: There was some windows specific code that I initially missed when I made this comment, but that should hopefully be ported now as well.
