### PR TITLE
Bump build dependencies and use `dev.py` on msys2/multiarch CI

### DIFF
--- a/.github/workflows/build-debian-multiarch.yml
+++ b/.github/workflows/build-debian-multiarch.yml
@@ -96,13 +96,11 @@ jobs:
         install: ${{ env.INSTALL_CMD }}
 
         # Build a wheel, install it for running unit tests.
-        # --no-build-isolation is passed so that preinstalled meson-python can be used
-        # (done for optimization reasons)
+        # pip does not know that ninja is installed, and tries to install it again.
+        # so pass --ignore-dep ninja explicitly
         run: |
-          echo "\nBuilding pygame wheel\n"
-          pip3 wheel . --no-build-isolation --wheel-dir /artifacts -vvv
-          echo "\nInstalling wheel\n"
-          pip3 install --no-index --pre --break-system-packages --find-links /artifacts pygame-ce
+          echo "\nBuilding and installing pygame wheel\n"
+          PIP_BREAK_SYSTEM_PACKAGES=1 python3 dev.py --ignore-dep ninja build --wheel /artifacts --lax
           echo "\nRunning tests\n"
           export SDL_VIDEODRIVER=dummy
           export SDL_AUDIODRIVER=disk

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Install uv for speed
         uses: yezz123/setup-uv@v4
         with:
-          uv-version: "0.4.10"
+          uv-version: "0.5.4"
 
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.21.3

--- a/.github/workflows/build-on-msys2.yml
+++ b/.github/workflows/build-on-msys2.yml
@@ -68,12 +68,10 @@ jobs:
           # mingw-w64-${{ matrix.env }}-freetype
           # mingw-w64-${{ matrix.env }}-portmidi
 
-      - name: Building pygame wheel
-        run: |
-          pip3 wheel . --wheel-dir /artifacts -vvv --no-build-isolation
-
-      - name: Installing wheel
-        run: pip3 install --no-index --pre --find-links /artifacts pygame-ce
+      # pip does not know that ninja is installed, and tries to install it again.
+      # so pass --ignore-dep ninja explicitly
+      - name: Build and install pygame wheel
+        run: python3 dev.py --ignore-dep ninja build --wheel /artifacts --lax
 
       - name: Run tests
         env:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install uv for speed
         uses: yezz123/setup-uv@v4
         with:
-          uv-version: "0.4.10"
+          uv-version: "0.5.4"
 
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.21.3

--- a/dev.py
+++ b/dev.py
@@ -196,9 +196,9 @@ class Dev:
             "build": get_build_deps(),
             "docs": get_build_deps(),
             "test": {"numpy"},
-            "lint": {"pylint==3.3.0", "numpy"},
-            "stubs": {"mypy==1.11.2", "numpy"},
-            "format": {"pre-commit==3.8.0"},
+            "lint": {"pylint==3.3.1", "numpy"},
+            "stubs": {"mypy==1.13.0", "numpy"},
+            "format": {"pre-commit==4.0.1"},
         }
         self.deps["all"] = set()
         for k in self.deps.values():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,11 @@ pygame_ce = 'pygame.__briefcase.pygame_ce:PygameCEGuiBootstrap'
 
 [build-system]
 requires = [
-  "meson-python<=0.16.0",
-  "meson<=1.5.1",
-  "ninja<=1.11.1.1",
+  "meson-python<=0.17.1",
+  "meson<=1.6.0",
+  "ninja<=1.12.1",
   "cython<=3.0.11",
-  "sphinx<=7.2.6",
+  "sphinx<=8.1.3",
 ]
 build-backend = 'mesonpy'
 


### PR DESCRIPTION
Separated out from https://github.com/pygame-community/pygame-ce/pull/3128 for independent review.

Most of the bumps are minor bumps, but there's also a major version bump for sphinx. From what I can tell nothing broke here, but more eyes on this would definitely be helpful.