### PR TITLE
Optimize pg_Two(Ints/Floats)FromObj

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -541,10 +541,25 @@ pg_TwoIntsFromObj(PyObject *obj, int *val1, int *val2)
     if (!PySequence_Check(obj) || PySequence_Length(obj) != 2) {
         return 0;
     }
-    if (!pg_IntFromObjIndex(obj, 0, val1) ||
-        !pg_IntFromObjIndex(obj, 1, val2)) {
+
+    PyObject *item1 = PySequence_ITEM(obj, 0);
+    PyObject *item2 = PySequence_ITEM(obj, 1);
+
+    if (item1 == NULL || item2 == NULL) {
+        Py_XDECREF(item1);
+        Py_XDECREF(item2);
+        PyErr_Clear();
         return 0;
     }
+
+    if (!pg_IntFromObj(item1, val1) || !pg_IntFromObj(item2, val2)) {
+        Py_DECREF(item1);
+        Py_DECREF(item2);
+        return 0;
+    }
+
+    Py_DECREF(item1);
+    Py_DECREF(item2);
     return 1;
 }
 
@@ -586,10 +601,25 @@ pg_TwoFloatsFromObj(PyObject *obj, float *val1, float *val2)
     if (!PySequence_Check(obj) || PySequence_Length(obj) != 2) {
         return 0;
     }
-    if (!pg_FloatFromObjIndex(obj, 0, val1) ||
-        !pg_FloatFromObjIndex(obj, 1, val2)) {
+
+    PyObject *item1 = PySequence_ITEM(obj, 0);
+    PyObject *item2 = PySequence_ITEM(obj, 1);
+
+    if (item1 == NULL || item2 == NULL) {
+        Py_XDECREF(item1);
+        Py_XDECREF(item2);
+        PyErr_Clear();
         return 0;
     }
+
+    if (!pg_FloatFromObj(item1, val1) || !pg_FloatFromObj(item2, val2)) {
+        Py_DECREF(item1);
+        Py_DECREF(item2);
+        return 0;
+    }
+
+    Py_DECREF(item1);
+    Py_DECREF(item2);
     return 1;
 }
 


### PR DESCRIPTION
pg_IntFromObjIndex doesn't take advantage of the fact that pg_TwoIntsFromObj already knows that obj is a sequence. Since obj is known to be a sequence, and negative indices are not needed, PySequence_ITEM can be used instead of PySequence_GetItem for better performance.
(+Same for pg_FloatFromObj and pg_FloatFromObjIndex)

Information on PySequence_ITEM: https://docs.python.org/3/c-api/sequence.html#c.PySequence_ITEM

```py
"""Rough testing script"""
import time

r = pygame.Rect(1,2,3,4)
fr = pygame.FRect(1,2,3,4)
start = time.time()
for _ in range(10000000):
    #r.inflate_ip((2,3))
    r.collidepoint((2,3))
    #fr.collidepoint((2,3))

print(time.time() - start)
```

In lightweight operations that use these functions for argument parsing I am able to get a single digit percent performance improvement. Hard to pin down an exact number, as it is hard to see the performance difference sometimes given noisy tests. But when averaging runs I see the average runtime is definitely lower with these changes.

This is a micro optimization, but I think it is a worthwhile thing to really scrutinize, as these functions are used all over the place. (Channeling my inner @itzpr3d4t0r on this PR)