### PR TITLE
Reduce errors in src_c/surface.c when compiling with SDL3

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -85,7 +85,7 @@
     SDL_GetPixelFormatDetails(PG_SurfaceFormatEnum(surf))
 #define PG_GetSurfacePalette SDL_GetSurfacePalette
 #define PG_SurfaceMapRGBA(surf, r, g, b, a) \
-    SDL_MapSurfaceRGBA(surface, r, g, b, a)
+    SDL_MapSurfaceRGBA(surf, r, g, b, a)
 #define PG_GetSurfaceClipRect(surf, rect) SDL_GetSurfaceClipRect(surf, rect)
 
 #define PG_SurfaceHasRLE SDL_SurfaceHasRLE
@@ -171,7 +171,7 @@ PG_FillRect(SDL_Surface *dst, const SDL_Rect *rect, Uint32 color)
 #define PG_GetSurfaceFormat(surf) (surf)->format
 #define PG_GetSurfacePalette(surf) (surf)->format->palette
 #define PG_SurfaceMapRGBA(surf, r, g, b, a) \
-    SDL_MapRGBA(PG_GetSurfaceFormat(surface), r, g, b, a)
+    SDL_MapRGBA(PG_GetSurfaceFormat(surf), r, g, b, a)
 #define PG_GetSurfaceClipRect(surf, rect) \
     {                                     \
         rect = &surf->clip_rect;          \

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -26,6 +26,8 @@
 #ifndef _PYGAME_INTERNAL_H
 #define _PYGAME_INTERNAL_H
 
+#include <stdbool.h>
+
 #include "pgplatform.h"
 /*
     If PY_SSIZE_T_CLEAN is defined before including Python.h, length is a
@@ -86,7 +88,7 @@
 #define PG_GetSurfacePalette SDL_GetSurfacePalette
 #define PG_SurfaceMapRGBA(surf, r, g, b, a) \
     SDL_MapSurfaceRGBA(surf, r, g, b, a)
-#define PG_GetSurfaceClipRect(surf, rect) SDL_GetSurfaceClipRect(surf, rect)
+#define PG_GetSurfaceClipRect SDL_GetSurfaceClipRect
 
 #define PG_SurfaceHasRLE SDL_SurfaceHasRLE
 
@@ -109,12 +111,7 @@ PG_UnlockMutex(SDL_mutex *mutex)
     return 0;
 }
 
-/* Emulating SDL2 SDL_FillRect API. In SDL3, it returns -1 on failure. */
-static inline int
-PG_FillRect(SDL_Surface *dst, const SDL_Rect *rect, Uint32 color)
-{
-    return SDL_FillSurfaceRect(dst, rect, color) ? 0 : -1;
-}
+#define PG_FillRect SDL_FillSurfaceRect
 
 #define PG_SURF_BitsPerPixel(surf) SDL_BITSPERPIXEL(surf->format)
 #define PG_SURF_BytesPerPixel(surf) SDL_BYTESPERPIXEL(surf->format)
@@ -192,10 +189,10 @@ PG_UnlockMutex(SDL_mutex *mutex)
     return SDL_UnlockMutex(mutex);
 }
 
-static inline int
+static inline bool
 PG_FillRect(SDL_Surface *dst, const SDL_Rect *rect, Uint32 color)
 {
-    return SDL_FillRect(dst, rect, color);
+    return SDL_FillRect(dst, rect, color) != -1;
 }
 
 #define PG_SURF_BitsPerPixel(surf) surf->format->BitsPerPixel

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -78,14 +78,15 @@
 #define PG_ConvertSurfaceFormat SDL_ConvertSurface
 
 #define PG_PixelFormatEnum SDL_PixelFormat
-#define PG_PixelFormat SDL_PixelFormatDetails
+#define PG_PixelFormat const SDL_PixelFormatDetails
+#define PG_PixelFormatMut SDL_PixelFormatDetails
 #define PG_SurfaceFormatEnum(surf) (surf)->format
 #define PG_GetSurfaceFormat(surf) \
     SDL_GetPixelFormatDetails(PG_SurfaceFormatEnum(surf))
 #define PG_GetSurfacePalette SDL_GetSurfacePalette
 #define PG_SurfaceMapRGBA(surf, r, g, b, a) \
     SDL_MapSurfaceRGBA(surface, r, g, b, a)
-#define PG_GetSurfaceClipRect(surf, rect) SDL_GetSurfaceClipRect(surf, &rect)
+#define PG_GetSurfaceClipRect(surf, rect) SDL_GetSurfaceClipRect(surf, rect)
 
 #define PG_SurfaceHasRLE SDL_SurfaceHasRLE
 
@@ -106,6 +107,13 @@ PG_UnlockMutex(SDL_mutex *mutex)
 {
     SDL_UnlockMutex(mutex);
     return 0;
+}
+
+/* Emulating SDL2 SDL_FillRect API. In SDL3, it returns -1 on failure. */
+static inline int
+PG_FillRect(SDL_Surface *dst, const SDL_Rect *rect, Uint32 color)
+{
+    return SDL_FillSurfaceRect(dst, rect, color) ? 0 : -1;
 }
 
 #define PG_SURF_BitsPerPixel(surf) SDL_BITSPERPIXEL(surf->format)
@@ -158,6 +166,7 @@ PG_UnlockMutex(SDL_mutex *mutex)
 
 #define PG_PixelFormatEnum SDL_PixelFormatEnum
 #define PG_PixelFormat SDL_PixelFormat
+#define PG_PixelFormatMut SDL_PixelFormat
 #define PG_SurfaceFormatEnum(surf) (surf)->format->format
 #define PG_GetSurfaceFormat(surf) (surf)->format
 #define PG_GetSurfacePalette(surf) (surf)->format->palette
@@ -165,7 +174,7 @@ PG_UnlockMutex(SDL_mutex *mutex)
     SDL_MapRGBA(PG_GetSurfaceFormat(surface), r, g, b, a)
 #define PG_GetSurfaceClipRect(surf, rect) \
     {                                     \
-        rect = surf->clip_rect;           \
+        rect = &surf->clip_rect;          \
     }
 
 #define PG_SoftStretchNearest(src, srcrect, dst, dstrect) \
@@ -181,6 +190,12 @@ static inline int
 PG_UnlockMutex(SDL_mutex *mutex)
 {
     return SDL_UnlockMutex(mutex);
+}
+
+static inline int
+PG_FillRect(SDL_Surface *dst, const SDL_Rect *rect, Uint32 color)
+{
+    return SDL_FillRect(dst, rect, color);
 }
 
 #define PG_SURF_BitsPerPixel(surf) surf->format->BitsPerPixel

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -78,6 +78,14 @@
 #define PG_ConvertSurfaceFormat SDL_ConvertSurface
 
 #define PG_PixelFormatEnum SDL_PixelFormat
+#define PG_PixelFormat SDL_PixelFormatDetails
+#define PG_SurfaceFormatEnum(surf) (surf)->format
+#define PG_GetSurfaceFormat(surf) \
+    SDL_GetPixelFormatDetails(PG_SurfaceFormatEnum(surf))
+#define PG_GetSurfacePalette SDL_GetSurfacePalette
+#define PG_SurfaceMapRGBA(surf, r, g, b, a) \
+    SDL_MapSurfaceRGBA(surface, r, g, b, a)
+#define PG_GetSurfaceClipRect(surf, rect) SDL_GetSurfaceClipRect(surf, &rect)
 
 #define PG_SurfaceHasRLE SDL_SurfaceHasRLE
 
@@ -149,6 +157,16 @@ PG_UnlockMutex(SDL_mutex *mutex)
     SDL_ConvertSurfaceFormat(src, pixel_format, 0)
 
 #define PG_PixelFormatEnum SDL_PixelFormatEnum
+#define PG_PixelFormat SDL_PixelFormat
+#define PG_SurfaceFormatEnum(surf) (surf)->format->format
+#define PG_GetSurfaceFormat(surf) (surf)->format
+#define PG_GetSurfacePalette(surf) (surf)->format->palette
+#define PG_SurfaceMapRGBA(surf, r, g, b, a) \
+    SDL_MapRGBA(PG_GetSurfaceFormat(surface), r, g, b, a)
+#define PG_GetSurfaceClipRect(surf, rect) \
+    {                                     \
+        rect = surf->clip_rect;           \
+    }
 
 #define PG_SoftStretchNearest(src, srcrect, dst, dstrect) \
     SDL_SoftStretch(src, srcrect, dst, dstrect)

--- a/src_c/surface.h
+++ b/src_c/surface.h
@@ -350,11 +350,21 @@
 #define PG_SurfaceGetRGB(colorkey, surf, r, g, b)   \
     SDL_GetRGB(colorkey, PG_GetSurfaceFormat(surf), \
                PG_GetSurfacePalette(surf), r, g, b)
-#else
+
+#define PG_GetRGBA SDL_GetRGBA
+
+#else /* ~SDL_VERSION_ATLEAST(3, 0, 0) */
 #define PG_SurfaceGetRGBA(colorkey, surf, r, g, b, a) \
     SDL_GetRGBA(colorkey, PG_GetSurfaceFormat(surf), r, g, b, a)
 #define PG_SurfaceGetRGB(colorkey, surf, r, g, b) \
     SDL_GetRGB(colorkey, PG_GetSurfaceFormat(surf), r, g, b)
+
+static inline void
+PG_GetRGBA(Uint32 pixel, const SDL_PixelFormat *format, SDL_Palette *palette,
+           Uint8 *r, Uint8 *g, Uint8 *b, Uint8 *a)
+{
+    SDL_GetRGBA(pixel, format, r, g, b, a);
+}
 #endif
 
 int

--- a/src_c/surface.h
+++ b/src_c/surface.h
@@ -342,6 +342,21 @@
     } while (0)
 #endif
 
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+
+#define PG_SurfaceGetRGBA(colorkey, surf, r, g, b, a) \
+    SDL_GetRGBA(colorkey, PG_GetSurfaceFormat(surf),  \
+                PG_GetSurfacePalette(surf), r, g, b, a)
+#define PG_SurfaceGetRGB(colorkey, surf, r, g, b)   \
+    SDL_GetRGB(colorkey, PG_GetSurfaceFormat(surf), \
+               PG_GetSurfacePalette(surf), r, g, b)
+#else
+#define PG_SurfaceGetRGBA(colorkey, surf, r, g, b, a) \
+    SDL_GetRGBA(colorkey, PG_GetSurfaceFormat(surf), r, g, b, a)
+#define PG_SurfaceGetRGB(colorkey, surf, r, g, b) \
+    SDL_GetRGB(colorkey, PG_GetSurfaceFormat(surf), r, g, b)
+#endif
+
 int
 surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
                    int blendargs);


### PR DESCRIPTION
Not a full port.

Things left to do:
- [x] ~Logic for palettes.~
- [x] ~``RLEACCEL``~
- [ ] ``alphablit``
- [ ] ``surface_fill``
- [ ] ``simd_blitters_avx2``
- [ ] ``simd_blitters_sse2``
- [ ] ``simd_surface_fill_avx2``
- [ ] ``simd_surface_fill_sse2``

Unchecked points will be done in a different PR / different PRs.