### PR TITLE
Implement lazy loading of pygame submodules (`surfarray`, `sndarray`)

### DIFF
--- a/docs/reST/ref/sndarray.rst
+++ b/docs/reST/ref/sndarray.rst
@@ -23,7 +23,7 @@ Each sample is an 8-bit or 16-bit integer, depending on the data format. A
 stereo sound file has two values per sample, while a mono sound file only has
 one.
 
-.. versionchanged:: 2.5.3 sndarray module is lazily loaded
+.. versionchanged:: 2.5.3 sndarray module is lazily loaded to avoid loading NumPy needlessly
 
 .. function:: array
 

--- a/docs/reST/ref/sndarray.rst
+++ b/docs/reST/ref/sndarray.rst
@@ -23,6 +23,8 @@ Each sample is an 8-bit or 16-bit integer, depending on the data format. A
 stereo sound file has two values per sample, while a mono sound file only has
 one.
 
+.. versionchanged:: 2.5.3 sndarray module is lazily loaded
+
 .. function:: array
 
    | :sl:`copy Sound samples into an array`

--- a/docs/reST/ref/surfarray.rst
+++ b/docs/reST/ref/surfarray.rst
@@ -35,6 +35,8 @@ pixels from the surface and any changes performed to the array will make changes
 in the surface. As this last functions share memory with the surface, this one
 will be locked during the lifetime of the array.
 
+.. versionchanged:: 2.5.3 surfarray module is lazily loaded
+
 .. function:: array2d
 
    | :sl:`Copy pixels into a 2d array`

--- a/docs/reST/ref/surfarray.rst
+++ b/docs/reST/ref/surfarray.rst
@@ -35,7 +35,7 @@ pixels from the surface and any changes performed to the array will make changes
 in the surface. As this last functions share memory with the surface, this one
 will be locked during the lifetime of the array.
 
-.. versionchanged:: 2.5.3 surfarray module is lazily loaded
+.. versionchanged:: 2.5.3 surfarray module is lazily loaded to avoid loading NumPy needlessly
 
 .. function:: array2d
 

--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -72,6 +72,8 @@ class MissingModule:
     _NOT_IMPLEMENTED_ = True
 
     def __init__(self, name, urgent=0):
+        import sys
+
         self.name = name
         exc_type, exc_msg = sys.exc_info()[:2]
         self.info = str(exc_msg)

--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -259,7 +259,26 @@ try:
 except (ImportError, OSError):
     transform = MissingModule("transform", urgent=1)
 
+
 # lastly, the "optional" pygame modules
+
+_MissingModule = MissingModule
+
+
+def __getattr__(name):
+    from importlib import import_module
+
+    LAZY_MODULES = "surfarray", "sndarray"
+    if name not in LAZY_MODULES:
+        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+    try:
+        module = import_module(f"{__name__}.{name}")
+    except (ImportError, OSError):
+        module = _MissingModule(name, urgent=0)
+        globals()[name] = module
+    return module
+
+
 if "PYGAME_FREETYPE" in os.environ:
     try:
         import pygame.ftfont as font
@@ -299,16 +318,6 @@ try:
     import pygame.scrap
 except (ImportError, OSError):
     scrap = MissingModule("scrap", urgent=0)
-
-try:
-    import pygame.surfarray
-except (ImportError, OSError):
-    surfarray = MissingModule("surfarray", urgent=0)
-
-try:
-    import pygame.sndarray
-except (ImportError, OSError):
-    sndarray = MissingModule("sndarray", urgent=0)
 
 try:
     import pygame._debug

--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -377,6 +377,10 @@ def packager_imports():
     import pygame.macosx
     import pygame.colordict
 
+    # lazily loaded pygame modules, just in case
+    import pygame.surfarray
+    import pygame.sndarray
+
 
 # make Rects pickleable
 

--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -72,7 +72,7 @@ class MissingModule:
     _NOT_IMPLEMENTED_ = True
 
     def __init__(self, name, urgent=0):
-        import sys
+        import sys  # pylint: disable=reimported
 
         self.name = name
         exc_type, exc_msg = sys.exc_info()[:2]


### PR DESCRIPTION
**Motivation:**
Previously, I discovered via profiling that `numpy` was being imported or loaded in my pygame program, when there were no mandatory runtime dependencies on it, though I had it installed.
The pygame submodules `surfarray` and `sndarray` both attempt to import numpy if possible, and pygame always tries to load these submodules. (If numpy is not available, they are replaced by `MissingModule`.)

When running `import pygame`, `numpy` (if available) loading takes up at least 40% of the time, around 100 milliseconds depending on the hardware. However, the `surfarray` and `sndarray` modules are not used in many pygame programs, and some users install `numpy` globally, or, like me, have dev dependencies that use numpy.

**Implementation:**
To fix this, `numpy` shouldn't be loaded unless it is actually needed by the user. This requires lazy loading/importing. Obviously, the implementation should be backwards-compatible.

<details><summary>Considered lazy import implementations</summary>

Five ways to implement lazy loading that I know of:
1. Don't import submodule in the parent package itself
2. Put all expensive imports inside of functions
3. Use [importlib.util.LazyLoader](https://docs.python.org/3/library/importlib.html#implementing-lazy-imports)
4. Use a custom `ModuleType` subclass, as in https://pypi.org/project/lazy-imports/
5. (**Chosen**) Use the [module `__getattr__` feature](https://peps.python.org/pep-0562/) (python 3.7+), similar to as in https://snarky.ca/lazy-importing-in-python-3-7/

Only the fifth is suitable because of backwards compatibility. It also happens to be one of the simplest.
Problems with 1 - 4:
1. Cannot implement the existing `MissingModule` behavior (when `numpy` is unavailable)
2. Too much effort, massive changes to code of the submodules. Does not preserve `MissingModule` behavior
3. Cannot implement `MissingModule` upon import failure
4. Too complicated. Cannot implement `MissingModule` behavior

</details>

The pygame submodules `surfarray` and `sndarray` will be lazily imported, deferring execution/loading of them to when the user themselves access it (if they do), e.g. `pygame.surfarray.array2d` or `import pygame.sndarray`.
If they do use it, `numpy` will usually not be loaded at an inconvenient time (to cause framedrops) *unless* the first use (including imports) is of the form `pygame.surfarray.___` inside a function (easy user fix).

**Backwards compatibility / Testing:**
<details><summary>All combinations of these factors must be compatible</summary>

- numpy is or is not installed
- `sndarray`, `surfarray` is or is not accessed by user
- If accessed, the access method used:
  - `import pygame.surfarray`
  - `from pygame import surfarray`
  - `pygame.surfarray.array2d`
  - `from pygame.surfarray import array2d`

In addition:
- Accessing undefined attribute on `pygame` module (same error message)
- PyInstaller and such must still work

</details>

I did not include test cases in this PR, though I think the implementation is probably compatible.

Notes:
Since `MissingModule` class is deleted at the end of `__init__.py` and unavailable to `__getattr__`, there is a new private alias `_MissingModule` in the pygame namespace.
I don't like the `MissingModule` behavior that much because half of the access forms bypass it.
If this PR is merged, then more optional pygame submodules may be lazily imported in the future.