### PR TITLE
Fix SDL3 CI apt issues

### DIFF
--- a/.github/workflows/build-sdl3.yml
+++ b/.github/workflows/build-sdl3.yml
@@ -56,7 +56,9 @@ jobs:
 
     - name: Install pygame deps (linux)
       if: matrix.os == 'ubuntu-24.04'
-      run: sudo apt-get install libfreetype6-dev libportmidi-dev python3-dev
+      run: |
+        sudo apt-get update --fix-missing
+        sudo apt-get install libfreetype6-dev libportmidi-dev python3-dev
 
     - name: Install pygame deps (mac)
       if: matrix.os == 'macos-14'


### PR DESCRIPTION
Our usual fix for the weird apt update issues that happen on github actions was missed from this particular CI, leading to unrelated fails as seen in the recent PR #3232 

This PR adds that fix