### PR TITLE
Deprecate `Window` `foreign` kwarg and `Window.focus` `input_only` kwarg

### DIFF
--- a/docs/reST/ref/window.rst
+++ b/docs/reST/ref/window.rst
@@ -37,7 +37,6 @@
    :param bool keyboard_grabbed: Create a window with grabbed keyboard input.
    :param bool input_focus: Create a window with input focus.
    :param bool mouse_focus: Create a window with mouse focus.
-   :param bool foreign: Marks a window not created by SDL.
    :param bool allow_high_dpi: Create a window in high-DPI mode if supported.
    :param bool mouse_capture: Create a window that has the mouse captured
                               (unrelated to INPUT_GRABBED).

--- a/docs/reST/ref/window.rst
+++ b/docs/reST/ref/window.rst
@@ -403,7 +403,10 @@
 
       :param bool input_only: if ``True``, the window will be given input focus
                               but may be completely obscured by other windows.
-                              Only supported on X11.
+                              Only supported on X11. This has been deprecated and
+                              may be removed in a future version.
+
+      .. deprecated:: 2.5.3 ``input_only`` argument
 
    .. method:: restore
 

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -289,6 +289,12 @@ window_focus(pgWindowObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
     if (input_only) {
+        if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "The input_only kwarg has been deprecated and may be "
+                         "removed in a future version",
+                         1) == -1) {
+            return NULL;
+        }
         if (SDL_SetWindowInputFocus(self->_win)) {
             return RAISE(pgExc_SDLError, SDL_GetError());
         }

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -923,6 +923,12 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
                     }
                 }
                 else if (!strcmp(_key_str, "foreign")) {
+                    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                                     "The foreign kwarg has been deprecated "
+                                     "and may be removed in a future version",
+                                     1) == -1) {
+                        return -1;
+                    }
                     if (_value_bool) {
                         flags |= SDL_WINDOW_FOREIGN;
                     }


### PR DESCRIPTION
I was looking at compiling `Window` under SDL3, and seems like `SDL_WINDOW_FOREIGN` is now gone, with no mention or a replacement in SDL3. The easiest thing to do now seems to be undocumenting, and the code now raises a deprecation warning if the `foreign` kwarg is received.