### PR TITLE
updated 'in' operator for sys.platform linux check 

### DIFF
--- a/src_py/camera.py
+++ b/src_py/camera.py
@@ -114,7 +114,7 @@ def get_backends():
     if sys.platform == "win32" and int(platform.win32_ver()[0].split(".")[0]) >= 8:
         possible_backends.append("_camera (MSMF)")
 
-    if "linux" in sys.platform:
+    if sys.platform == "linux":
         possible_backends.append("_camera (V4L2)")
 
     if "darwin" in sys.platform:


### PR DESCRIPTION
As Pygame currently uses CPython 3.8>=, the 'in' operator in the sys.platform check of get_backends() could be considered unnecessary, as no major version of Linux will be returned when accessing sys.platform. According to [Python documentation](https://docs.python.org/3/library/sys.html#sys.platform ), as of 3.3, sys.platform will only return the string, 'linux' (lowercased). Therefore, the == operator could potentially be more appropriate. Just a thought. 