### PR TITLE
New approach to lazy loading of pygame submodules (`surfarray`, `sndarray`)

### DIFF
--- a/docs/reST/ref/sndarray.rst
+++ b/docs/reST/ref/sndarray.rst
@@ -23,6 +23,8 @@ Each sample is an 8-bit or 16-bit integer, depending on the data format. A
 stereo sound file has two values per sample, while a mono sound file only has
 one.
 
+.. versionchanged:: 2.5.3 sndarray module is lazily loaded to avoid loading NumPy needlessly
+
 .. function:: array
 
    | :sl:`copy Sound samples into an array`

--- a/docs/reST/ref/surfarray.rst
+++ b/docs/reST/ref/surfarray.rst
@@ -35,6 +35,8 @@ pixels from the surface and any changes performed to the array will make changes
 in the surface. As this last functions share memory with the surface, this one
 will be locked during the lifetime of the array.
 
+.. versionchanged:: 2.5.3 surfarray module is lazily loaded to avoid loading NumPy needlessly
+
 .. function:: array2d
 
    | :sl:`Copy pixels into a 2d array`

--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -322,22 +322,30 @@ def lazy_import(name):
     return module
 
 
-numpy_exists = find_spec("numpy") is not None
+# Check if numpy is available for surfarray and sndarray modules
+numpy_missing = find_spec("numpy") is None
 
-# Preserve MissingModule behavior when numpy is not installed
-# and when their pygame module dependencies are unavailable
-
-if numpy_exists and not isinstance(pixelcopy, MissingModule):
-    surfarray = lazy_import("surfarray")
-else:
+try:
+    if numpy_missing:
+        # Always fails here. Need the error message for MissingModule.reason
+        import numpy
+    # Check that module dependencies are not missing, or get error message
+    import pygame.pixelcopy
+except (ImportError, OSError):
     surfarray = MissingModule("surfarray", urgent=0)
-
-if numpy_exists and not isinstance(mixer, MissingModule):
-    sndarray = lazy_import("sndarray")
 else:
-    sndarray = MissingModule("sndarray", urgent=0)
+    surfarray = lazy_import("surfarray")
 
-del LazyLoader, find_spec, lazy_import, module_from_spec, numpy_exists
+try:
+    if numpy_missing:
+        import numpy
+    import pygame.mixer
+except (ImportError, OSError):
+    sndarray = MissingModule("sndarray", urgent=0)
+else:
+    sndarray = lazy_import("sndarray")
+
+del LazyLoader, find_spec, lazy_import, module_from_spec, numpy_missing
 
 try:
     import pygame._debug

--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -306,9 +306,11 @@ from importlib.util import LazyLoader, find_spec, module_from_spec
 
 
 def lazy_import(name):
-    """See https://docs.python.org/3/library/importlib.html#implementing-lazy-imports
+    """Lazily import a pygame module.
 
-    Only load modules upon their first attribute access.
+    See https://docs.python.org/3/library/importlib.html#implementing-lazy-imports
+    Only load the module upon its first attribute access.
+
     Lazily imported modules are directly referenced in packager_imports function.
     """
     spec = find_spec("pygame." + name)
@@ -320,15 +322,22 @@ def lazy_import(name):
     return module
 
 
-if find_spec("numpy") is not None:
+numpy_exists = find_spec("numpy") is not None
+
+# Preserve MissingModule behavior when numpy is not installed
+# and when their pygame module dependencies are unavailable
+
+if numpy_exists and not isinstance(pixelcopy, MissingModule):
     surfarray = lazy_import("surfarray")
+else:
+    surfarray = MissingModule("surfarray", urgent=0)
+
+if numpy_exists and not isinstance(mixer, MissingModule):
     sndarray = lazy_import("sndarray")
 else:
-    # Preserve MissingModule behavior when numpy is not installed
-    surfarray = MissingModule("surfarray", urgent=0)
     sndarray = MissingModule("sndarray", urgent=0)
 
-del LazyLoader, find_spec, lazy_import, module_from_spec
+del LazyLoader, find_spec, lazy_import, module_from_spec, numpy_exists
 
 try:
     import pygame._debug


### PR DESCRIPTION
A new approach to lazy loading pygame submodules after #3232 had a problem with slower attribute accesses (`__getattr__`).

**Implementation explanation:**
The implementation is twofold, where the second part has many alternatives.

First, pygame checks if `numpy` exists.
Then, each submodule is loaded if numpy exists and the submodule's other pygame module dependencies (e.g. `mixer`) load successfully. If numpy is missing or a module dependency fails, then the submodule becomes `MissingModule`. It is necessary to get an error to use its message in `MissingModule.reason`, so `try-except` is used.

If successful, the submodule is created and put into `sys.modules`, using the documented [`LazyLoader`](https://docs.python.org/3/library/importlib.html#implementing-lazy-imports) implementation, relying on import machinery.
This makes it so that the submodule exists, but its contents are not executed until the first attribute or method access on the submodule.
It does this by changing the module class temporarily to `_LazyModule`; after the module is actually loaded, the module class is set back to the normal module type.

**Potential differences from current behavior:**
The initial checks are not completely perfect. It is assumed that if `numpy` is importable, it will not raise an `ImportError` nor `OSError`.
Obviously, `numpy` not being loaded by pygame automatically is an intended difference. Instead, it is loaded upon the first attribute access of either submodule. I do not expect this to cause any lag spikes in-game: the user probably imports numpy themselves, and it will also load if directly importing one of the submodule functions, or using one during game loading.
After a submodule is loaded successfully, there should not be any noticeable difference from current behavior. The module class is the same, the original loader is put back, the module code was not changed.
https://docs.python.org/3/library/importlib.html#importlib.util.LazyLoader
>**Note:** For projects where startup time is critical, this class allows for potentially minimizing the cost of loading a module if it is never used. For projects where startup time is not essential then use of this class is **heavily** discouraged due to error messages created during loading being postponed and thus occurring out of context.

There are no expected errors during postponed loading of these submodules, as they should have all been handled at the start.

Lazy loading of numpy has great potential benefits, so it's worth the extra complexity.

Closes #3232