### PR TITLE
Port imageext.c to SDL3(_image)

### DIFF
--- a/.github/workflows/build-sdl3.yml
+++ b/.github/workflows/build-sdl3.yml
@@ -86,6 +86,17 @@ jobs:
         cmake --build . --config Release --parallel
         sudo cmake --install . --config Release
 
+    - name: Install SDL3_image
+      if: matrix.os != 'windows-latest'
+      run: |
+        git clone https://github.com/libsdl-org/SDL_image
+        cd SDL_image
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Release ..
+        cmake --build . --config Release --parallel
+        sudo cmake --install . --config Release
+
     - name: Build with SDL3
       run: python3 dev.py build --sdl3
 

--- a/buildconfig/download_win_prebuilt.py
+++ b/buildconfig/download_win_prebuilt.py
@@ -90,6 +90,10 @@ def get_urls(x86=True, x64=True):
         '71ad2b5aacbc934a39e390ad733421313dd5d059'
         ],
         [
+        'https://github.com/libsdl-org/SDL_image/releases/download/preview-3.1.0/SDL3_image-devel-3.1.0-VC.zip',
+        '8538fea0cc4aabba2fc64db06196f1bb76a2785f'
+        ],
+        [
         'https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.22.0/SDL2_ttf-devel-2.22.0-VC.zip',
         '2d4f131909af2985b5ebc5ed296d28628c87c243'
         ],
@@ -213,6 +217,18 @@ def place_downloaded_prebuilts(temp_dir, move_to_dir, x86=True, x64=True):
                 'SDL2_image-2.8.3'
             )
         )
+        copy(
+            os.path.join(
+                temp_dir,
+                'SDL3_image-devel-3.1.0-VC/SDL3_image-3.1.0'
+            ),
+            os.path.join(
+                move_to_dir,
+                prebuilt_dir,
+                'SDL3_image-3.1.0'
+            )
+        )
+
         copy(
             os.path.join(
                 temp_dir,

--- a/dev.py
+++ b/dev.py
@@ -26,7 +26,6 @@ pyproject_path = source_tree / "pyproject.toml"
 
 SDL3_ARGS = [
     "-Csetup-args=-Dsdl_api=3",
-    "-Csetup-args=-Dimage=disabled",
     "-Csetup-args=-Dmixer=disabled",
     "-Csetup-args=-Dfont=disabled",
 ]

--- a/meson.build
+++ b/meson.build
@@ -110,7 +110,7 @@ if plat == 'win' and host_machine.cpu_family().startswith('x86')
     endif
 
     sdl_ver = (sdl_api == 3) ? '3.1.6' : '2.30.10'
-    sdl_image_ver = '2.8.3'
+    sdl_image_ver = (sdl_api == 3) ? '3.1.0' : '2.8.3'
     sdl_mixer_ver = '2.8.0'
     sdl_ttf_ver = '2.22.0'
 
@@ -131,12 +131,18 @@ if plat == 'win' and host_machine.cpu_family().startswith('x86')
         pg_lib_dirs += sdl_image_lib_dir
         dlls += [
             sdl_image_lib_dir / '@0@.dll'.format(sdl_image),
-            sdl_image_lib_dir / 'optional' / 'libjpeg-62.dll',
-            sdl_image_lib_dir / 'optional' / 'libpng16-16.dll',
-            sdl_image_lib_dir / 'optional' / 'libtiff-5.dll',
+            sdl_image_lib_dir / 'optional' / (sdl_api == 3 ? 'libtiff-6.dll' : 'libtiff-5.dll'),
             sdl_image_lib_dir / 'optional' / 'libwebp-7.dll',
             sdl_image_lib_dir / 'optional' / 'libwebpdemux-2.dll',
         ]
+        # temporary solution to get things compiling under SDL3_image. In the future
+        # we would want to have libpng and libjpeg on SDL3_image as well.
+        if sdl_api != 3
+            dlls += [
+                sdl_image_lib_dir / 'optional' / 'libjpeg-62.dll',
+                sdl_image_lib_dir / 'optional' / 'libpng16-16.dll',
+            ]
+        endif
     endif
 
     # SDL_mixer

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -46,7 +46,15 @@
 
 #include "pgopengl.h"
 
+#ifdef PG_SDL3
+#include <SDL3_image/SDL_image.h>
+
+// SDL3_images uses SDL3 error reporting API
+#define IMG_GetError SDL_GetError
+#else
 #include <SDL_image.h>
+#endif
+
 #ifdef WIN32
 #define strcasecmp _stricmp
 #else

--- a/src_c/meson.build
+++ b/src_c/meson.build
@@ -407,9 +407,6 @@ endif
 
 # optional modules
 
-# TODO: support SDL3
-if sdl_api != 3
-
 if sdl_image_dep.found()
     imageext = py.extension_module(
         'imageext',
@@ -420,6 +417,9 @@ if sdl_image_dep.found()
         subdir: pg,
     )
 endif
+
+# TODO: support SDL3
+if sdl_api != 3
 
 if sdl_ttf_dep.found()
     font = py.extension_module(


### PR DESCRIPTION
With the release of the SDL3_image prerelease, we can now start testing compilation of `imageext.c` on our SDL3 CI. The actual code changes in this PR are rather trivial because most of the porting work has already been done in previous PRs