### PR TITLE
this statement seems to be false, removing

### DIFF
--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -205,7 +205,7 @@
       object and dest is its destination position on this Surface. It draws each source Surface
       fully (meaning that unlike `blit()` you cannot pass an "area" parameter to represent
       a smaller portion of the source Surface to draw) on this Surface with the same blending
-      mode specified by special_flags. The sequence must have at least one (source, dest) pair.
+      mode specified by special_flags.
 
       :param blit_sequence: a sequence of (source, dest)
       :param special_flags: the flag(s) representing the blend mode used for each surface.


### PR DESCRIPTION
From a quick test `fblits` seems to work fine (not drawing anything) with an empty sequence. Unless I'm missing something I think this sentence can be removed.