### PR TITLE
Docs updates (mainly to mixer)

### DIFF
--- a/docs/reST/ref/image.rst
+++ b/docs/reST/ref/image.rst
@@ -245,7 +245,7 @@ following formats.
 
    .. note:: The use of this function is recommended over :func:`tostring` as of pygame 2.1.3.
              This function was introduced so it matches nicely with other
-             libraries (PIL, numpy, etc), and with people's expectations.
+             libraries (PIL, NumPy, etc), and with people's expectations.
 
    .. versionadded:: 2.1.3
    .. versionchanged:: 2.2.0 Now supports keyword arguments.
@@ -290,7 +290,7 @@ following formats.
 
    .. note:: The use of this function is recommended over :func:`fromstring` as of pygame 2.1.3.
              This function was introduced so it matches nicely with other
-             libraries (PIL, numpy, etc), and with people's expectations.
+             libraries (PIL, NumPy, etc), and with people's expectations.
 
    .. versionadded:: 2.1.3
    .. versionadded:: 2.1.4 Added a 'pitch' argument and support for keyword arguments.

--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -364,7 +364,7 @@ The following file formats are supported
    it and the Sound object.
 
    For now buffer and array support is consistent with ``sndarray.make_sound``
-   for Numeric arrays, in that sample sign and byte order are ignored. This
+   for NumPy arrays, in that sample sign and byte order are ignored. This
    will change, either by correctly handling sign and byte order, or by raising
    an exception when different. Also, source samples are truncated to fit the
    audio sample size. This will not change.

--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -9,9 +9,7 @@
 | :sl:`pygame module for loading and playing sounds`
 
 This module contains classes for loading Sound objects and controlling
-playback. The mixer module is optional and depends on SDL_mixer. Your program
-should test that :mod:`pygame.mixer` is available and initialized before using
-it.
+playback.
 
 The mixer module has a limited number of channels for playback of sounds.
 Usually programs tell pygame to start playing audio and it selects an available
@@ -30,9 +28,7 @@ streams the music from the files without loading music at once into memory.
 
 The mixer module must be initialized like other pygame modules, but it has some
 extra conditions. The ``pygame.mixer.init()`` function takes several optional
-arguments to control the playback rate and sample size. Pygame will default to
-reasonable values, but pygame cannot perform Sound resampling, so the mixer
-should be initialized to match the values of your audio resources.
+arguments to control the playback rate and sample size.
 
 ``NOTE``: For less laggy sound use a smaller buffer size. The default
 is set to reduce the chance of scratchy sounds on some computers. You can
@@ -91,7 +87,7 @@ The following file formats are supported
    the next nearest power of 2).
 
    The devicename parameter is the name of sound device to open for audio
-   playback.  Allowed device names will vary based on the host system.
+   playback. Allowed device names will vary based on the host system.
    If left as ``None`` then a sensible default will be chosen for you.
 
    Some platforms require the :mod:`pygame.mixer` module to be initialized
@@ -331,7 +327,7 @@ The following file formats are supported
    :rtype: tuple
 
    .. note::
-      The linked and compile version numbers should be the same.
+      The linked and compiled version numbers should be the same.
 
    .. versionaddedold:: 2.0.0
 

--- a/docs/reST/ref/surfarray.rst
+++ b/docs/reST/ref/surfarray.rst
@@ -30,7 +30,7 @@ specific pixel value of a color. Integer pixel values can only be used directly
 between surfaces with matching pixel layouts (see :class:`pygame.Surface`).
 
 All functions that refer to "array" will copy the surface information to a new
-numpy array. All functions that refer to "pixels" will directly reference the
+NumPy array. All functions that refer to "pixels" will directly reference the
 pixels from the surface and any changes performed to the array will make changes
 in the surface. As this last functions share memory with the surface, this one
 will be locked during the lifetime of the array.


### PR DESCRIPTION
> The mixer module is optional and depends on SDL_mixer. Your program should test that :mod:`pygame.mixer` is available and initialized before using it.

It's part of our API. Any remotely compliant build of pygame-ce has this, it's not something to be afraid of. I don't expect people's programs to test for pygame.mixer.

> Pygame will default to reasonable values, but pygame cannot perform Sound resampling, so the mixer should be initialized to match the values of your audio resources.

Technically, true, pygame-ce does not perform resampling. But SDL does, and they will resample into the format of your audio resources, this is highly misleading.

