### PR TITLE
Rename TestTags so it doesn't get confused for a test

### DIFF
--- a/test/test_utils/test_machinery.py
+++ b/test/test_utils/test_machinery.py
@@ -44,7 +44,7 @@ class PygameTestLoader(unittest.TestLoader):
 TAGS_RE = re.compile(r"\|[tT]ags:(-?[ a-zA-Z,0-9_\n]+)\|", re.M)
 
 
-class TestTags:
+class TheTestTags:
     def __init__(self):
         self.memoized = {}
         self.parent_modules = {}
@@ -86,4 +86,4 @@ class TestTags:
         return self.memoized[key]
 
 
-get_tags = TestTags()
+get_tags = TheTestTags()


### PR DESCRIPTION
Noticed this warning in the console:

```
test\test_utils\test_machinery.py:47
  C:\Users\dan\Programming\pygame-ce\test\test_utils\test_machinery.py:47: PytestCollectionWarning: cannot collect test class 'TestTags' because it has a __init__ constructor (from: test/test_utils/test_machinery.py)
    class TestTags:
```

The class name starting with `Test` is confusing the testing machinery that looks for tests in the `tests` folder. Seems a simple enough fix to rename the class slightly so it doesn't begin with `Test`.