### PR TITLE
Fix mypy to 1.13.0 to avoid __all__ duplication

### DIFF
--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -84,7 +84,7 @@ jobs:
 
     - name: Test typestubs
       run: |
-        pip3 install mypy
+        pip3 install mypy==1.13.0
         python3 buildconfig/stubs/stubcheck.py
 
     # We upload the generated files under github actions assets


### PR DESCRIPTION
The relevant mypy issue: https://github.com/python/mypy/issues/13300
and PR: https://github.com/python/mypy/pull/18005

Basically MyPy updated and added a new feature of erroring on `__all__` not being included in the stubs. I'm not sure we want to do this as constants `__all__` is very large. Either way it is some annoying work to solve in the future that is causing the unit tests to fail right now.

This PR just locks us to the previous version before this change was added.
