### PR TITLE
Remove unnecessary lock in gfxdraw

### DIFF
--- a/src_c/SDL_gfx/SDL_gfxPrimitives.c
+++ b/src_c/SDL_gfx/SDL_gfxPrimitives.c
@@ -4093,7 +4093,7 @@ ellipseColor(SDL_Surface *dst, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry,
                         result |= pixelColorNolock(dst, xmi, ypj, color);
                         result |= pixelColorNolock(dst, xpi, ypj, color);
                         result |= pixelColorNolock(dst, xmi, ymj, color);
-                        result |= pixelColor(dst, xpi, ymj, color);
+                        result |= pixelColorNolock(dst, xpi, ymj, color);
                     }
                     else {
                         result |= pixelColorNolock(dst, xmi, y, color);


### PR DESCRIPTION
All the surrounding code is written to assume the surface has already been locked (which it has). Possibly this was a copy paste error many years ago, it's been in pygame/pygame-ce for at least 9 years.

If you look at the source of `pixelColor` vs `pixelColorNolock`, they do the exact same thing, except the former locks and unlocks the surface, which is unnecessary.

I noticed this when looking into porting gfxdraw to SDL3.