### PR TITLE
Introduce PG_SURF_FORMATENUM macro (SDL3 compat)

### DIFF
--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -109,7 +109,7 @@ surf_colorspace(PyObject *self, PyObject *arg)
     surf = pgSurface_AsSurface(surfobj);
 
     if (!surfobj2) {
-        newsurf = PG_CreateSurface(surf->w, surf->h, surf->format->format);
+        newsurf = PG_CreateSurface(surf->w, surf->h, PG_SURF_FORMATENUM(surf));
         if (!newsurf) {
             return NULL;
         }

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -106,6 +106,7 @@ PG_UnlockMutex(SDL_mutex *mutex)
 #define PG_SURF_BytesPerPixel(surf) SDL_BYTESPERPIXEL(surf->format)
 #define PG_FORMAT_BitsPerPixel(format) format->bits_per_pixel
 #define PG_FORMAT_BytesPerPixel(format) format->bytes_per_pixel
+#define PG_SURF_FORMATENUM(surf) surf->format
 
 /* Mask to test if surface flags are in a fullscreen window. */
 #define PG_WINDOW_FULLSCREEN_INCLUSIVE SDL_WINDOW_FULLSCREEN
@@ -173,6 +174,7 @@ PG_UnlockMutex(SDL_mutex *mutex)
 #define PG_SURF_BytesPerPixel(surf) surf->format->BytesPerPixel
 #define PG_FORMAT_BitsPerPixel(format) format->BitsPerPixel
 #define PG_FORMAT_BytesPerPixel(format) format->BytesPerPixel
+#define PG_SURF_FORMATENUM(surf) surf->format->format
 
 /* Mask to test if surface flags are in a fullscreen window.
  * SDL_WINDOW_FULLSCREEN_DESKTOP works here because it also contains

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -174,7 +174,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                                         &info);
                                 }
                                 else if (SDL_ISPIXELFORMAT_ALPHA(
-                                             dst->format->format) &&
+                                             PG_SURF_FORMATENUM(dst)) &&
                                          info.dst_blend !=
                                              SDL_BLENDMODE_NONE) {
                                     alphablit_alpha_avx2_argb_no_surf_alpha(
@@ -193,7 +193,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                                         &info);
                                 }
                                 else if (SDL_ISPIXELFORMAT_ALPHA(
-                                             dst->format->format) &&
+                                             PG_SURF_FORMATENUM(dst)) &&
                                          info.dst_blend !=
                                              SDL_BLENDMODE_NONE) {
                                     alphablit_alpha_sse2_argb_no_surf_alpha(

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -2172,11 +2172,7 @@ static PG_PixelFormatEnum
 pg_GetDefaultConvertFormat(void)
 {
     if (pg_default_screen) {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-        return pg_default_screen->surf->format;
-#else
-        return pg_default_screen->surf->format->format;
-#endif
+        return PG_SURF_FORMATENUM(pg_default_screen->surf);
     }
     return pg_default_convert_format;
 }

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -2111,13 +2111,7 @@ draw_to_surface(SDL_Surface *surf, bitmask_t *bitmask, int x_dest, int y_dest,
 static int
 check_surface_pixel_format(SDL_Surface *surf, SDL_Surface *check_surf)
 {
-    if ((PG_SURF_BytesPerPixel(surf) != PG_SURF_BytesPerPixel(check_surf)) ||
-        (PG_SURF_BitsPerPixel(surf) != PG_SURF_BitsPerPixel(check_surf)) ||
-        (surf->format->format != check_surf->format->format)) {
-        return 0;
-    }
-
-    return 1;
+    return PG_SURF_FORMATENUM(surf) == PG_SURF_FORMATENUM(check_surf);
 }
 
 /* Draws a mask on a surface.

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -131,7 +131,7 @@ _make_surface(pgPixelArrayObject *array, PyObject *args)
      * create a new surface with the array dimensions */
     if (!same_dims) {
         if (!(temp_surf = PG_CreateSurface((int)dim0, (int)dim1,
-                                           surf->format->format)))
+                                           PG_SURF_FORMATENUM(surf))))
             return RAISE(pgExc_SDLError, SDL_GetError());
     }
 

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -1170,7 +1170,7 @@ make_surface(PyObject *self, PyObject *arg)
         pgBuffer_Release(&pg_view);
         return RAISE(pgExc_SDLError, SDL_GetError());
     }
-    if (SDL_ISPIXELFORMAT_INDEXED(surf->format->format)) {
+    if (SDL_ISPIXELFORMAT_INDEXED(PG_SURF_FORMATENUM(surf))) {
         /* Give the surface something other than an all white palette.
          *          */
         if (SDL_SetPaletteColors(surf->format->palette, default_palette_colors,

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -584,7 +584,8 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
         /*
          * Target surface is 32bit with source RGBA/ABGR ordering
          */
-        rz_dst = PG_CreateSurface(dstwidth, dstheight, rz_src->format->format);
+        rz_dst =
+            PG_CreateSurface(dstwidth, dstheight, PG_SURF_FORMATENUM(rz_src));
         if (SDL_HasColorKey(src)) {
             SDL_GetColorKey(src, &colorkey);
             if (SDL_SetColorKey(rz_dst, SDL_TRUE, colorkey) != 0) {
@@ -643,7 +644,8 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
          * Target surface is 32bit with source RGBA/ABGR ordering
          */
 
-        rz_dst = PG_CreateSurface(dstwidth, dstheight, rz_src->format->format);
+        rz_dst =
+            PG_CreateSurface(dstwidth, dstheight, PG_SURF_FORMATENUM(rz_src));
         if (SDL_HasColorKey(src)) {
             SDL_GetColorKey(src, &colorkey);
             if (SDL_SetColorKey(rz_dst, SDL_TRUE, colorkey) != 0) {

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -686,7 +686,7 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
         }
     }
 
-    if (SDL_ISPIXELFORMAT_INDEXED(surface->format->format)) {
+    if (SDL_ISPIXELFORMAT_INDEXED(PG_SURF_FORMATENUM(surface))) {
         /* Give the surface something other than an all white palette.
          *          */
         if (SDL_SetPaletteColors(surface->format->palette,
@@ -936,7 +936,7 @@ surf_unmap_rgb(PyObject *self, PyObject *arg)
     }
     SURF_INIT_CHECK(surf)
 
-    if (SDL_ISPIXELFORMAT_ALPHA(surf->format->format))
+    if (SDL_ISPIXELFORMAT_ALPHA(PG_SURF_FORMATENUM(surf)))
         SDL_GetRGBA(col, surf->format, rgba, rgba + 1, rgba + 2, rgba + 3);
     else {
         SDL_GetRGB(col, surf->format, rgba, rgba + 1, rgba + 2);
@@ -1109,7 +1109,7 @@ surf_set_palette(PyObject *self, PyObject *seq)
 
     pal = surf->format->palette;
 
-    if (!SDL_ISPIXELFORMAT_INDEXED(surf->format->format))
+    if (!SDL_ISPIXELFORMAT_INDEXED(PG_SURF_FORMATENUM(surf)))
         return RAISE(pgExc_SDLError, "Surface colors are not indexed\n");
 
     if (!pal)
@@ -1164,7 +1164,7 @@ surf_set_palette_at(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    if (!SDL_ISPIXELFORMAT_INDEXED(surf->format->format))
+    if (!SDL_ISPIXELFORMAT_INDEXED(PG_SURF_FORMATENUM(surf)))
         return RAISE(pgExc_SDLError, "Surface colors are not indexed\n");
 
     pal = surf->format->palette;
@@ -1248,7 +1248,7 @@ surf_get_colorkey(pgSurfaceObject *self, PyObject *_null)
 
     SDL_GetColorKey(surf, &mapped_color);
 
-    if (SDL_ISPIXELFORMAT_ALPHA(surf->format->format))
+    if (SDL_ISPIXELFORMAT_ALPHA(PG_SURF_FORMATENUM(surf)))
         SDL_GetRGBA(mapped_color, surf->format, &r, &g, &b, &a);
     else
         SDL_GetRGB(mapped_color, surf->format, &r, &g, &b);
@@ -1314,7 +1314,7 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
         sdlrect.h = 0;
         sdlrect.w = 0;
 
-        surface = PG_CreateSurface(1, 1, surf->format->format);
+        surface = PG_CreateSurface(1, 1, PG_SURF_FORMATENUM(surf));
 
         SDL_LowerBlit(surf, &sdlrect, surface, &sdlrect);
         SDL_FreeSurface(surface);
@@ -1411,7 +1411,7 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
 
     if ((has_colorkey = SDL_HasColorKey(surf))) {
         SDL_GetColorKey(surf, &colorkey);
-        if (SDL_ISPIXELFORMAT_ALPHA(surf->format->format))
+        if (SDL_ISPIXELFORMAT_ALPHA(PG_SURF_FORMATENUM(surf)))
             SDL_GetRGBA(colorkey, surf->format, &key_r, &key_g, &key_b,
                         &key_a);
         else
@@ -1535,7 +1535,7 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
             if (SDL_ISPIXELFORMAT_INDEXED(SDL_MasksToPixelFormatEnum(
                     PG_FORMAT_BitsPerPixel((&format)), format.Rmask,
                     format.Gmask, format.Bmask, format.Amask))) {
-                if (SDL_ISPIXELFORMAT_INDEXED(surf->format->format)) {
+                if (SDL_ISPIXELFORMAT_INDEXED(PG_SURF_FORMATENUM(surf))) {
                     SDL_SetPixelFormatPalette(&format, surf->format->palette);
                 }
                 else {
@@ -2768,7 +2768,7 @@ surf_subsurface(PyObject *self, PyObject *args)
         return RAISE(pgExc_SDLError, SDL_GetError());
 
     /* copy the colormap if we need it */
-    if (SDL_ISPIXELFORMAT_INDEXED(surf->format->format) &&
+    if (SDL_ISPIXELFORMAT_INDEXED(PG_SURF_FORMATENUM(surf)) &&
         surf->format->palette) {
         SDL_Color *colors = surf->format->palette->colors;
         int ncolors = surf->format->palette->ncolors;
@@ -4011,7 +4011,7 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
     }
     /* can't blit alpha to 8bit, crashes SDL */
     else if (PG_SURF_BytesPerPixel(dst) == 1 &&
-             (SDL_ISPIXELFORMAT_ALPHA(src->format->format) ||
+             (SDL_ISPIXELFORMAT_ALPHA(PG_SURF_FORMATENUM(src)) ||
               ((SDL_GetSurfaceAlphaMod(src, &alpha) == 0 && alpha != 255)))) {
         /* Py_BEGIN_ALLOW_THREADS */
         if (PG_SURF_BytesPerPixel(src) == 1) {
@@ -4057,7 +4057,7 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
              (PG_SURF_BytesPerPixel(dst) == 4 ||
               PG_SURF_BytesPerPixel(dst) == 2) &&
              _PgSurface_SrcAlpha(src) &&
-             (SDL_ISPIXELFORMAT_ALPHA(src->format->format)) &&
+             (SDL_ISPIXELFORMAT_ALPHA(PG_SURF_FORMATENUM(src))) &&
              !PG_SurfaceHasRLE(src) && !PG_SurfaceHasRLE(dst) &&
              !(src->flags & SDL_RLEACCEL) && !(dst->flags & SDL_RLEACCEL)) {
         /* If we have a 32bit source surface with per pixel alpha


### PR DESCRIPTION
- Brings SDL3 just a bit closer. Rotozoom.c for example now compiles, previously did not.
- Simplify 2 pixel format checks (in mask and transform)
- Remove unneeded include from transform.c (SDL_cpuinfo.h comes in fine from SDL.h, and fails to include on SDL3)

This macro is the same as PG_SurfaceFormatEnum from gresm's surface PR #3215, but named as a macro and applied throughout the project. Except for window.c, because I didn't want to cause a merge conflict with Ankith's window SDL3 PR.