### PR TITLE
Optimize correct colordict entries

### DIFF
--- a/src_c/color.c
+++ b/src_c/color.c
@@ -620,8 +620,7 @@ _parse_color_from_text(PyObject *str_obj, Uint8 *rgba)
                 case TRISTATE_ERROR:
                     return -1;
                 default:
-                    goto success;
-                    break;
+                    return 0;
             }
         }
     }
@@ -634,7 +633,6 @@ _parse_color_from_text(PyObject *str_obj, Uint8 *rgba)
                      Py_TYPE(color)->tp_name);
         return -1;
     }
-success:
     return 0;
 }
 

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -624,15 +624,8 @@ _parse_color_from_text(PyObject *str_obj, Uint8 *rgba)
                     break;
             }
         }
-        else {
-            goto found_color;
-        }
-    }
-    else {
-        goto found_color;
     }
 
-found_color:
     if (!pg_RGBAFromObjEx(color, rgba, PG_COLOR_HANDLE_RESTRICT_SEQ)) {
         PyErr_Format(PyExc_RuntimeError,
                      "internal pygame error - colordict is supposed to "


### PR DESCRIPTION
as @Starbuck5 noticed string methods are called even if the color name existed raw in the color dictionary. This PR adds a fast path when that is the case. I tested with timeit before and after this PR and correct names got a major performance increase (from 5.5 to 1.8) while other cases are basically left unchanged. I believe a fast path should also be considered for hex colors, but it's beyond the scope of this PR. MRE:
```py
import pygame
import timeit

# change the string for different cases
print(timeit.timeit("pygame.Color('white')", globals=globals(), number=10_000_000))

# OLD
# correct: 5.5-5.8
# hex: 8-8.2
# case: 5.6-5.8
# space: 5.9+

# NEW
# correct: 1.8-1.9
# hex: 8-8.2
# case: 5.7-5.9
# space: 6+
```