### PR TITLE
Docs fix for time, weird generation in c api

### DIFF
--- a/buildconfig/stubs/pygame/time.pyi
+++ b/buildconfig/stubs/pygame/time.pyi
@@ -1,8 +1,8 @@
 """Pygame module for monitoring time.
 
-Times in pygame are represented in milliseconds (1/1000 seconds). Most
-platforms have a limited time resolution of around 10 milliseconds. This
-resolution, in milliseconds, is given in the ``TIMER_RESOLUTION`` constant.
+Provides utilities for monitoring time, delaying time, and maintaining a
+constant frame rate.
+Times in pygame-ce are represented in milliseconds (1/1000 of a second).
 """
 
 from typing import Union, final

--- a/docs/reST/c_api/base.rst
+++ b/docs/reST/c_api/base.rst
@@ -178,8 +178,7 @@ C header: src_c/include/pygame.h
    Argument *screen* may be *NULL*.
    This functions is called by pygame.display.set_mode().
 
-.. c:function:: PyObject* pgObject_getRectHelper(PyObject *rect, PyObject *const *args,
-                                                 Py_ssize_t nargs, PyObject *kwnames, char *type)
+.. c:function:: PyObject* pgObject_getRectHelper(PyObject *rect, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames, char *type)
 
    Return a rectangle covering the entire object. Rectangle will start at (0, 0)
    with a width and height the same size as the object. You can pass keyword


### PR DESCRIPTION
This PR has two independent (but small) changes.

- Replace incorrect info in time module doc. Noticed this with Zoldalma's docs->stubs PR, when I typed in pygame.time the first thing I saw was that there is a TIMER_RESOLUTION I had never heard of. This was removed in SDL2 and we just set it zero for compat. Not helping anyone by recommending its usage here.
- Fix function arg doc generation. Noticed warning about this when generating the docs for the first change.
