### PR TITLE
Prep surface_fill.c for SDL3

### DIFF
--- a/src_c/surface.h
+++ b/src_c/surface.h
@@ -142,20 +142,22 @@
     }
 #endif
 
-#define CREATE_PIXEL(buf, r, g, b, a, bp, ft)                       \
-    switch (bp) {                                                   \
-        case 2:                                                     \
-            *((Uint16 *)(buf)) = ((r >> ft->Rloss) << ft->Rshift) | \
-                                 ((g >> ft->Gloss) << ft->Gshift) | \
-                                 ((b >> ft->Bloss) << ft->Bshift) | \
-                                 ((a >> ft->Aloss) << ft->Ashift);  \
-            break;                                                  \
-        case 4:                                                     \
-            *((Uint32 *)(buf)) = ((r >> ft->Rloss) << ft->Rshift) | \
-                                 ((g >> ft->Gloss) << ft->Gshift) | \
-                                 ((b >> ft->Bloss) << ft->Bshift) | \
-                                 ((a >> ft->Aloss) << ft->Ashift);  \
-            break;                                                  \
+#define CREATE_PIXEL(buf, r, g, b, a, bp, ft)                 \
+    switch (bp) {                                             \
+        case 2:                                               \
+            *((Uint16 *)(buf)) =                              \
+                ((r >> PG_FORMAT_R_LOSS(ft)) << ft->Rshift) | \
+                ((g >> PG_FORMAT_G_LOSS(ft)) << ft->Gshift) | \
+                ((b >> PG_FORMAT_B_LOSS(ft)) << ft->Bshift) | \
+                ((a >> PG_FORMAT_A_LOSS(ft)) << ft->Ashift);  \
+            break;                                            \
+        case 4:                                               \
+            *((Uint32 *)(buf)) =                              \
+                ((r >> PG_FORMAT_R_LOSS(ft)) << ft->Rshift) | \
+                ((g >> PG_FORMAT_G_LOSS(ft)) << ft->Gshift) | \
+                ((b >> PG_FORMAT_B_LOSS(ft)) << ft->Bshift) | \
+                ((a >> PG_FORMAT_A_LOSS(ft)) << ft->Ashift);  \
+            break;                                            \
     }
 
 /* Pretty good idea from Tom Duff :-). */

--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -86,7 +86,6 @@ surface_fill_blend_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int skip;
     int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
-    SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
     Uint32 pixel;
     Uint32 tmp;
@@ -94,6 +93,11 @@ surface_fill_blend_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
+    PG_PixelFormat *fmt;
+    SDL_Palette *palette;
+    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
+        return -1;
+    }
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -102,13 +106,13 @@ surface_fill_blend_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 
     switch (bpp) {
         case 1: {
-            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA);
+            PG_GetRGBA(color, fmt, palette, &cR, &cG, &cB, &cA);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
                         BLEND_ADD(tmp, cR, cG, cB, cA, sR, sG, sB, sA);
-                        *pixels = SDL_MapRGBA(fmt, sR, sG, sB, sA);
+                        *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
                     },
                     n, width);
@@ -172,7 +176,6 @@ surface_fill_blend_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int skip;
     int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
-    SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
     Uint32 pixel;
     Sint32 tmp2;
@@ -180,6 +183,11 @@ surface_fill_blend_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
+    PG_PixelFormat *fmt;
+    SDL_Palette *palette;
+    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
+        return -1;
+    }
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -188,13 +196,13 @@ surface_fill_blend_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 
     switch (bpp) {
         case 1: {
-            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA);
+            PG_GetRGBA(color, fmt, palette, &cR, &cG, &cB, &cA);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
                         BLEND_SUB(tmp2, cR, cG, cB, cA, sR, sG, sB, sA);
-                        *pixels = SDL_MapRGBA(fmt, sR, sG, sB, sA);
+                        *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
                     },
                     n, width);
@@ -258,13 +266,17 @@ surface_fill_blend_mult(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int skip;
     int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
-    SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
     Uint32 pixel;
     int result = -1;
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
+    PG_PixelFormat *fmt;
+    SDL_Palette *palette;
+    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
+        return -1;
+    }
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -273,13 +285,13 @@ surface_fill_blend_mult(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 
     switch (bpp) {
         case 1: {
-            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA);
+            PG_GetRGBA(color, fmt, palette, &cR, &cG, &cB, &cA);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
                         BLEND_MULT(cR, cG, cB, cA, sR, sG, sB, sA);
-                        *pixels = SDL_MapRGBA(fmt, sR, sG, sB, sA);
+                        *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
                     },
                     n, width);
@@ -343,13 +355,17 @@ surface_fill_blend_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int skip;
     int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
-    SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
     Uint32 pixel;
     int result = -1;
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
+    PG_PixelFormat *fmt;
+    SDL_Palette *palette;
+    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
+        return -1;
+    }
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -358,13 +374,13 @@ surface_fill_blend_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 
     switch (bpp) {
         case 1: {
-            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA);
+            PG_GetRGBA(color, fmt, palette, &cR, &cG, &cB, &cA);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
                         BLEND_MIN(cR, cG, cB, cA, sR, sG, sB, sA);
-                        *pixels = SDL_MapRGBA(fmt, sR, sG, sB, sA);
+                        *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
                     },
                     n, width);
@@ -428,13 +444,17 @@ surface_fill_blend_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int skip;
     int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
-    SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
     Uint32 pixel;
     int result = -1;
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
+    PG_PixelFormat *fmt;
+    SDL_Palette *palette;
+    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
+        return -1;
+    }
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -443,13 +463,13 @@ surface_fill_blend_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 
     switch (bpp) {
         case 1: {
-            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA);
+            PG_GetRGBA(color, fmt, palette, &cR, &cG, &cB, &cA);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
                         BLEND_MAX(cR, cG, cB, cA, sR, sG, sB, sA);
-                        *pixels = SDL_MapRGBA(fmt, sR, sG, sB, sA);
+                        *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
                     },
                     n, width);
@@ -515,7 +535,6 @@ surface_fill_blend_rgba_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int skip;
     int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
-    SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
     Uint32 pixel;
     Uint32 tmp;
@@ -523,6 +542,11 @@ surface_fill_blend_rgba_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
+    PG_PixelFormat *fmt;
+    SDL_Palette *palette;
+    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
+        return -1;
+    }
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     if (!ppa) {
@@ -535,13 +559,13 @@ surface_fill_blend_rgba_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 
     switch (bpp) {
         case 1: {
-            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA);
+            PG_GetRGBA(color, fmt, palette, &cR, &cG, &cB, &cA);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
                         BLEND_RGBA_ADD(tmp, cR, cG, cB, cA, sR, sG, sB, sA);
-                        *pixels = SDL_MapRGBA(fmt, sR, sG, sB, sA);
+                        *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
                     },
                     n, width);
@@ -584,7 +608,6 @@ surface_fill_blend_rgba_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int skip;
     int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
-    SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
     Uint32 pixel;
     Sint32 tmp2;
@@ -592,6 +615,11 @@ surface_fill_blend_rgba_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
+    PG_PixelFormat *fmt;
+    SDL_Palette *palette;
+    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
+        return -1;
+    }
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     if (!ppa) {
@@ -604,13 +632,13 @@ surface_fill_blend_rgba_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 
     switch (bpp) {
         case 1: {
-            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA);
+            PG_GetRGBA(color, fmt, palette, &cR, &cG, &cB, &cA);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
                         BLEND_RGBA_SUB(tmp2, cR, cG, cB, cA, sR, sG, sB, sA);
-                        *pixels = SDL_MapRGBA(fmt, sR, sG, sB, sA);
+                        *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
                     },
                     n, width);
@@ -654,13 +682,17 @@ surface_fill_blend_rgba_mult(SDL_Surface *surface, SDL_Rect *rect,
     int skip;
     int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
-    SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
     Uint32 pixel;
     int result = -1;
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
+    PG_PixelFormat *fmt;
+    SDL_Palette *palette;
+    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
+        return -1;
+    }
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     if (!ppa) {
@@ -673,13 +705,13 @@ surface_fill_blend_rgba_mult(SDL_Surface *surface, SDL_Rect *rect,
 
     switch (bpp) {
         case 1: {
-            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA);
+            PG_GetRGBA(color, fmt, palette, &cR, &cG, &cB, &cA);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
                         BLEND_RGBA_MULT(cR, cG, cB, cA, sR, sG, sB, sA);
-                        *pixels = SDL_MapRGBA(fmt, sR, sG, sB, sA);
+                        *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
                     },
                     n, width);
@@ -722,13 +754,17 @@ surface_fill_blend_rgba_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int skip;
     int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
-    SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
     Uint32 pixel;
     int result = -1;
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
+    PG_PixelFormat *fmt;
+    SDL_Palette *palette;
+    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
+        return -1;
+    }
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     if (!ppa) {
@@ -741,13 +777,13 @@ surface_fill_blend_rgba_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 
     switch (bpp) {
         case 1: {
-            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA);
+            PG_GetRGBA(color, fmt, palette, &cR, &cG, &cB, &cA);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
                         BLEND_RGBA_MIN(cR, cG, cB, cA, sR, sG, sB, sA);
-                        *pixels = SDL_MapRGBA(fmt, sR, sG, sB, sA);
+                        *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
                     },
                     n, width);
@@ -790,13 +826,17 @@ surface_fill_blend_rgba_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int skip;
     int bpp = PG_SURF_BytesPerPixel(surface);
     int n;
-    SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
     Uint32 pixel;
     int result = -1;
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
+    PG_PixelFormat *fmt;
+    SDL_Palette *palette;
+    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
+        return -1;
+    }
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     if (!ppa) {
@@ -809,13 +849,13 @@ surface_fill_blend_rgba_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 
     switch (bpp) {
         case 1: {
-            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA);
+            PG_GetRGBA(color, fmt, palette, &cR, &cG, &cB, &cA);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
                         BLEND_RGBA_MAX(cR, cG, cB, cA, sR, sG, sB, sA);
-                        *pixels = SDL_MapRGBA(fmt, sR, sG, sB, sA);
+                        *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
                     },
                     n, width);


### PR DESCRIPTION
Putting this one out as a simple PR, hopefully straightforward to review.

It brings some of the SDL3 compat macros that have been developed in previous PRs into the surface_fill.c's sphere of influence. To get surface_fill.c to fully compile I additionally had to mess with the GET_PIXELVALS macros, which I have not included in this PR because I am keeping it simple and because I am waiting to reunify them with the macros I split out in https://github.com/pygame-community/pygame-ce/pull/3309.