### PR TITLE
GET_PIXELVALS SDL3 compat

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -601,7 +601,9 @@ blit_blend_rgba_add(SDL_BlitInfo *info)
     int dstpxskip = info->d_pxskip;
     int dstskip = info->d_skip;
     PG_PixelFormat *srcfmt = info->src;
+    SDL_Palette *srcpal = info->src_palette;
     PG_PixelFormat *dstfmt = info->dst;
+    SDL_Palette *dstpal = info->dst_palette;
     int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
     int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
@@ -646,8 +648,8 @@ blit_blend_rgba_add(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_RGBA_ADD(tmp, sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -663,9 +665,10 @@ blit_blend_rgba_add(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_RGBA_ADD(tmp, sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -684,8 +687,9 @@ blit_blend_rgba_add(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_RGBA_ADD(tmp, sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -702,9 +706,11 @@ blit_blend_rgba_add(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_RGBA_ADD(tmp, sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -731,7 +737,9 @@ blit_blend_rgba_sub(SDL_BlitInfo *info)
     int dstpxskip = info->d_pxskip;
     int dstskip = info->d_skip;
     PG_PixelFormat *srcfmt = info->src;
+    SDL_Palette *srcpal = info->src_palette;
     PG_PixelFormat *dstfmt = info->dst;
+    SDL_Palette *dstpal = info->dst_palette;
     int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
     int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
@@ -776,8 +784,8 @@ blit_blend_rgba_sub(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_RGBA_SUB(tmp2, sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -793,9 +801,10 @@ blit_blend_rgba_sub(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_RGBA_SUB(tmp2, sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -814,8 +823,9 @@ blit_blend_rgba_sub(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_RGBA_SUB(tmp2, sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -832,9 +842,11 @@ blit_blend_rgba_sub(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_RGBA_SUB(tmp2, sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -861,7 +873,9 @@ blit_blend_rgba_mul(SDL_BlitInfo *info)
     int dstpxskip = info->d_pxskip;
     int dstskip = info->d_skip;
     PG_PixelFormat *srcfmt = info->src;
+    SDL_Palette *srcpal = info->src_palette;
     PG_PixelFormat *dstfmt = info->dst;
+    SDL_Palette *dstpal = info->dst_palette;
     int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
     int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
@@ -908,8 +922,8 @@ blit_blend_rgba_mul(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_RGBA_MULT(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -925,9 +939,10 @@ blit_blend_rgba_mul(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_RGBA_MULT(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -946,8 +961,9 @@ blit_blend_rgba_mul(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_RGBA_MULT(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -964,9 +980,11 @@ blit_blend_rgba_mul(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_RGBA_MULT(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -993,7 +1011,9 @@ blit_blend_rgba_min(SDL_BlitInfo *info)
     int dstpxskip = info->d_pxskip;
     int dstskip = info->d_skip;
     PG_PixelFormat *srcfmt = info->src;
+    SDL_Palette *srcpal = info->src_palette;
     PG_PixelFormat *dstfmt = info->dst;
+    SDL_Palette *dstpal = info->dst_palette;
     int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
     int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
@@ -1037,8 +1057,8 @@ blit_blend_rgba_min(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_RGBA_MIN(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1054,9 +1074,10 @@ blit_blend_rgba_min(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_RGBA_MIN(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1075,8 +1096,9 @@ blit_blend_rgba_min(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_RGBA_MIN(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1093,9 +1115,11 @@ blit_blend_rgba_min(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_RGBA_MIN(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1122,7 +1146,9 @@ blit_blend_rgba_max(SDL_BlitInfo *info)
     int dstpxskip = info->d_pxskip;
     int dstskip = info->d_skip;
     PG_PixelFormat *srcfmt = info->src;
+    SDL_Palette *srcpal = info->src_palette;
     PG_PixelFormat *dstfmt = info->dst;
+    SDL_Palette *dstpal = info->dst_palette;
     int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
     int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
@@ -1166,8 +1192,8 @@ blit_blend_rgba_max(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_RGBA_MAX(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1183,9 +1209,10 @@ blit_blend_rgba_max(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_RGBA_MAX(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1204,8 +1231,9 @@ blit_blend_rgba_max(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_RGBA_MAX(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1222,9 +1250,11 @@ blit_blend_rgba_max(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_RGBA_MAX(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1251,7 +1281,9 @@ blit_blend_premultiplied(SDL_BlitInfo *info)
     int dstpxskip = info->d_pxskip;
     int dstskip = info->d_skip;
     PG_PixelFormat *srcfmt = info->src;
+    SDL_Palette *srcpal = info->src_palette;
     PG_PixelFormat *dstfmt = info->dst;
+    SDL_Palette *dstpal = info->dst_palette;
     int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
     int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
@@ -1296,11 +1328,11 @@ blit_blend_premultiplied(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         ALPHA_BLEND_PREMULTIPLIED(tmp, sR, sG, sB, sA, dR, dG,
                                                   dB, dA);
-                        SET_PIXELVAL(dst, dstfmt, dR, dG, dB, dA);
+                        SET_PIXELVAL(dst, dstfmt, dstpal, dR, dG, dB, dA);
                         src += srcpxskip;
                         dst += dstpxskip;
                     },
@@ -1315,9 +1347,10 @@ blit_blend_premultiplied(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         ALPHA_BLEND_PREMULTIPLIED(tmp, sR, sG, sB, sA, dR, dG,
                                                   dB, dA);
                         dst[offsetR] = dR;
@@ -1336,9 +1369,10 @@ blit_blend_premultiplied(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         ALPHA_BLEND_PREMULTIPLIED(tmp, sR, sG, sB, sA, dR, dG,
                                                   dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
@@ -1358,11 +1392,12 @@ blit_blend_premultiplied(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         ALPHA_BLEND_PREMULTIPLIED(tmp, sR, sG, sB, sA, dR, dG,
                                                   dB, dA);
-                        SET_PIXELVAL(dst, dstfmt, dR, dG, dB, dA);
+                        SET_PIXELVAL(dst, dstfmt, dstpal, dR, dG, dB, dA);
                         src += srcpxskip;
                         dst += dstpxskip;
                     },
@@ -1378,9 +1413,11 @@ blit_blend_premultiplied(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         if (sA == 0) {
                             dst[offsetR] = dR;
                             dst[offsetG] = dG;
@@ -1412,9 +1449,11 @@ blit_blend_premultiplied(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         // We can save some blending time by just copying
                         // pixels with  alphas of 255 or 0
                         if (sA == 0) {
@@ -1454,7 +1493,9 @@ blit_blend_add(SDL_BlitInfo *info)
     int dstpxskip = info->d_pxskip;
     int dstskip = info->d_skip;
     PG_PixelFormat *srcfmt = info->src;
+    SDL_Palette *srcpal = info->src_palette;
     PG_PixelFormat *dstfmt = info->dst;
+    SDL_Palette *dstpal = info->dst_palette;
     int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
     int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
@@ -1502,10 +1543,10 @@ blit_blend_add(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_ADD(tmp, sR, sG, sB, sA, dR, dG, dB, dA);
-                        SET_PIXELVAL(dst, dstfmt, dR, dG, dB, dA);
+                        SET_PIXELVAL(dst, dstfmt, dstpal, dR, dG, dB, dA);
                         src += srcpxskip;
                         dst += dstpxskip;
                     },
@@ -1520,9 +1561,10 @@ blit_blend_add(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_ADD(tmp, sR, sG, sB, sA, dR, dG, dB, dA);
                         dst[offsetR] = dR;
                         dst[offsetG] = dG;
@@ -1540,9 +1582,10 @@ blit_blend_add(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_ADD(tmp, sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1561,10 +1604,11 @@ blit_blend_add(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_ADD(tmp, sR, sG, sB, sA, dR, dG, dB, dA);
-                        SET_PIXELVAL(dst, dstfmt, dR, dG, dB, dA);
+                        SET_PIXELVAL(dst, dstfmt, dstpal, dR, dG, dB, dA);
                         src += srcpxskip;
                         dst += dstpxskip;
                     },
@@ -1580,9 +1624,11 @@ blit_blend_add(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_ADD(tmp, sR, sG, sB, sA, dR, dG, dB, dA);
                         dst[offsetR] = dR;
                         dst[offsetG] = dG;
@@ -1601,9 +1647,11 @@ blit_blend_add(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_ADD(tmp, sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1630,7 +1678,9 @@ blit_blend_sub(SDL_BlitInfo *info)
     int dstpxskip = info->d_pxskip;
     int dstskip = info->d_skip;
     PG_PixelFormat *srcfmt = info->src;
+    SDL_Palette *srcpal = info->src_palette;
     PG_PixelFormat *dstfmt = info->dst;
+    SDL_Palette *dstpal = info->dst_palette;
     int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
     int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
@@ -1678,10 +1728,10 @@ blit_blend_sub(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_SUB(tmp2, sR, sG, sB, sA, dR, dG, dB, dA);
-                        SET_PIXELVAL(dst, dstfmt, dR, dG, dB, dA);
+                        SET_PIXELVAL(dst, dstfmt, dstpal, dR, dG, dB, dA);
                         src += srcpxskip;
                         dst += dstpxskip;
                     },
@@ -1696,9 +1746,10 @@ blit_blend_sub(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstfmt);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_SUB(tmp2, sR, sG, sB, sA, dR, dG, dB, dA);
                         dst[offsetR] = dR;
                         dst[offsetG] = dG;
@@ -1716,9 +1767,10 @@ blit_blend_sub(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_SUB(tmp2, sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1737,10 +1789,11 @@ blit_blend_sub(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_SUB(tmp2, sR, sG, sB, sA, dR, dG, dB, dA);
-                        SET_PIXELVAL(dst, dstfmt, dR, dG, dB, dA);
+                        SET_PIXELVAL(dst, dstfmt, dstpal, dR, dG, dB, dA);
                         src += srcpxskip;
                         dst += dstpxskip;
                     },
@@ -1756,9 +1809,11 @@ blit_blend_sub(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_SUB(tmp2, sR, sG, sB, sA, dR, dG, dB, dA);
                         dst[offsetR] = dR;
                         dst[offsetG] = dG;
@@ -1777,9 +1832,11 @@ blit_blend_sub(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_SUB(tmp2, sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1806,6 +1863,7 @@ blit_blend_mul(SDL_BlitInfo *info)
     int dstpxskip = info->d_pxskip;
     int dstskip = info->d_skip;
     PG_PixelFormat *srcfmt = info->src;
+    SDL_Palette *srcpal = info->src_palette;
     PG_PixelFormat *dstfmt = info->dst;
     SDL_Palette *dstpal = info->dst_palette;
     int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
@@ -1864,10 +1922,10 @@ blit_blend_mul(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_MULT(sR, sG, sB, sA, dR, dG, dB, dA);
-                        SET_PIXELVAL(dst, dstfmt, dR, dG, dB, dA);
+                        SET_PIXELVAL(dst, dstfmt, dstpal, dR, dG, dB, dA);
                         src += srcpxskip;
                         dst += dstpxskip;
                     },
@@ -1882,9 +1940,10 @@ blit_blend_mul(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_MULT(sR, sG, sB, sA, dR, dG, dB, dA);
                         dst[offsetR] = dR;
                         dst[offsetG] = dG;
@@ -1902,9 +1961,10 @@ blit_blend_mul(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_MULT(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1923,10 +1983,11 @@ blit_blend_mul(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_MULT(sR, sG, sB, sA, dR, dG, dB, dA);
-                        SET_PIXELVAL(dst, dstfmt, dR, dG, dB, dA);
+                        SET_PIXELVAL(dst, dstfmt, dstpal, dR, dG, dB, dA);
                         *dst = (Uint8)PG_MapRGB(dstfmt, dstpal, dR, dG, dB);
                         src += srcpxskip;
                         dst += dstpxskip;
@@ -1943,9 +2004,11 @@ blit_blend_mul(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_MULT(sR, sG, sB, sA, dR, dG, dB, dA);
                         dst[offsetR] = dR;
                         dst[offsetG] = dG;
@@ -1964,9 +2027,11 @@ blit_blend_mul(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_MULT(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -1993,6 +2058,7 @@ blit_blend_min(SDL_BlitInfo *info)
     int dstpxskip = info->d_pxskip;
     int dstskip = info->d_skip;
     PG_PixelFormat *srcfmt = info->src;
+    SDL_Palette *srcpal = info->src_palette;
     PG_PixelFormat *dstfmt = info->dst;
     SDL_Palette *dstpal = info->dst_palette;
     int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
@@ -2044,10 +2110,10 @@ blit_blend_min(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_MIN(sR, sG, sB, sA, dR, dG, dB, dA);
-                        SET_PIXELVAL(dst, dstfmt, dR, dG, dB, dA);
+                        SET_PIXELVAL(dst, dstfmt, dstpal, dR, dG, dB, dA);
                         src += srcpxskip;
                         dst += dstpxskip;
                     },
@@ -2062,9 +2128,10 @@ blit_blend_min(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_MIN(sR, sG, sB, sA, dR, dG, dB, dA);
                         dst[offsetR] = dR;
                         dst[offsetG] = dG;
@@ -2082,9 +2149,10 @@ blit_blend_min(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_MIN(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -2103,8 +2171,9 @@ blit_blend_min(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_MIN(sR, sG, sB, sA, dR, dG, dB, dA);
                         *dst = (Uint8)PG_MapRGB(dstfmt, dstpal, dR, dG, dB);
                         src += srcpxskip;
@@ -2122,9 +2191,11 @@ blit_blend_min(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_MIN(sR, sG, sB, sA, dR, dG, dB, dA);
                         dst[offsetR] = dR;
                         dst[offsetG] = dG;
@@ -2143,9 +2214,11 @@ blit_blend_min(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_MIN(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -2172,7 +2245,9 @@ blit_blend_max(SDL_BlitInfo *info)
     int dstpxskip = info->d_pxskip;
     int dstskip = info->d_skip;
     PG_PixelFormat *srcfmt = info->src;
+    SDL_Palette *srcpal = info->src_palette;
     PG_PixelFormat *dstfmt = info->dst;
+    SDL_Palette *dstpal = info->dst_palette;
     int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
     int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
     Uint8 dR, dG, dB, dA, sR, sG, sB, sA;
@@ -2222,10 +2297,10 @@ blit_blend_max(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_MAX(sR, sG, sB, sA, dR, dG, dB, dA);
-                        SET_PIXELVAL(dst, dstfmt, dR, dG, dB, dA);
+                        SET_PIXELVAL(dst, dstfmt, dstpal, dR, dG, dB, dA);
                         src += srcpxskip;
                         dst += dstpxskip;
                     },
@@ -2240,9 +2315,10 @@ blit_blend_max(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_MAX(sR, sG, sB, sA, dR, dG, dB, dA);
                         dst[offsetR] = dR;
                         dst[offsetG] = dG;
@@ -2260,9 +2336,10 @@ blit_blend_max(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcfmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_MAX(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -2281,10 +2358,11 @@ blit_blend_max(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
-                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstfmt);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
+                        GET_PIXELVALS_1(dR, dG, dB, dA, dst, dstpal);
                         BLEND_MAX(sR, sG, sB, sA, dR, dG, dB, dA);
-                        SET_PIXELVAL(dst, dstfmt, dR, dG, dB, dA);
+                        SET_PIXELVAL(dst, dstfmt, dstpal, dR, dG, dB, dA);
                         src += srcpxskip;
                         dst += dstpxskip;
                     },
@@ -2300,9 +2378,11 @@ blit_blend_max(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_MAX(sR, sG, sB, sA, dR, dG, dB, dA);
                         dst[offsetR] = dR;
                         dst[offsetG] = dG;
@@ -2321,9 +2401,11 @@ blit_blend_max(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcpal,
+                                      srcppa);
                         GET_PIXEL(pixel, dstbpp, dst);
-                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstppa);
+                        GET_PIXELVALS(dR, dG, dB, dA, pixel, dstfmt, dstpal,
+                                      dstppa);
                         BLEND_MAX(sR, sG, sB, sA, dR, dG, dB, dA);
                         CREATE_PIXEL(dst, dR, dG, dB, dA, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -2371,8 +2453,8 @@ alphablit_alpha(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sRi, sGi, sBi, sAi, src, srcfmt);
-                        GET_PIXELVALS_1(dRi, dGi, dBi, dAi, dst, dstfmt);
+                        GET_PIXELVALS_1(sRi, sGi, sBi, sAi, src, srcpal);
+                        GET_PIXELVALS_1(dRi, dGi, dBi, dAi, dst, dstpal);
                         ALPHA_BLEND(sRi, sGi, sBi, sAi, dRi, dGi, dBi, dAi);
                         CREATE_PIXEL(dst, dRi, dGi, dBi, dAi, dstbpp, dstfmt);
                         src += srcpxskip;
@@ -2388,7 +2470,7 @@ alphablit_alpha(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sRi, sGi, sBi, sAi, src, srcfmt);
+                        GET_PIXELVALS_1(sRi, sGi, sBi, sAi, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
                         PG_GetRGBA(pixel, dstfmt, dstpal, &dR, &dG, &dB, &dA);
                         dRi = dR;
@@ -2413,7 +2495,7 @@ alphablit_alpha(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS_1(dRi, dGi, dBi, dAi, dst, dstfmt);
+                        GET_PIXELVALS_1(dRi, dGi, dBi, dAi, dst, dstpal);
                         PG_GetRGBA(pixel, srcfmt, srcpal, &sR, &sG, &sB, &sA);
                         ALPHA_BLEND(sR, sG, sB, sA, dRi, dGi, dBi, dAi);
                         CREATE_PIXEL(dst, dRi, dGi, dBi, dAi, dstbpp, dstfmt);
@@ -2488,9 +2570,9 @@ alphablit_colorkey(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sRi, sGi, sBi, sAi, src, srcfmt);
+                        GET_PIXELVALS_1(sRi, sGi, sBi, sAi, src, srcpal);
                         sAi = (*src == colorkey) ? 0 : alpha;
-                        GET_PIXELVALS_1(dRi, dGi, dBi, dAi, dst, dstfmt);
+                        GET_PIXELVALS_1(dRi, dGi, dBi, dAi, dst, dstpal);
                         ALPHA_BLEND(sRi, sGi, sBi, sAi, dRi, dGi, dBi, dAi);
                         *dst = (Uint8)PG_MapRGBA(dstfmt, dstpal, dRi, dGi, dBi,
                                                  dAi);
@@ -2507,7 +2589,7 @@ alphablit_colorkey(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sRi, sGi, sBi, sAi, src, srcfmt);
+                        GET_PIXELVALS_1(sRi, sGi, sBi, sAi, src, srcpal);
                         sAi = (*src == colorkey) ? 0 : alpha;
                         GET_PIXEL(pixel, dstbpp, dst);
                         PG_GetRGBA(pixel, dstfmt, dstpal, &dR, &dG, &dB, &dA);
@@ -2535,7 +2617,7 @@ alphablit_colorkey(SDL_BlitInfo *info)
                         GET_PIXEL(pixel, srcbpp, src);
                         PG_GetRGBA(pixel, srcfmt, srcpal, &sR, &sG, &sB, &sA);
                         sA = (pixel == colorkey) ? 0 : alpha;
-                        GET_PIXELVALS_1(dRi, dGi, dBi, dAi, dst, dstfmt);
+                        GET_PIXELVALS_1(dRi, dGi, dBi, dAi, dst, dstpal);
                         ALPHA_BLEND(sR, sG, sB, sA, dRi, dGi, dBi, dAi);
                         *dst = (Uint8)PG_MapRGBA(dstfmt, dstpal, dRi, dGi, dBi,
                                                  dAi);
@@ -2636,8 +2718,8 @@ alphablit_solid(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sRi, sGi, sBi, dAi, src, srcfmt);
-                        GET_PIXELVALS_1(dRi, dGi, dBi, dAi, dst, dstfmt);
+                        GET_PIXELVALS_1(sRi, sGi, sBi, dAi, src, srcpal);
+                        GET_PIXELVALS_1(dRi, dGi, dBi, dAi, dst, dstpal);
                         ALPHA_BLEND(sRi, sGi, sBi, alpha, dRi, dGi, dBi, dAi);
                         *dst = (Uint8)PG_MapRGBA(dstfmt, dstpal, dRi, dGi, dBi,
                                                  dAi);
@@ -2654,7 +2736,7 @@ alphablit_solid(SDL_BlitInfo *info)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sRi, sGi, sBi, dAi, src, srcfmt);
+                        GET_PIXELVALS_1(sRi, sGi, sBi, dAi, src, srcpal);
                         GET_PIXEL(pixel, dstbpp, dst);
                         PG_GetRGBA(pixel, dstfmt, dstpal, &dR, &dG, &dB, &dA);
                         dRi = dR;
@@ -2679,7 +2761,7 @@ alphablit_solid(SDL_BlitInfo *info)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, srcbpp, src);
-                        GET_PIXELVALS_1(dRi, dGi, dBi, dAi, dst, dstfmt);
+                        GET_PIXELVALS_1(dRi, dGi, dBi, dAi, dst, dstpal);
                         PG_GetRGBA(pixel, srcfmt, srcpal, &sR, &sG, &sB, &sA);
                         ALPHA_BLEND(sR, sG, sB, alpha, dRi, dGi, dBi, dAi);
                         *dst = (Uint8)PG_MapRGBA(dstfmt, dstpal, dRi, dGi, dBi,
@@ -2858,12 +2940,22 @@ pygame_AlphaBlit(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
     return pygame_Blit(src, srcrect, dst, dstrect, blend_flags);
 }
 
+// Returns -1 if has no alpha channel, -2 on SDL error
 int
 premul_surf_color_by_alpha(SDL_Surface *src, SDL_Surface *dst)
 {
     SDL_BlendMode src_blend;
     SDL_GetSurfaceBlendMode(src, &src_blend);
-    if (src_blend == SDL_BLENDMODE_NONE && !(src->format->Amask != 0))
+
+    PG_PixelFormat *src_format, *dst_format;
+    SDL_Palette *src_palette, *dst_palette;
+
+    if (!PG_GetSurfaceDetails(src, &src_format, &src_palette) ||
+        !PG_GetSurfaceDetails(dst, &dst_format, &dst_palette)) {
+        return -2;  // signal SDL error to caller
+    }
+
+    if (src_blend == SDL_BLENDMODE_NONE && !(src_format->Amask != 0))
         return -1;
         // since we know dst is a copy of src we can simplify the normal checks
 #if !defined(__EMSCRIPTEN__)
@@ -2886,24 +2978,27 @@ premul_surf_color_by_alpha(SDL_Surface *src, SDL_Surface *dst)
 #endif /* PG_ENABLE_ARM_NEON */
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
-    premul_surf_color_by_alpha_non_simd(src, dst);
+    premul_surf_color_by_alpha_non_simd(src, src_format, src_palette, dst,
+                                        dst_format, dst_palette);
     return 0;
 }
 
 void
-premul_surf_color_by_alpha_non_simd(SDL_Surface *src, SDL_Surface *dst)
+premul_surf_color_by_alpha_non_simd(SDL_Surface *src,
+                                    PG_PixelFormat *src_format,
+                                    SDL_Palette *src_palette, SDL_Surface *dst,
+                                    PG_PixelFormat *dst_format,
+                                    SDL_Palette *dst_palette)
 {
-    SDL_PixelFormat *srcfmt = src->format;
-    SDL_PixelFormat *dstfmt = dst->format;
     int width = src->w;
     int height = src->h;
-    int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
-    int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
+    int srcbpp = PG_FORMAT_BytesPerPixel(src_format);
+    int dstbpp = PG_FORMAT_BytesPerPixel(dst_format);
     Uint8 *src_pixels = (Uint8 *)src->pixels;
     Uint8 *dst_pixels = (Uint8 *)dst->pixels;
 
-    int srcpxskip = PG_SURF_BytesPerPixel(src);
-    int dstpxskip = PG_SURF_BytesPerPixel(dst);
+    int srcpxskip = srcbpp;
+    int dstpxskip = dstbpp;
 
     int srcppa = SDL_TRUE;
 
@@ -2915,12 +3010,13 @@ premul_surf_color_by_alpha_non_simd(SDL_Surface *src, SDL_Surface *dst)
         LOOP_UNROLLED4(
             {
                 GET_PIXEL(pixel, srcbpp, src_pixels);
-                GET_PIXELVALS(sR, sG, sB, sA, pixel, srcfmt, srcppa);
+                GET_PIXELVALS(sR, sG, sB, sA, pixel, src_format, src_palette,
+                              srcppa);
                 dR = (Uint8)(((sR + 1) * sA) >> 8);
                 dG = (Uint8)(((sG + 1) * sA) >> 8);
                 dB = (Uint8)(((sB + 1) * sA) >> 8);
                 dA = sA;
-                CREATE_PIXEL(dst_pixels, dR, dG, dB, dA, dstbpp, dstfmt);
+                CREATE_PIXEL(dst_pixels, dR, dG, dB, dA, dstbpp, dst_format);
                 src_pixels += srcpxskip;
                 dst_pixels += dstpxskip;
             },

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -28,21 +28,6 @@
           wb * (b1 - b2) * (b1 - b2)) /                             \
      255.0)
 
-// TODO: once things are fully ported, consolidate PXM_GET_PIXELVALS
-// and PXM_GET_PIXELVALS_1 back into GET_PIXELVALS and GET_PIXELVALS_1
-// from surface.h
-#define PXM_GET_PIXELVALS(_sR, _sG, _sB, _sA, px, fmt, palette, ppa) \
-    PG_GetRGBA(px, fmt, palette, &(_sR), &(_sG), &(_sB), &(_sA));    \
-    if (!ppa) {                                                      \
-        _sA = 255;                                                   \
-    }
-
-#define PXM_GET_PIXELVALS_1(sr, sg, sb, sa, _src, _palette) \
-    sr = _palette->colors[*((Uint8 *)(_src))].r;            \
-    sg = _palette->colors[*((Uint8 *)(_src))].g;            \
-    sb = _palette->colors[*((Uint8 *)(_src))].b;            \
-    sa = 255;
-
 #define WR_NTSC 0.299
 #define WG_NTSC 0.587
 #define WB_NTSC 0.114
@@ -422,7 +407,7 @@ _replace_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                 for (x = 0; x < dim0; ++x) {
                     px_p = pixel_p;
                     if (distance != 0.0) {
-                        PXM_GET_PIXELVALS_1(r2, g2, b2, a2, px_p, palette);
+                        GET_PIXELVALS_1(r2, g2, b2, a2, px_p, palette);
                         if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2,
                                            b2) <= distance) {
                             *px_p = (Uint8)rcolor;
@@ -446,8 +431,8 @@ _replace_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                 for (x = 0; x < dim0; ++x) {
                     px_p = (Uint16 *)pixel_p;
                     if (distance != 0.0) {
-                        PXM_GET_PIXELVALS(r2, g2, b2, a2, (Uint32)*px_p,
-                                          format, palette, ppa);
+                        GET_PIXELVALS(r2, g2, b2, a2, (Uint32)*px_p, format,
+                                      palette, ppa);
                         if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2,
                                            b2) <= distance) {
                             *px_p = (Uint16)rcolor;
@@ -482,8 +467,8 @@ _replace_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                                ((Uint32)pixel_p[Goffset] << 8) +
                                ((Uint32)pixel_p[Boffset]));
                     if (distance != 0.0) {
-                        PXM_GET_PIXELVALS(r2, g2, b2, a2, pxcolor, format,
-                                          palette, ppa);
+                        GET_PIXELVALS(r2, g2, b2, a2, pxcolor, format, palette,
+                                      ppa);
                         if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2,
                                            b2) <= distance) {
                             pixel_p[Roffset] = (Uint8)(rcolor >> 16);
@@ -512,8 +497,8 @@ _replace_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                 for (x = 0; x < dim0; ++x) {
                     px_p = (Uint32 *)pixel_p;
                     if (distance != 0.0) {
-                        PXM_GET_PIXELVALS(r2, g2, b2, a2, *px_p, format,
-                                          palette, ppa);
+                        GET_PIXELVALS(r2, g2, b2, a2, *px_p, format, palette,
+                                      ppa);
                         if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2,
                                            b2) <= distance) {
                             *px_p = rcolor;
@@ -632,7 +617,7 @@ _extract_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                 for (x = 0; x < dim0; ++x) {
                     px_p = pixel_p;
                     if (distance != 0.0) {
-                        PXM_GET_PIXELVALS_1(r2, g2, b2, a2, px_p, palette);
+                        GET_PIXELVALS_1(r2, g2, b2, a2, px_p, palette);
                         if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2,
                                            b2) <= distance) {
                             *px_p = (Uint8)white;
@@ -659,8 +644,8 @@ _extract_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                 for (x = 0; x < dim0; ++x) {
                     px_p = (Uint16 *)pixel_p;
                     if (distance != 0.0) {
-                        PXM_GET_PIXELVALS(r2, g2, b2, a2, (Uint32)*px_p,
-                                          format, palette, ppa);
+                        GET_PIXELVALS(r2, g2, b2, a2, (Uint32)*px_p, format,
+                                      palette, ppa);
                         if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2,
                                            b2) <= distance) {
                             *px_p = (Uint16)white;
@@ -704,8 +689,8 @@ _extract_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                                ((Uint32)pixel_p[Goffset] << 8) +
                                ((Uint32)pixel_p[Boffset]));
                     if (distance != 0.0) {
-                        PXM_GET_PIXELVALS(r2, g2, b2, a2, pxcolor, format,
-                                          palette, ppa);
+                        GET_PIXELVALS(r2, g2, b2, a2, pxcolor, format, palette,
+                                      ppa);
                         if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2,
                                            b2) <= distance) {
                             pixel_p[Roffset] = white_r;
@@ -744,8 +729,8 @@ _extract_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                 for (x = 0; x < dim0; ++x) {
                     px_p = (Uint32 *)pixel_p;
                     if (distance != 0.0) {
-                        PXM_GET_PIXELVALS(r2, g2, b2, a2, *px_p, format,
-                                          palette, ppa);
+                        GET_PIXELVALS(r2, g2, b2, a2, *px_p, format, palette,
+                                      ppa);
                         if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2,
                                            b2) <= distance) {
                             *px_p = white;
@@ -888,9 +873,9 @@ _compare(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                     pixel_p = byte_p;
                     other_pixel_p = other_byte_p;
                     if (distance != 0.0) {
-                        PXM_GET_PIXELVALS_1(r1, g1, b1, a1, pixel_p, palette);
-                        PXM_GET_PIXELVALS_1(r2, g2, b2, a2, other_pixel_p,
-                                            other_palette);
+                        GET_PIXELVALS_1(r1, g1, b1, a1, pixel_p, palette);
+                        GET_PIXELVALS_1(r2, g2, b2, a2, other_pixel_p,
+                                        other_palette);
                         if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2,
                                            b2) <= distance) {
                             *pixel_p = (Uint8)white;
@@ -925,11 +910,10 @@ _compare(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                     pixel_p = (Uint16 *)byte_p;
                     other_pixel_p = (Uint16 *)other_byte_p;
                     if (distance != 0.0) {
-                        PXM_GET_PIXELVALS(r1, g1, b1, a1, (Uint32)*pixel_p,
-                                          format, palette, ppa);
-                        PXM_GET_PIXELVALS(r2, g2, b2, a2,
-                                          (Uint32)*other_pixel_p, other_format,
-                                          other_palette, other_ppa);
+                        GET_PIXELVALS(r1, g1, b1, a1, (Uint32)*pixel_p, format,
+                                      palette, ppa);
+                        GET_PIXELVALS(r2, g2, b2, a2, (Uint32)*other_pixel_p,
+                                      other_format, other_palette, other_ppa);
                         if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2,
                                            b2) <= distance) {
                             *pixel_p = (Uint16)white;
@@ -1029,11 +1013,10 @@ _compare(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                     pixel_p = (Uint32 *)byte_p;
                     other_pixel_p = (Uint32 *)other_byte_p;
                     if (distance != 0.0) {
-                        PXM_GET_PIXELVALS(r1, g1, b1, a1, *pixel_p, format,
-                                          palette, ppa);
-                        PXM_GET_PIXELVALS(r2, g2, b2, a2, *other_pixel_p,
-                                          other_format, other_palette,
-                                          other_ppa);
+                        GET_PIXELVALS(r1, g1, b1, a1, *pixel_p, format,
+                                      palette, ppa);
+                        GET_PIXELVALS(r2, g2, b2, a2, *other_pixel_p,
+                                      other_format, other_palette, other_ppa);
                         if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2,
                                            b2) <= distance) {
                             *pixel_p = white;

--- a/src_c/simd_blitters.h
+++ b/src_c/simd_blitters.h
@@ -49,7 +49,11 @@ blit_blend_premultiplied_sse2(SDL_BlitInfo *info);
    generic like surface_ops*/
 
 void
-premul_surf_color_by_alpha_non_simd(SDL_Surface *src, SDL_Surface *dst);
+premul_surf_color_by_alpha_non_simd(SDL_Surface *src,
+                                    PG_PixelFormat *src_format,
+                                    SDL_Palette *src_palette, SDL_Surface *dst,
+                                    PG_PixelFormat *dst_format,
+                                    SDL_Palette *dst_palette);
 void
 premul_surf_color_by_alpha_sse2(SDL_Surface *src, SDL_Surface *dst);
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3336,10 +3336,14 @@ surf_premul_alpha(pgSurfaceObject *self, PyObject *_null)
     if ((surf->w > 0 && surf->h > 0)) {
         // If the surface has no pixels we don't need to premul
         // just return the copy.
-        if (premul_surf_color_by_alpha(surf, newsurf) != 0) {
+        int result = premul_surf_color_by_alpha(surf, newsurf);
+        if (result == -1) {
             return RAISE(PyExc_ValueError,
                          "source surface to be alpha pre-multiplied must have "
                          "alpha channel");
+        }
+        else if (result == -2) {
+            return RAISE(pgExc_SDLError, SDL_GetError());
         }
     }
     pgSurface_Unprep(self);
@@ -3363,10 +3367,14 @@ surf_premul_alpha_ip(pgSurfaceObject *self, PyObject *_null)
 
     pgSurface_Prep(self);
 
-    if (premul_surf_color_by_alpha(surf, surf) != 0) {
+    int result = premul_surf_color_by_alpha(surf, surf);
+    if (result == -1) {
         return RAISE(PyExc_ValueError,
                      "source surface to be alpha pre-multiplied must have "
                      "alpha channel");
+    }
+    else if (result == -2) {
+        return RAISE(pgExc_SDLError, SDL_GetError());
     }
 
     pgSurface_Unprep(self);

--- a/src_c/surface.h
+++ b/src_c/surface.h
@@ -78,21 +78,21 @@
         } break;                         \
     }
 
-#define GET_PIXELVALS(_sR, _sG, _sB, _sA, px, fmt, ppa)   \
-    SDL_GetRGBA(px, fmt, &(_sR), &(_sG), &(_sB), &(_sA)); \
-    if (!ppa) {                                           \
-        _sA = 255;                                        \
+#define GET_PIXELVALS(_sR, _sG, _sB, _sA, px, fmt, palette, ppa)  \
+    PG_GetRGBA(px, fmt, palette, &(_sR), &(_sG), &(_sB), &(_sA)); \
+    if (!ppa) {                                                   \
+        _sA = 255;                                                \
     }
 
-#define GET_PIXELVALS_1(sr, sg, sb, sa, _src, _fmt)   \
-    sr = _fmt->palette->colors[*((Uint8 *)(_src))].r; \
-    sg = _fmt->palette->colors[*((Uint8 *)(_src))].g; \
-    sb = _fmt->palette->colors[*((Uint8 *)(_src))].b; \
+#define GET_PIXELVALS_1(sr, sg, sb, sa, _src, _palette) \
+    sr = _palette->colors[*((Uint8 *)(_src))].r;        \
+    sg = _palette->colors[*((Uint8 *)(_src))].g;        \
+    sb = _palette->colors[*((Uint8 *)(_src))].b;        \
     sa = 255;
 
 /* For 1 byte palette pixels */
-#define SET_PIXELVAL(px, fmt, _dR, _dG, _dB, _dA) \
-    *(px) = (Uint8)SDL_MapRGBA(fmt, _dR, _dG, _dB, _dA)
+#define SET_PIXELVAL(px, fmt, palette, _dR, _dG, _dB, _dA) \
+    *(px) = (Uint8)PG_MapRGBA(fmt, palette, _dR, _dG, _dB, _dA)
 
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
 #define SET_OFFSETS_24(or, og, ob, fmt)                         \

--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -110,7 +110,7 @@ surface_fill_blend_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, palette);
                         BLEND_ADD(tmp, cR, cG, cB, cA, sR, sG, sB, sA);
                         *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
@@ -124,12 +124,13 @@ surface_fill_blend_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
         case 3: {
             size_t offsetR, offsetG, offsetB;
             SET_OFFSETS_24(offsetR, offsetG, offsetB, fmt);
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_ADD(tmp, cR, cG, cB, cA, sR, sG, sB, sA);
                         pixels[offsetR] = sR;
                         pixels[offsetG] = sG;
@@ -143,7 +144,7 @@ surface_fill_blend_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             break;
         }
         default: {
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             /*
             printf ("Color: %d, %d, %d, %d, BPP is: %d\n", cR, cG, cB, cA,
             bpp);
@@ -152,7 +153,8 @@ surface_fill_blend_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_ADD(tmp, cR, cG, cB, cA, sR, sG, sB, sA);
                         CREATE_PIXEL(pixels, sR, sG, sB, sA, bpp, fmt);
                         pixels += bpp;
@@ -200,7 +202,7 @@ surface_fill_blend_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, palette);
                         BLEND_SUB(tmp2, cR, cG, cB, cA, sR, sG, sB, sA);
                         *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
@@ -214,12 +216,13 @@ surface_fill_blend_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
         case 3: {
             size_t offsetR, offsetG, offsetB;
             SET_OFFSETS_24(offsetR, offsetG, offsetB, fmt);
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_SUB(tmp2, cR, cG, cB, cA, sR, sG, sB, sA);
                         pixels[offsetR] = sR;
                         pixels[offsetG] = sG;
@@ -233,7 +236,7 @@ surface_fill_blend_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             break;
         }
         default: {
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             /*
             printf ("Color: %d, %d, %d, %d, BPP is: %d\n", cR, cG, cB, cA,
             bpp);
@@ -242,7 +245,8 @@ surface_fill_blend_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_SUB(tmp2, cR, cG, cB, cA, sR, sG, sB, sA);
                         CREATE_PIXEL(pixels, sR, sG, sB, sA, bpp, fmt);
                         pixels += bpp;
@@ -289,7 +293,7 @@ surface_fill_blend_mult(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, palette);
                         BLEND_MULT(cR, cG, cB, cA, sR, sG, sB, sA);
                         *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
@@ -303,12 +307,13 @@ surface_fill_blend_mult(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
         case 3: {
             size_t offsetR, offsetG, offsetB;
             SET_OFFSETS_24(offsetR, offsetG, offsetB, fmt);
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_MULT(cR, cG, cB, cA, sR, sG, sB, sA);
                         pixels[offsetR] = sR;
                         pixels[offsetG] = sG;
@@ -322,7 +327,7 @@ surface_fill_blend_mult(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             break;
         }
         default: {
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             /*
             printf ("Color: %d, %d, %d, %d, BPP is: %d\n", cR, cG, cB, cA,
             bpp);
@@ -331,7 +336,8 @@ surface_fill_blend_mult(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_MULT(cR, cG, cB, cA, sR, sG, sB, sA);
                         CREATE_PIXEL(pixels, sR, sG, sB, sA, bpp, fmt);
                         pixels += bpp;
@@ -378,7 +384,7 @@ surface_fill_blend_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, palette);
                         BLEND_MIN(cR, cG, cB, cA, sR, sG, sB, sA);
                         *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
@@ -392,12 +398,13 @@ surface_fill_blend_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
         case 3: {
             size_t offsetR, offsetG, offsetB;
             SET_OFFSETS_24(offsetR, offsetG, offsetB, fmt);
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_MIN(cR, cG, cB, cA, sR, sG, sB, sA);
                         pixels[offsetR] = sR;
                         pixels[offsetG] = sG;
@@ -411,7 +418,7 @@ surface_fill_blend_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             break;
         }
         default: {
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             /*
             printf ("Color: %d, %d, %d, %d, BPP is: %d\n", cR, cG, cB, cA,
             bpp);
@@ -420,7 +427,8 @@ surface_fill_blend_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_MIN(cR, cG, cB, cA, sR, sG, sB, sA);
                         CREATE_PIXEL(pixels, sR, sG, sB, sA, bpp, fmt);
                         pixels += bpp;
@@ -467,7 +475,7 @@ surface_fill_blend_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, palette);
                         BLEND_MAX(cR, cG, cB, cA, sR, sG, sB, sA);
                         *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
@@ -481,12 +489,13 @@ surface_fill_blend_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
         case 3: {
             size_t offsetR, offsetG, offsetB;
             SET_OFFSETS_24(offsetR, offsetG, offsetB, fmt);
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             while (height--) {
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_MAX(cR, cG, cB, cA, sR, sG, sB, sA);
                         pixels[offsetR] = sR;
                         pixels[offsetG] = sG;
@@ -500,7 +509,7 @@ surface_fill_blend_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             break;
         }
         default: {
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             /*
             printf ("Color: %d, %d, %d, %d, BPP is: %d\n", cR, cG, cB, cA,
             bpp);
@@ -509,7 +518,8 @@ surface_fill_blend_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_MAX(cR, cG, cB, cA, sR, sG, sB, sA);
                         CREATE_PIXEL(pixels, sR, sG, sB, sA, bpp, fmt);
                         pixels += bpp;
@@ -563,7 +573,7 @@ surface_fill_blend_rgba_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, palette);
                         BLEND_RGBA_ADD(tmp, cR, cG, cB, cA, sR, sG, sB, sA);
                         *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
@@ -575,7 +585,7 @@ surface_fill_blend_rgba_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             break;
         }
         default: {
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             /*
             printf ("Color: %d, %d, %d, %d, BPP is: %d\n", cR, cG, cB, cA,
             bpp);
@@ -584,7 +594,8 @@ surface_fill_blend_rgba_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_RGBA_ADD(tmp, cR, cG, cB, cA, sR, sG, sB, sA);
                         CREATE_PIXEL(pixels, sR, sG, sB, sA, bpp, fmt);
                         pixels += bpp;
@@ -636,7 +647,7 @@ surface_fill_blend_rgba_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, palette);
                         BLEND_RGBA_SUB(tmp2, cR, cG, cB, cA, sR, sG, sB, sA);
                         *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
@@ -648,7 +659,7 @@ surface_fill_blend_rgba_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             break;
         }
         default: {
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             /*
             printf ("Color: %d, %d, %d, %d, BPP is: %d\n", cR, cG, cB, cA,
             bpp);
@@ -657,7 +668,8 @@ surface_fill_blend_rgba_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_RGBA_SUB(tmp2, cR, cG, cB, cA, sR, sG, sB, sA);
                         CREATE_PIXEL(pixels, sR, sG, sB, sA, bpp, fmt);
                         pixels += bpp;
@@ -709,7 +721,7 @@ surface_fill_blend_rgba_mult(SDL_Surface *surface, SDL_Rect *rect,
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, palette);
                         BLEND_RGBA_MULT(cR, cG, cB, cA, sR, sG, sB, sA);
                         *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
@@ -721,7 +733,7 @@ surface_fill_blend_rgba_mult(SDL_Surface *surface, SDL_Rect *rect,
             break;
         }
         default: {
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             /*
             printf ("Color: %d, %d, %d, %d, BPP is: %d\n", cR, cG, cB, cA,
             bpp);
@@ -730,7 +742,8 @@ surface_fill_blend_rgba_mult(SDL_Surface *surface, SDL_Rect *rect,
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_RGBA_MULT(cR, cG, cB, cA, sR, sG, sB, sA);
                         CREATE_PIXEL(pixels, sR, sG, sB, sA, bpp, fmt);
                         pixels += bpp;
@@ -781,7 +794,7 @@ surface_fill_blend_rgba_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, palette);
                         BLEND_RGBA_MIN(cR, cG, cB, cA, sR, sG, sB, sA);
                         *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
@@ -793,7 +806,7 @@ surface_fill_blend_rgba_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             break;
         }
         default: {
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             /*
             printf ("Color: %d, %d, %d, %d, BPP is: %d\n", cR, cG, cB, cA,
             bpp);
@@ -802,7 +815,8 @@ surface_fill_blend_rgba_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_RGBA_MIN(cR, cG, cB, cA, sR, sG, sB, sA);
                         CREATE_PIXEL(pixels, sR, sG, sB, sA, bpp, fmt);
                         pixels += bpp;
@@ -853,7 +867,7 @@ surface_fill_blend_rgba_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             while (height--) {
                 LOOP_UNROLLED4(
                     {
-                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, fmt);
+                        GET_PIXELVALS_1(sR, sG, sB, sA, pixels, palette);
                         BLEND_RGBA_MAX(cR, cG, cB, cA, sR, sG, sB, sA);
                         *pixels = PG_MapRGBA(fmt, palette, sR, sG, sB, sA);
                         pixels += bpp;
@@ -865,7 +879,7 @@ surface_fill_blend_rgba_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
             break;
         }
         default: {
-            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, ppa);
+            GET_PIXELVALS(cR, cG, cB, cA, color, fmt, palette, ppa);
             /*
             printf ("Color: %d, %d, %d, %d, BPP is: %d\n", cR, cG, cB, cA,
             bpp);
@@ -874,7 +888,8 @@ surface_fill_blend_rgba_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
                 LOOP_UNROLLED4(
                     {
                         GET_PIXEL(pixel, bpp, pixels);
-                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, ppa);
+                        GET_PIXELVALS(sR, sG, sB, sA, pixel, fmt, palette,
+                                      ppa);
                         BLEND_RGBA_MAX(cR, cG, cB, cA, sR, sG, sB, sA);
                         CREATE_PIXEL(pixels, sR, sG, sB, sA, bpp, fmt);
                         pixels += bpp;


### PR DESCRIPTION
Changes
- Ports the macros GET_PIXELVALS, GET_PIXELVALS_1, and SET_PIXELVAL to SDL3, consolidating back in the pixelarray methods version which I introduced recently to port the pixelarray module only
- Ports the non-SIMD premultiply to SDL3 (since it was using the macro)

These changes lead to surface_fill.c and alphablit.c fully compiling on SDL3.