### PR TITLE
Fixed stub for pygame._sdl2.video.Texture.__init__

### DIFF
--- a/buildconfig/stubs/pygame/_sdl2/video.pyi
+++ b/buildconfig/stubs/pygame/_sdl2/video.pyi
@@ -45,6 +45,7 @@ class Texture:
         self,
         renderer: Renderer,
         size: Iterable[int],
+        depth: int = 0,
         static: bool = False,
         streaming: bool = False,
         target: bool = False,


### PR DESCRIPTION
Added the `depth` argument between `size` and `static` as per the Cython function definition.

Very small contribution but I ran into an error where I passed my value for `static` as a positional argument instead of a keyword-argument and debugged it to find that an argument was missing from the stubs.

For reference, passing `True` to the `depth` argument results in an error similar to the following:

```
  ...
    self._texture = SDL2Texture(display.renderer, surface.size, static, streaming)
  File "video.pyx", line 226, in pygame._sdl2.video.Texture.__init__
  File "video.pyx", line 224, in pygame._sdl2.video.Texture.__init__
  File "video.pyx", line 165, in pygame._sdl2.video.format_from_depth
ValueError: no standard masks exist for given bitdepth with alpha

```