### PR TITLE
Use spaces instead of tabs in docs rst files

### DIFF
--- a/docs/reST/c_api/slots.rst
+++ b/docs/reST/c_api/slots.rst
@@ -16,7 +16,7 @@ base.c has this exposing the pg_RGBAFromObj function to the `c_api` structure:
 
 Then in src_c/include/_pygame.h there is an
 
-	#define pg_RGBAFromObj.
+    #define pg_RGBAFromObj.
 
 Also in _pygame.h, it needs to define the number of slots the base module uses. This is PYGAMEAPI_BASE_NUMSLOTS. So if you were adding another function, you need to increment this PYGAMEAPI_BASE_NUMSLOTS number.
 
@@ -25,6 +25,6 @@ Then to use the pg_RGBAFromObj in other files,
 1) include the "pygame.h" file,
 2) they have to make sure base is imported with:
 
-	import_pygame_base();
+    import_pygame_base();
 
 Examples that use pg_RGBAFromObj are: _freetype.c, color.c, gfxdraw.c, and surface.c.

--- a/docs/reST/ref/bufferproxy.rst
+++ b/docs/reST/ref/bufferproxy.rst
@@ -47,8 +47,8 @@
 
       ``"strides"`` : tuple : (optional)
          Array stride information as a tuple of integers. It is required
-	 only of non C-contiguous arrays. The tuple length must match
-	 that of ``"shape"``.
+         only of non C-contiguous arrays. The tuple length must match
+         that of ``"shape"``.
 
       ``"parent"`` : object : (optional)
          The exporting object. It can be used to keep the parent object
@@ -57,7 +57,7 @@
       ``"before"`` : callable : (optional)
          Callback invoked when the :class:`BufferProxy` instance
          exports the buffer. The callback is given one argument, the
-	   ``"parent"`` object if given, otherwise ``None``.
+         ``"parent"`` object if given, otherwise ``None``.
          The callback is useful for setting a lock on the parent.
 
       ``"after"`` : callable : (optional)

--- a/docs/reST/ref/mask.rst
+++ b/docs/reST/ref/mask.rst
@@ -535,8 +535,8 @@ to store which parts collide.
       component.
 
       :param int minimum: (optional) indicates the minimum number of bits (to
-	 filter out noise) per connected component (default is 0, which equates
- 	 to no minimum and is equivalent to setting it to 1, as a connected
+         filter out noise) per connected component (default is 0, which equates
+         to no minimum and is equivalent to setting it to 1, as a connected
          component must have at least 1 bit set)
 
       :returns: a list containing a :class:`Mask` object for each connected

--- a/docs/reST/ref/mouse.rst
+++ b/docs/reST/ref/mouse.rst
@@ -275,7 +275,7 @@ scroll, such as ``which`` (it will tell you what exact mouse device trigger the 
 
    .. note:: Code that unpacked a get_cursor() call into
              ``size, hotspot, xormasks, andmasks`` will still work,
-	     assuming the call returns an old school type cursor.
+             assuming the call returns an old school type cursor.
 
    .. versionchangedold:: 2.0.1
 

--- a/docs/reST/ref/sdl2_video.rst
+++ b/docs/reST/ref/sdl2_video.rst
@@ -7,10 +7,10 @@
    :synopsis: Experimental pygame module for porting new SDL video systems
 
 .. warning::
-	This module isn't ready for prime time yet, it's still in development.
-        These docs are primarily meant to help the pygame developers and
-        super-early adopters who are in communication with the developers.
-        This API will change.
+   This module isn't ready for prime time yet, it's still in development.
+   These docs are primarily meant to help the pygame developers and
+   super-early adopters who are in communication with the developers.
+   This API will change.
 
 | :sl:`Experimental pygame module for porting new SDL video systems`
 

--- a/docs/reST/tutorials/en/tom-games6.rst
+++ b/docs/reST/tutorials/en/tom-games6.rst
@@ -28,19 +28,19 @@ after we've worked out the new position of the ball.
 
 ::
 
-  if not self.area.contains(newpos):
-  	tl = not self.area.collidepoint(newpos.topleft)
-  	tr = not self.area.collidepoint(newpos.topright)
-  	bl = not self.area.collidepoint(newpos.bottomleft)
-  	br = not self.area.collidepoint(newpos.bottomright)
-  	if tr and tl or (br and bl):
-  		angle = -angle
-  	if tl and bl:
-  		self.offcourt(player=2)
-  	if tr and br:
-  		self.offcourt(player=1)
+    if not self.area.contains(newpos):
+        tl = not self.area.collidepoint(newpos.topleft)
+        tr = not self.area.collidepoint(newpos.topright)
+        bl = not self.area.collidepoint(newpos.bottomleft)
+        br = not self.area.collidepoint(newpos.bottomright)
+        if tr and tl or (br and bl):
+            angle = -angle
+        if tl and bl:
+            self.offcourt(player=2)
+        if tr and br:
+            self.offcourt(player=1)
 
-  self.vector = (angle,z)
+    self.vector = (angle,z)
 
 Here we check to see if the ``area``
 contains the new position of the ball (it always should, so we needn't have an ``else`` clause,


### PR DESCRIPTION
Just minor whitespace changes to our docs rst files, to make all spacing consistent.

Our docs generation system was complaining about bad indentation/spacing for the bufferproxy docs, this PR fixes that.