### PR TITLE
Fix failing CI

### DIFF
--- a/.github/workflows/build-debian-multiarch.yml
+++ b/.github/workflows/build-debian-multiarch.yml
@@ -68,7 +68,7 @@ jobs:
     - uses: actions/checkout@v4.2.2
 
     - name: Build sources and run tests
-      uses: uraimo/run-on-arch-action@v2.8.1
+      uses: uraimo/run-on-arch-action@v3.0.0
       id: build
       with:
         arch: ${{ matrix.base_image && 'none' || matrix.arch }}
@@ -134,7 +134,7 @@ jobs:
         done
 
     - name: Test armv7 wheel on armv6
-      uses: uraimo/run-on-arch-action@v2.8.1
+      uses: uraimo/run-on-arch-action@v3.0.0
       with:
         arch: armv6
         distro: bookworm


### PR DESCRIPTION
Updating to [the newest release of this action](https://github.com/uraimo/run-on-arch-action/releases/tag/v3.0.0) will hopefully fix our fails