### PR TITLE
Fix meson warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,8 +7,9 @@ project(
     ).stdout().strip(),
     default_options: [
         # the warning level is set in code below, gives more flexibility there
-        'warning_level=0',
+        'warning_level=3',
     ],
+    meson_version: '>= 1.3.0'
 )
 
 defines = run_command(
@@ -387,7 +388,7 @@ warnings_temp_mask = []
 
 if cc.get_argument_syntax() == 'msvc'
     # base warnings on msvc
-    add_global_arguments(['/W3', '/wd4142', '/wd4996'], language: 'c')
+    add_global_arguments(['/wd4142', '/wd4996'], language: 'c')
 
     warnings_temp_mask += ['/wd6385', '/wd6386']
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,15 +24,15 @@ option('midi', type: 'feature', value: 'enabled')
 # Controls whether to make a "stripped" pygame install. Enabling this disables
 # the bundling of docs/examples/tests/stubs in the wheels.
 # The default behaviour is to bundle all of these.
-option('stripped', type: 'boolean', value: 'false')
+option('stripped', type: 'boolean', value: false)
 
 # Controls whether to compile with -Werror (or its msvc equivalent). The default
 # behaviour is to not do this by default
-option('error_on_warns', type: 'boolean', value: 'false')
+option('error_on_warns', type: 'boolean', value: false)
 
 # Controls whether to error on build if generated docs are missing. Defaults to
 # false.
-option('error_docs_missing', type: 'boolean', value: 'false')
+option('error_docs_missing', type: 'boolean', value: false)
 
 # Controls whether to do a coverage build.
 # This argument must be used together with the editable install.


### PR DESCRIPTION
Small commit that should fix the following meson warnings:

```meson
..\meson_options.txt:27: WARNING: Project does not target a minimum version but uses feature deprecated since '1.1.0': "boolean option" keyword argument "value" of type str. use a boolean, not a string
..\meson_options.txt:31: WARNING: Project does not target a minimum version but uses feature deprecated since '1.1.0': "boolean option" keyword argument "value" of type str. use a boolean, not a string
..\meson_options.txt:35: WARNING: Project does not target a minimum version but uses feature deprecated since '1.1.0': "boolean option" keyword argument "value" of type str. use a boolean, not a string
..\meson.build:122: WARNING: Project does not target a minimum version but uses feature introduced in '1.3.0': fs.relative_to.
..\meson.build:130: WARNING: Project does not target a minimum version but uses feature introduced in '1.3.0': fs.relative_to.
..\meson.build:152: WARNING: Project does not target a minimum version but uses feature introduced in '1.3.0': fs.relative_to.
..\meson.build:168: WARNING: Project does not target a minimum version but uses feature introduced in '1.3.0': fs.relative_to.
..\meson.build:176: WARNING: Project does not target a minimum version but uses feature introduced in '1.3.0': fs.relative_to.
..\meson.build:391: WARNING: Consider using the built-in warning_level option instead of using "/W3".
```