### PR TITLE
Remove warning with zero size & RESIZABLE in display.set_mode

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1440,10 +1440,10 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
             ((surface->surf->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0)) {
             char buffer[150];
             char *format_string =
-                "Requested window size was smaller than minimum supported "
-                "window size on platform. Using (%d, %d) instead.";
-            snprintf(buffer, sizeof(buffer), format_string, surface->surf->w,
-                     surface->surf->h);
+                "Requested window was forcibly resized by the OS.\n\t"
+                "Requested window size: (%d, %d)\n\tNew window size: (%d, %d)";
+            snprintf(buffer, sizeof(buffer), format_string, w_actual, h_actual,
+                     surface->surf->w, surface->surf->h);
             if (PyErr_WarnEx(PyExc_RuntimeWarning, buffer, 1) != 0) {
                 return NULL;
             }

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -988,6 +988,8 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
            desktop resolution without breaking compatibility. */
             w = display_mode.w;
             h = display_mode.h;
+            w_actual = w; /* avoid warning false positives */
+            h_actual = h;
         }
 
         if (flags & PGS_FULLSCREEN) {

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -871,6 +871,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
     SDL_Surface *newownedsurf = NULL;
     int depth = 0;
     int flags = 0;
+    int zero_size = 0;
     int w, h, w_actual, h_actual;
     PyObject *size = NULL;
     int vsync = SDL_FALSE;
@@ -988,8 +989,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
            desktop resolution without breaking compatibility. */
             w = display_mode.w;
             h = display_mode.h;
-            w_actual = w; /* avoid warning false positives */
-            h_actual = h;
+            zero_size = 1;
         }
 
         if (flags & PGS_FULLSCREEN) {
@@ -1434,7 +1434,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
      * be respected enough that we don't need to issue a warning
      */
     if (!state->using_gl && ((flags & (PGS_SCALED | PGS_FULLSCREEN)) == 0) &&
-        !vsync) {
+        !vsync && (((flags & PGS_RESIZABLE) == 0) || !zero_size)) {
         if (((surface->surf->w != w_actual) ||
              (surface->surf->h != h_actual)) &&
             ((surface->surf->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0)) {


### PR DESCRIPTION
Probably fixes https://github.com/pygame-community/pygame-ce/issues/3385 .
NEW approach: don't warn if (0, 0) size is used with `pygame.RESIZABLE`. Explanation below
I humbly ask @oddbookworm (original implementation) and Kennedy Richard (issue opener) to test this PR if they can to see if it is fixed.