### PR TITLE
Fix CI by avoiding bugged version of `pyproject-metadata` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ requires = [
   "cython<=3.0.11",
   "sphinx<=8.1.3",
   "sphinx-autoapi<=3.3.2",
+  "pyproject-metadata!=0.9.1",
 ]
 build-backend = 'mesonpy'
 


### PR DESCRIPTION
`pyproject-metadata` version `0.9.1` has an incorrect dependency minimum version requirement for `packaging`, sometimes causing crashes during building, when `pyproject-metadata==0.9.1` and `packaging<23.2`. See https://github.com/pypa/pyproject-metadata/pull/239, issue got fixed but version `0.9.1` was released with the bug.

This affected #3379. Then it also failed tests on my fork's main branch, at https://github.com/aatle/pygame-ce/actions/runs/14256274454, so the fact that tests aren't failing on main right now is by chance.

Fix: Require that `pyproject-metadata` is not `0.9.1`.