### PR TITLE
Port `display.c` to SDL3

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -718,7 +718,13 @@ pg_ResizeEventWatch(void *userdata, SDL_Event *event)
     _DisplayState *state;
     SDL_Window *window;
 
-    if (event->type != SDL_WINDOWEVENT) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    if (event->type >= SDL_EVENT_WINDOW_FIRST &&
+        event->type <= SDL_EVENT_WINDOW_LAST)
+#else
+    if (event->type == SDL_WINDOWEVENT)
+#endif
+    {
         return 0;
     }
 
@@ -3067,7 +3073,11 @@ pg_message_box(PyObject *self, PyObject *arg, PyObject *kwargs)
     if (buttons == NULL) {
         buttons_data = malloc(sizeof(SDL_MessageBoxButtonData));
         buttons_data->flags = 0;
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+        buttons_data->buttonID = 0;
+#else
         buttons_data->buttonid = 0;
+#endif
         buttons_data->text = "OK";
 
         msgbox_data.numbuttons = 1;
@@ -3141,6 +3151,19 @@ pg_message_box(PyObject *self, PyObject *arg, PyObject *kwargs)
             }
 
             buttons_data[i].text = btn_name;
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+            buttons_data[i].buttonID = (int)i;
+            buttons_data[i].flags = 0;
+            if (return_button_index == buttons_data[i].buttonID) {
+                buttons_data[i].flags |=
+                    SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT;
+            }
+            if (escape_button_used &&
+                escape_button_index == buttons_data[i].buttonID) {
+                buttons_data[i].flags |=
+                    SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT;
+            }
+#else
             buttons_data[i].buttonid = (int)i;
             buttons_data[i].flags = 0;
             if (return_button_index == buttons_data[i].buttonid) {
@@ -3152,6 +3175,7 @@ pg_message_box(PyObject *self, PyObject *arg, PyObject *kwargs)
                 buttons_data[i].flags |=
                     SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT;
             }
+#endif
         }
     }
 

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -2370,12 +2370,25 @@ pg_is_vsync(PyObject *self, PyObject *_null)
     }
 
     if (state->using_gl) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+        int interval;
+        if (!SDL_GL_GetSwapInterval(&interval)) {
+            return RAISE(pgExc_SDLError, SDL_GetError());
+        }
+        if (interval != 0) {
+            Py_RETURN_TRUE;
+        }
+        else {
+            Py_RETURN_FALSE;
+        }
+#else
         if (SDL_GL_GetSwapInterval() != 0) {
             Py_RETURN_TRUE;
         }
         else {
             Py_RETURN_FALSE;
         }
+#endif
     }
 
     Py_RETURN_FALSE;
@@ -2534,7 +2547,11 @@ pg_toggle_fullscreen(PyObject *self, PyObject *_null)
     */
     if (state->using_gl) {
         p_glViewport = (GL_glViewport_Func)SDL_GL_GetProcAddress("glViewport");
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+        SDL_GetWindowSizeInPixels(win, &w, &h);
+#else
         SDL_GL_GetDrawableSize(win, &w, &h);
+#endif
     }
     else {
         w = display_surface->surf->w;

--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -284,8 +284,14 @@ typedef struct {
     Uint32 blit_sw_A : 1;
     Uint32 blit_fill : 1;
     Uint32 video_mem;
+#if PG_SDL3
+    /* We cannot use PG_PixelFormat here because it aliases to const */
+    SDL_PixelFormatDetails *vfmt;
+    SDL_PixelFormatDetails vfmt_data;
+#else
     SDL_PixelFormat *vfmt;
     SDL_PixelFormat vfmt_data;
+#endif
     int current_w;
     int current_h;
 } pg_VideoInfo;

--- a/src_c/meson.build
+++ b/src_c/meson.build
@@ -27,8 +27,6 @@ constants = py.extension_module(
     subdir: pg,
 )
 
-# TODO: support SDL3
-if sdl_api != 3
 display = py.extension_module(
     'display',
     'display.c',
@@ -37,7 +35,6 @@ display = py.extension_module(
     install: true,
     subdir: pg,
 )
-endif
 
 event = py.extension_module(
     'event',

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -331,6 +331,10 @@ pg_window_set_fullscreen(SDL_Window *window, int desktop)
             goto end;
         }
     }
+
+    if (!SDL_SetWindowFullscreen(window, 1)) {
+        goto end;
+    }
     if (!SDL_SetWindowFullscreenMode(window, chosen_mode)) {
         goto end;
     }


### PR DESCRIPTION
WIP to port `display.c` to SDL3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - SDL3 compatibility for display and window management.
  - Updated display enumeration, mode queries, and refresh rate reporting.
  - Unified integer scaling behavior across SDL2 and SDL3.
  - Improved window/WM info retrieval and fullscreen handling.

- Bug Fixes
  - More reliable fullscreen transitions and state detection across platforms.
  - Safer pixel format handling.

- Refactor
  - Broad internal updates to support dual SDL2/SDL3 code paths without changing public APIs.

- Chores
  - Display module is now always built.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->