### PR TITLE
Fix SRCALPHA TGA image saving

### DIFF
--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1690,7 +1690,7 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
     int alpha = 0;
     struct TGAheader h;
     int srcbpp;
-    Uint8 surf_alpha;
+    SDL_BlendMode surf_blendmode;
     int have_surf_colorkey = 0;
     Uint32 surf_colorkey;
     SDL_Rect r;
@@ -1721,7 +1721,15 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
     SDL_PixelFormatEnum output_format;
 #endif
 
-    SDL_GetSurfaceAlphaMod(surface, &surf_alpha);
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    if (!SDL_GetSurfaceBlendMode(surface, &surf_blendmode))
+#else
+    if (SDL_GetSurfaceBlendMode(surface, &surf_blendmode) < 0)
+#endif
+    {
+        PyErr_SetString(pgExc_SDLError, SDL_GetError());
+        return -1;
+    }
     if ((have_surf_colorkey = SDL_HasColorKey(surface))) {
         SDL_GetColorKey(surface, &surf_colorkey);
     }
@@ -1811,12 +1819,8 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
         }
     }
 
-    /* Temporarily remove colorkey and alpha from surface so copies are
-       opaque */
-    SDL_SetSurfaceAlphaMod(surface, SDL_ALPHA_OPAQUE);
-    if (have_surf_colorkey) {
-        SDL_SetColorKey(surface, SDL_FALSE, surf_colorkey);
-    }
+    /* Temporarily set SDL_BLENDMODE_NONE so that copies are opaque */
+    SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE);
 
     r.x = 0;
     r.w = surface->w;
@@ -1847,10 +1851,7 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
     }
 
     /* restore flags */
-    SDL_SetSurfaceAlphaMod(surface, surf_alpha);
-    if (have_surf_colorkey) {
-        SDL_SetColorKey(surface, SDL_TRUE, surf_colorkey);
-    }
+    SDL_SetSurfaceBlendMode(surface, surf_blendmode);
 
     free(rlebuf);
     SDL_FreeSurface(linebuf);

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -4,6 +4,7 @@ import glob
 import io
 import os
 import pathlib
+import random
 import tempfile
 import unittest
 from concurrent.futures import ThreadPoolExecutor
@@ -405,6 +406,39 @@ class ImageModuleTest(unittest.TestCase):
             for pixelnum, pixelval in enumerate(result_pixels):
                 y, x = divmod(pixelnum, 3)
                 self.assertEqual(s2.get_at((x, y)), pixelval)
+        finally:
+            # clean up the temp file, even if test fails
+            os.remove(temp_filename)
+
+    def test_save_tga_srcalpha(self):
+        WIDTH = 10
+        HEIGHT = 10
+        s = pygame.Surface((WIDTH, HEIGHT), pygame.SRCALPHA)
+        pixels = [
+            [
+                (
+                    random.randint(0, 255),
+                    random.randint(0, 255),
+                    random.randint(0, 255),
+                    random.randint(0, 255),
+                )
+                for _ in range(WIDTH)
+            ]
+            for _ in range(HEIGHT)
+        ]
+        for y in range(HEIGHT):
+            for x in range(WIDTH):
+                s.set_at((x, y), pixels[y][x])
+
+        with tempfile.NamedTemporaryFile(suffix=".tga", delete=False) as f:
+            temp_filename = f.name
+
+        try:
+            pygame.image.save(s, temp_filename)
+            s2 = pygame.image.load(temp_filename)
+            for y in range(HEIGHT):
+                for x in range(WIDTH):
+                    self.assertEqual(s2.get_at((x, y)), pixels[y][x])
         finally:
             # clean up the temp file, even if test fails
             os.remove(temp_filename)


### PR DESCRIPTION
This PR is a fix for an issue @fladd raised on the og pygame repo.

Essentially, images with per pixel alpha were not being saved to TGA correctly because there was blending happening in intermediate steps that should not happen. This was being prevented for blanket alpha and color key alpha cases already in the code, but not for per pixel alpha cases. This PR implements a more generic blendmode based approach so that all cases are handled correctly.

Reproducer code for this issue (by @fladd, from the original issue)

```python3
import pygame

pygame.init()
screen = pygame.display.set_mode((800, 600))

circle_color = (255, 0, 0, 255)
circle_surface = pygame.Surface((800, 600), pygame.SRCALPHA)
pygame.draw.circle(circle_surface, circle_color, (400, 300), 100)

# Save the circle surface as an image
pygame.image.save(circle_surface, 'image.tga')
```