### PR TITLE
Port over some SDL functions to SDL3

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -134,6 +134,8 @@ PG_GetSurfaceFormat(SDL_Surface *surf)
 #define PG_SetPaletteColors SDL_SetPaletteColors
 #define PG_SetSurfaceBlendMode SDL_SetSurfaceBlendMode
 #define PG_GetSurfaceBlendMode SDL_GetSurfaceBlendMode
+#define PG_GetSurfaceAlphaMod SDL_GetSurfaceAlphaMod
+#define PG_SetSurfaceAlphaMod SDL_SetSurfaceAlphaMod
 
 #define PG_GetRGBA SDL_GetRGBA
 #define PG_GetRGB SDL_GetRGB
@@ -253,6 +255,18 @@ static inline bool
 PG_GetSurfaceBlendMode(SDL_Surface *surface, SDL_BlendMode *blendMode)
 {
     return SDL_GetSurfaceBlendMode(surface, blendMode) == 0;
+}
+
+static inline bool
+PG_GetSurfaceAlphaMod(SDL_Surface *surface, Uint8 *alpha)
+{
+    return SDL_GetSurfaceAlphaMod(surface, alpha) == 0;
+}
+
+static inline bool
+PG_SetSurfaceAlphaMod(SDL_Surface *surface, Uint8 alpha)
+{
+    return SDL_SetSurfaceAlphaMod(surface, alpha) == 0;
 }
 
 // NOTE:

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -132,6 +132,8 @@ PG_GetSurfaceFormat(SDL_Surface *surf)
 
 #define PG_GetSurfacePalette SDL_GetSurfacePalette
 #define PG_SetPaletteColors SDL_SetPaletteColors
+#define PG_SetSurfaceBlendMode SDL_SetSurfaceBlendMode
+#define PG_GetSurfaceBlendMode SDL_GetSurfaceBlendMode
 
 #define PG_GetRGBA SDL_GetRGBA
 #define PG_GetRGB SDL_GetRGB
@@ -239,6 +241,18 @@ PG_SetPaletteColors(SDL_Palette *palette, const SDL_Color *colors,
                     int firstcolor, int ncolors)
 {
     return SDL_SetPaletteColors(palette, colors, firstcolor, ncolors) == 0;
+}
+
+static inline bool
+PG_SetSurfaceBlendMode(SDL_Surface *surface, SDL_BlendMode blendMode)
+{
+    return SDL_SetSurfaceBlendMode(surface, blendMode) == 0;
+}
+
+static inline bool
+PG_GetSurfaceBlendMode(SDL_Surface *surface, SDL_BlendMode *blendMode)
+{
+    return SDL_GetSurfaceBlendMode(surface, blendMode) == 0;
 }
 
 // NOTE:

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -131,6 +131,7 @@ PG_GetSurfaceFormat(SDL_Surface *surf)
 }
 
 #define PG_GetSurfacePalette SDL_GetSurfacePalette
+#define PG_SetPaletteColors SDL_SetPaletteColors
 
 #define PG_GetRGBA SDL_GetRGBA
 #define PG_GetRGB SDL_GetRGB
@@ -231,6 +232,13 @@ static inline SDL_Palette *
 PG_GetSurfacePalette(SDL_Surface *surf)
 {
     return surf->format->palette;
+}
+
+static inline bool
+PG_SetPaletteColors(SDL_Palette *palette, const SDL_Color *colors,
+                    int firstcolor, int ncolors)
+{
+    return SDL_SetPaletteColors(palette, colors, firstcolor, ncolors) == 0;
 }
 
 // NOTE:

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -127,8 +127,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
         if ((info.src_has_colorkey = SDL_HasColorKey(src))) {
             SDL_GetColorKey(src, &info.src_colorkey);
         }
-        if (SDL_GetSurfaceBlendMode(src, &info.src_blend) ||
-            SDL_GetSurfaceBlendMode(dst, &info.dst_blend)) {
+        if (!PG_GetSurfaceBlendMode(src, &info.src_blend) ||
+            !PG_GetSurfaceBlendMode(dst, &info.dst_blend)) {
             okay = 0;
         }
         if (okay) {

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -494,7 +494,7 @@ _PGFT_Render_NewSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
         colors[0].g = ~colors[1].g;
         colors[0].b = ~colors[1].b;
         colors[0].a = SDL_ALPHA_OPAQUE;
-        if (SDL_SetPaletteColors(palette, colors, 0, 2)) {
+        if (!PG_SetPaletteColors(palette, colors, 0, 2)) {
             PyErr_Format(PyExc_SystemError,
                          "Pygame bug in _PGFT_Render_NewSurface: %.200s",
                          SDL_GetError());

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -1210,8 +1210,8 @@ make_surface(PyObject *self, PyObject *arg)
     if (SDL_ISPIXELFORMAT_INDEXED(PG_SURF_FORMATENUM(surf))) {
         /* Give the surface something other than an all white palette.
          *          */
-        if (SDL_SetPaletteColors(palette, default_palette_colors, 0,
-                                 default_palette_size - 1) != 0) {
+        if (!PG_SetPaletteColors(palette, default_palette_colors, 0,
+                                 default_palette_size - 1)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(surf);
             return 0;

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -287,12 +287,7 @@ _copy_colorplane(Py_buffer *view_p, SDL_Surface *surf,
                      intsize);
         return -1;
     }
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-    if (!SDL_GetSurfaceBlendMode(surf, &mode))
-#else
-    if (SDL_GetSurfaceBlendMode(surf, &mode) < 0)
-#endif
-    {
+    if (!PG_GetSurfaceBlendMode(surf, &mode)) {
         PyErr_SetString(pgExc_SDLError, SDL_GetError());
         return -1;
     }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1517,12 +1517,12 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
             return RAISE(PyExc_TypeError, "invalid alpha argument");
         }
 
-        if (SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_BLEND) != 0) {
+        if (!PG_SetSurfaceBlendMode(surf, SDL_BLENDMODE_BLEND)) {
             return RAISE(pgExc_SDLError, SDL_GetError());
         }
     }
     else {
-        if (SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE) != 0) {
+        if (!PG_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE)) {
             return RAISE(pgExc_SDLError, SDL_GetError());
         }
     }
@@ -1539,7 +1539,7 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
 
     if (alpha == 255 && (PG_SURF_BytesPerPixel(surf) == 1)) {
         /* Can't blend with a surface alpha of 255 and 8bit surfaces */
-        if (SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE) != 0) {
+        if (!PG_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE)) {
             return RAISE(pgExc_SDLError, SDL_GetError());
         }
     }
@@ -1582,7 +1582,7 @@ surf_get_alpha(pgSurfaceObject *self, PyObject *_null)
 
     SURF_INIT_CHECK(surf)
 
-    if (SDL_GetSurfaceBlendMode(surf, &mode) != 0) {
+    if (!PG_GetSurfaceBlendMode(surf, &mode)) {
         return RAISE(pgExc_SDLError, SDL_GetError());
     }
 
@@ -1605,7 +1605,7 @@ surf_get_blendmode(PyObject *self, PyObject *_null)
 
     SURF_INIT_CHECK(surf)
 
-    if (SDL_GetSurfaceBlendMode(surf, &mode) != 0) {
+    if (!PG_GetSurfaceBlendMode(surf, &mode)) {
         return RAISE(pgExc_SDLError, SDL_GetError());
     }
     return PyLong_FromLong((long)mode);
@@ -2970,7 +2970,7 @@ static int
 _PgSurface_SrcAlpha(SDL_Surface *surf)
 {
     SDL_BlendMode mode;
-    if (SDL_GetSurfaceBlendMode(surf, &mode) < 0) {
+    if (!PG_GetSurfaceBlendMode(surf, &mode)) {
         PyErr_SetString(pgExc_SDLError, SDL_GetError());
         return -1;
     }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -674,8 +674,8 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
         /* Give the surface something other than an all white palette.
          *          */
         SDL_Palette *surf_palette = SDL_CreateSurfacePalette(surface);
-        if (SDL_SetPaletteColors(surf_palette, default_palette_colors, 0,
-                                 default_palette_size - 1) != 0) {
+        if (!PG_SetPaletteColors(surf_palette, default_palette_colors, 0,
+                                 default_palette_size - 1)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(surface);
             return -1;
@@ -858,9 +858,9 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
     if (SDL_ISPIXELFORMAT_INDEXED(PG_SURF_FORMATENUM(surface))) {
         /* Give the surface something other than an all white palette.
          *          */
-        if (SDL_SetPaletteColors(surface->format->palette,
+        if (!PG_SetPaletteColors(surface->format->palette,
                                  default_palette_colors, 0,
-                                 default_palette_size - 1) != 0) {
+                                 default_palette_size - 1)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(surface);
             return -1;
@@ -1332,7 +1332,7 @@ surf_set_palette(PyObject *self, PyObject *seq)
     }
 
     if (!pal) {
-        return RAISE(pgExc_SDLError, "Surface is not palettitized\n");
+        return RAISE(pgExc_SDLError, "Surface is not palettized\n");
     }
     old_colors = pal->colors;
 
@@ -1360,8 +1360,7 @@ surf_set_palette(PyObject *self, PyObject *seq)
         colors[i].a = (unsigned char)old_colors[i].a;
     }
 
-    ecode = SDL_SetPaletteColors(pal, colors, 0, len);
-    if (ecode != 0) {
+    if (!PG_SetPaletteColors(pal, colors, 0, len)) {
         return RAISE(pgExc_SDLError, SDL_GetError());
     }
     Py_RETURN_NONE;
@@ -1405,7 +1404,7 @@ surf_set_palette_at(PyObject *self, PyObject *args)
     color.b = rgba[2];
     color.a = pal->colors[_index].a; /* May be a colorkey color. */
 
-    if (SDL_SetPaletteColors(pal, &color, _index, 1) != 0) {
+    if (!PG_SetPaletteColors(pal, &color, _index, 1)) {
         return RAISE(pgExc_SDLError, SDL_GetError());
     }
 
@@ -3232,7 +3231,7 @@ surf_subsurface(PyObject *self, PyObject *args)
             SDL_FreeSurface(sub);
             return NULL;
         }
-        if (SDL_SetPaletteColors(pal, colors, 0, ncolors) != 0) {
+        if (!PG_SetPaletteColors(pal, colors, 0, ncolors)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreePalette(pal);
             SDL_FreeSurface(sub);

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -95,12 +95,7 @@ _PgSurface_SrcAlpha(SDL_Surface *surf)
 {
     if (SDL_ISPIXELFORMAT_ALPHA(PG_SURF_FORMATENUM(surf))) {
         SDL_BlendMode mode;
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-        if (!SDL_GetSurfaceBlendMode(surf, &mode))
-#else
-        if (SDL_GetSurfaceBlendMode(surf, &mode) < 0)
-#endif
-        {
+        if (!PG_GetSurfaceBlendMode(surf, &mode)) {
             return -1;
         }
         if (mode == SDL_BLENDMODE_BLEND) {
@@ -181,7 +176,7 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
 
     isalpha = _PgSurface_SrcAlpha(surf);
     if (isalpha == 1) {
-        if (SDL_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_BLEND) != 0) {
+        if (!PG_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_BLEND)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
             return NULL;
@@ -193,7 +188,7 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
         return NULL;
     }
     else {
-        if (SDL_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_NONE) != 0) {
+        if (!PG_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_NONE)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
             return NULL;

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -158,8 +158,8 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
             return NULL;
         }
 
-        if (SDL_SetPaletteColors(newsurf_palette, surf_palette->colors, 0,
-                                 surf_palette->ncolors) != 0) {
+        if (!PG_SetPaletteColors(newsurf_palette, surf_palette->colors, 0,
+                                 surf_palette->ncolors)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
             return NULL;

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -104,7 +104,7 @@ _PgSurface_SrcAlpha(SDL_Surface *surf)
     }
     else {
         Uint8 color = SDL_ALPHA_OPAQUE;
-        if (SDL_GetSurfaceAlphaMod(surf, &color) != 0) {
+        if (!PG_GetSurfaceAlphaMod(surf, &color)) {
             return -1;
         }
         if (color != SDL_ALPHA_OPAQUE) {
@@ -161,13 +161,13 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
         }
     }
 
-    if (SDL_GetSurfaceAlphaMod(surf, &alpha) != 0) {
+    if (!PG_GetSurfaceAlphaMod(surf, &alpha)) {
         PyErr_SetString(pgExc_SDLError, SDL_GetError());
         SDL_FreeSurface(newsurf);
         return NULL;
     }
     if (alpha != 255) {
-        if (SDL_SetSurfaceAlphaMod(newsurf, alpha) != 0) {
+        if (!PG_SetSurfaceAlphaMod(newsurf, alpha)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
             return NULL;


### PR DESCRIPTION
There are a lot of functions that used to return 0 on success, negative error code on failure that in SDL3 return true on success and false on failure. This means our old code compiles but fails at runtime. This PR ports a few of them.

This PR introduces little PG_ compat macros for SDL_SetPaletteColors, SDL_SetSurfaceBlendMode, SDL_GetSurfaceBlendMode, SDL_GetSurfaceAlphaMod, SDL_SetSurfaceAlphaMod.

I only replaced instances of these functions that are actually error checked, I didn't replace them globally. I also fixed a typo in an error message in surf_set_palette.