### PR TITLE
Surface module compiling in SDL3

### DIFF
--- a/src_c/_surface.h
+++ b/src_c/_surface.h
@@ -27,4 +27,28 @@
 #include "_pygame.h"
 #include "surface.h"
 
+// Some simd compat stuff going here for now.
+#if PG_SDL3
+// SDL3 no longer includes intrinsics by default, we need to do it explicitly
+#include <SDL3/SDL_intrin.h>
+
+/* If SDL_AVX2_INTRINSICS is defined by SDL3, we need to set macros that our
+ * code checks for avx2 build time support */
+#ifdef SDL_AVX2_INTRINSICS
+#ifndef HAVE_IMMINTRIN_H
+#define HAVE_IMMINTRIN_H 1
+#endif /* HAVE_IMMINTRIN_H*/
+#ifndef __AVX2__
+#define __AVX2__
+#endif /* __AVX2__*/
+#endif /* SDL_AVX2_INTRINSICS*/
+
+// TODO reenable this to test best
+#ifdef SDL_SSE2_INTRINSICS
+#ifndef __SSE2__
+#define __SSE2__
+#endif /* __SSE2__*/
+#endif /* SDL_SSE2_INTRINSICS*/
+#endif /* PG_SDL3 */
+
 #endif

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -1715,18 +1715,18 @@ premul_surf_color_by_alpha(SDL_Surface *src, SDL_Surface *dst)
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
     if ((PG_SURF_BytesPerPixel(src) == 4) && pg_has_avx2()) {
-        premul_surf_color_by_alpha_avx2(src, dst);
+        premul_surf_color_by_alpha_avx2(src, src_format, dst);
         return 0;
     }
 #if defined(__SSE2__)
     if ((PG_SURF_BytesPerPixel(src) == 4) && SDL_HasSSE2()) {
-        premul_surf_color_by_alpha_sse2(src, dst);
+        premul_surf_color_by_alpha_sse2(src, src_format, dst);
         return 0;
     }
 #endif /* __SSE2__*/
 #if PG_ENABLE_ARM_NEON
     if ((PG_SURF_BytesPerPixel(src) == 4) && SDL_HasNEON()) {
-        premul_surf_color_by_alpha_sse2(src, dst);
+        premul_surf_color_by_alpha_sse2(src, src_format, dst);
         return 0;
     }
 #endif /* PG_ENABLE_ARM_NEON */

--- a/src_c/meson.build
+++ b/src_c/meson.build
@@ -84,8 +84,6 @@ rwobject = py.extension_module(
     subdir: pg,
 )
 
-# TODO: support SDL3
-if sdl_api != 3
 simd_blitters_avx2 = static_library(
     'simd_blitters_avx2',
     'simd_blitters_avx2.c',
@@ -132,7 +130,6 @@ surface = py.extension_module(
     install: true,
     subdir: pg,
 )
-endif
 
 surflock = py.extension_module(
     'surflock',

--- a/src_c/simd_blitters.h
+++ b/src_c/simd_blitters.h
@@ -55,7 +55,8 @@ premul_surf_color_by_alpha_non_simd(SDL_Surface *src,
                                     PG_PixelFormat *dst_format,
                                     SDL_Palette *dst_palette);
 void
-premul_surf_color_by_alpha_sse2(SDL_Surface *src, SDL_Surface *dst);
+premul_surf_color_by_alpha_sse2(SDL_Surface *src, PG_PixelFormat *srcfmt,
+                                SDL_Surface *dst);
 
 void
 alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info);
@@ -86,4 +87,5 @@ blit_blend_rgb_min_avx2(SDL_BlitInfo *info);
 void
 blit_blend_premultiplied_avx2(SDL_BlitInfo *info);
 void
-premul_surf_color_by_alpha_avx2(SDL_Surface *src, SDL_Surface *dst);
+premul_surf_color_by_alpha_avx2(SDL_Surface *src, PG_PixelFormat *src_format,
+                                SDL_Surface *dst);

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -1561,7 +1561,8 @@ blit_blend_premultiplied_avx2(SDL_BlitInfo *info)
 #if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
     !defined(SDL_DISABLE_IMMINTRIN_H)
 void
-premul_surf_color_by_alpha_avx2(SDL_Surface *src, SDL_Surface *dst)
+premul_surf_color_by_alpha_avx2(SDL_Surface *src, PG_PixelFormat *src_format,
+                                SDL_Surface *dst)
 {
     int i, height = src->h;
     const int width = src->w;
@@ -1578,7 +1579,7 @@ premul_surf_color_by_alpha_avx2(SDL_Surface *src, SDL_Surface *dst)
     __m256i mm_src, mm_dst, alphaA, alphaB, mm_alpha_in;
     __m256i mm_srcA, mm_srcB;
 
-    const __m256i mm256_amask = _mm256_set1_epi32(src->format->Amask);
+    const __m256i mm256_amask = _mm256_set1_epi32(src_format->Amask);
     const __m256i mm_zero = _mm256_setzero_si256();
     const __m256i partial_mask =
         _mm256_set_epi32(0, pxl_excess > 6 ? -1 : 0, pxl_excess > 5 ? -1 : 0,
@@ -1587,10 +1588,10 @@ premul_surf_color_by_alpha_avx2(SDL_Surface *src, SDL_Surface *dst)
                          pxl_excess > 0 ? -1 : 0);
     const __m256i mm256_ones = _mm256_set1_epi16(0x0001);
 
-    char _a_off = ((src->format->Amask >> 8) == 0)    ? 0
-                  : ((src->format->Amask >> 16) == 0) ? 1
-                  : ((src->format->Amask >> 24) == 0) ? 2
-                                                      : 3;
+    char _a_off = ((src_format->Amask >> 8) == 0)    ? 0
+                  : ((src_format->Amask >> 16) == 0) ? 1
+                  : ((src_format->Amask >> 24) == 0) ? 2
+                                                     : 3;
 
     /* masks for shuffling the alpha to the RGB channels for multiplication */
     const __m256i shuffle_maskA = _mm256_set_epi8(
@@ -1637,7 +1638,8 @@ premul_surf_color_by_alpha_avx2(SDL_Surface *src, SDL_Surface *dst)
 }
 #else
 void
-premul_surf_color_by_alpha_avx2(SDL_Surface *src, SDL_Surface *dst)
+premul_surf_color_by_alpha_avx2(SDL_Surface *src, PG_PixelFormat *src_format,
+                                SDL_Surface *dst)
 {
     BAD_AVX2_FUNCTION_CALL;
 }

--- a/src_c/simd_blitters_sse2.c
+++ b/src_c/simd_blitters_sse2.c
@@ -151,8 +151,8 @@ alphablit_alpha_sse2_argb_surf_alpha(SDL_BlitInfo *info)
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
 
-    SDL_PixelFormat *srcfmt = info->src;
-    SDL_PixelFormat *dstfmt = info->dst;
+    PG_PixelFormat *srcfmt = info->src;
+    PG_PixelFormat *dstfmt = info->dst;
 
     // int srcbpp = PG_FORMAT_BytesPerPixel(srcfmt);
     // int dstbpp = PG_FORMAT_BytesPerPixel(dstfmt);
@@ -293,8 +293,8 @@ alphablit_alpha_sse2_argb_no_surf_alpha(SDL_BlitInfo *info)
     int height = info->height;
     int srcskip = info->s_skip >> 2;
     int dstskip = info->d_skip >> 2;
-    SDL_PixelFormat *srcfmt = info->src;
-    SDL_PixelFormat *dstfmt = info->dst;
+    PG_PixelFormat *srcfmt = info->src;
+    PG_PixelFormat *dstfmt = info->dst;
 
     /* Original 'Straight Alpha' blending equation:
        --------------------------------------------
@@ -719,7 +719,7 @@ blit_blend_premultiplied_sse2(SDL_BlitInfo *info)
     int srcskip = info->s_skip >> 2;
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
-    SDL_PixelFormat *srcfmt = info->src;
+    PG_PixelFormat *srcfmt = info->src;
     Uint32 amask = srcfmt->Amask;
     // Uint64 multmask;
     Uint64 ones;
@@ -787,15 +787,14 @@ blit_blend_premultiplied_sse2(SDL_BlitInfo *info)
 }
 
 void
-premul_surf_color_by_alpha_sse2(SDL_Surface *src, SDL_Surface *dst)
+premul_surf_color_by_alpha_sse2(SDL_Surface *src, PG_PixelFormat *srcfmt,
+                                SDL_Surface *dst)
 {
     int n;
     int width = src->w;
     int height = src->h;
     Uint32 *srcp = (Uint32 *)src->pixels;
     Uint32 *dstp = (Uint32 *)dst->pixels;
-
-    SDL_PixelFormat *srcfmt = src->format;
     Uint32 amask = srcfmt->Amask;
     Uint64 ones;
 

--- a/src_c/simd_fill.h
+++ b/src_c/simd_fill.h
@@ -40,64 +40,84 @@ _pg_HasSSE_NEON();
 
 // AVX2 functions
 int
-surface_fill_blend_add_avx2(SDL_Surface *surface, SDL_Rect *rect,
+surface_fill_blend_add_avx2(SDL_Surface *surface,
+                            PG_PixelFormat *surface_format, SDL_Rect *rect,
                             Uint32 color);
 int
-surface_fill_blend_rgba_add_avx2(SDL_Surface *surface, SDL_Rect *rect,
-                                 Uint32 color);
+surface_fill_blend_rgba_add_avx2(SDL_Surface *surface,
+                                 PG_PixelFormat *surface_format,
+                                 SDL_Rect *rect, Uint32 color);
 
 int
-surface_fill_blend_sub_avx2(SDL_Surface *surface, SDL_Rect *rect,
+surface_fill_blend_sub_avx2(SDL_Surface *surface,
+                            PG_PixelFormat *surface_format, SDL_Rect *rect,
                             Uint32 color);
 int
-surface_fill_blend_rgba_sub_avx2(SDL_Surface *surface, SDL_Rect *rect,
-                                 Uint32 color);
+surface_fill_blend_rgba_sub_avx2(SDL_Surface *surface,
+                                 PG_PixelFormat *surface_format,
+                                 SDL_Rect *rect, Uint32 color);
 int
-surface_fill_blend_mult_avx2(SDL_Surface *surface, SDL_Rect *rect,
+surface_fill_blend_mult_avx2(SDL_Surface *surface,
+                             PG_PixelFormat *surface_format, SDL_Rect *rect,
                              Uint32 color);
 int
-surface_fill_blend_rgba_mult_avx2(SDL_Surface *surface, SDL_Rect *rect,
-                                  Uint32 color);
+surface_fill_blend_rgba_mult_avx2(SDL_Surface *surface,
+                                  PG_PixelFormat *surface_format,
+                                  SDL_Rect *rect, Uint32 color);
 int
-surface_fill_blend_min_avx2(SDL_Surface *surface, SDL_Rect *rect,
+surface_fill_blend_min_avx2(SDL_Surface *surface,
+                            PG_PixelFormat *surface_format, SDL_Rect *rect,
                             Uint32 color);
 int
-surface_fill_blend_rgba_min_avx2(SDL_Surface *surface, SDL_Rect *rect,
-                                 Uint32 color);
+surface_fill_blend_rgba_min_avx2(SDL_Surface *surface,
+                                 PG_PixelFormat *surface_format,
+                                 SDL_Rect *rect, Uint32 color);
 int
-surface_fill_blend_max_avx2(SDL_Surface *surface, SDL_Rect *rect,
+surface_fill_blend_max_avx2(SDL_Surface *surface,
+                            PG_PixelFormat *surface_format, SDL_Rect *rect,
                             Uint32 color);
 int
-surface_fill_blend_rgba_max_avx2(SDL_Surface *surface, SDL_Rect *rect,
-                                 Uint32 color);
+surface_fill_blend_rgba_max_avx2(SDL_Surface *surface,
+                                 PG_PixelFormat *surface_format,
+                                 SDL_Rect *rect, Uint32 color);
 // SSE2 functions
 int
-surface_fill_blend_add_sse2(SDL_Surface *surface, SDL_Rect *rect,
+surface_fill_blend_add_sse2(SDL_Surface *surface,
+                            PG_PixelFormat *surface_format, SDL_Rect *rect,
                             Uint32 color);
 int
-surface_fill_blend_rgba_add_sse2(SDL_Surface *surface, SDL_Rect *rect,
-                                 Uint32 color);
+surface_fill_blend_rgba_add_sse2(SDL_Surface *surface,
+                                 PG_PixelFormat *surface_format,
+                                 SDL_Rect *rect, Uint32 color);
 int
-surface_fill_blend_sub_sse2(SDL_Surface *surface, SDL_Rect *rect,
+surface_fill_blend_sub_sse2(SDL_Surface *surface,
+                            PG_PixelFormat *surface_format, SDL_Rect *rect,
                             Uint32 color);
 int
-surface_fill_blend_rgba_sub_sse2(SDL_Surface *surface, SDL_Rect *rect,
-                                 Uint32 color);
+surface_fill_blend_rgba_sub_sse2(SDL_Surface *surface,
+                                 PG_PixelFormat *surface_format,
+                                 SDL_Rect *rect, Uint32 color);
 int
-surface_fill_blend_mult_sse2(SDL_Surface *surface, SDL_Rect *rect,
+surface_fill_blend_mult_sse2(SDL_Surface *surface,
+                             PG_PixelFormat *surface_format, SDL_Rect *rect,
                              Uint32 color);
 int
-surface_fill_blend_rgba_mult_sse2(SDL_Surface *surface, SDL_Rect *rect,
-                                  Uint32 color);
+surface_fill_blend_rgba_mult_sse2(SDL_Surface *surface,
+                                  PG_PixelFormat *surface_format,
+                                  SDL_Rect *rect, Uint32 color);
 int
-surface_fill_blend_min_sse2(SDL_Surface *surface, SDL_Rect *rect,
+surface_fill_blend_min_sse2(SDL_Surface *surface,
+                            PG_PixelFormat *surface_format, SDL_Rect *rect,
                             Uint32 color);
 int
-surface_fill_blend_rgba_min_sse2(SDL_Surface *surface, SDL_Rect *rect,
-                                 Uint32 color);
+surface_fill_blend_rgba_min_sse2(SDL_Surface *surface,
+                                 PG_PixelFormat *surface_format,
+                                 SDL_Rect *rect, Uint32 color);
 int
-surface_fill_blend_max_sse2(SDL_Surface *surface, SDL_Rect *rect,
+surface_fill_blend_max_sse2(SDL_Surface *surface,
+                            PG_PixelFormat *surface_format, SDL_Rect *rect,
                             Uint32 color);
 int
-surface_fill_blend_rgba_max_sse2(SDL_Surface *surface, SDL_Rect *rect,
-                                 Uint32 color);
+surface_fill_blend_rgba_max_sse2(SDL_Surface *surface,
+                                 PG_PixelFormat *surface_format,
+                                 SDL_Rect *rect, Uint32 color);

--- a/src_c/simd_surface_fill_avx2.c
+++ b/src_c/simd_surface_fill_avx2.c
@@ -47,7 +47,7 @@ _pg_has_avx2()
                          pxl_excess > 2 ? -1 : 0, pxl_excess > 1 ? -1 : 0,    \
                          pxl_excess > 0 ? -1 : 0);                            \
     /* prep and load the color */                                             \
-    Uint32 amask = surface->format->Amask;                                    \
+    Uint32 amask = surface_format->Amask;                                     \
     if (amask) {                                                              \
         {                                                                     \
             COLOR_PROCESS_CODE                                                \
@@ -105,52 +105,58 @@ _pg_has_avx2()
     /* ==== recombine A and B pixels ==== */                   \
     mm256_dst = _mm256_packus_epi16(_shuff16_temp, shuff_dst);
 
-#define FILLERS(NAME, COLOR_PROCESS_CODE, FILL_CODE)                        \
-    int surface_fill_blend_##NAME##_avx2(SDL_Surface *surface,              \
-                                         SDL_Rect *rect, Uint32 color)      \
-    {                                                                       \
-        SETUP_AVX2_FILLER(COLOR_PROCESS_CODE)                               \
-        RUN_AVX2_FILLER(FILL_CODE)                                          \
-        return 0;                                                           \
-    }                                                                       \
-    int surface_fill_blend_rgba_##NAME##_avx2(SDL_Surface *surface,         \
-                                              SDL_Rect *rect, Uint32 color) \
-    {                                                                       \
-        SETUP_AVX2_FILLER({})                                               \
-        RUN_AVX2_FILLER(FILL_CODE)                                          \
-        return 0;                                                           \
+#define FILLERS(NAME, COLOR_PROCESS_CODE, FILL_CODE)                          \
+    int surface_fill_blend_##NAME##_avx2(SDL_Surface *surface,                \
+                                         PG_PixelFormat *surface_format,      \
+                                         SDL_Rect *rect, Uint32 color)        \
+    {                                                                         \
+        SETUP_AVX2_FILLER(COLOR_PROCESS_CODE)                                 \
+        RUN_AVX2_FILLER(FILL_CODE)                                            \
+        return 0;                                                             \
+    }                                                                         \
+    int surface_fill_blend_rgba_##NAME##_avx2(SDL_Surface *surface,           \
+                                              PG_PixelFormat *surface_format, \
+                                              SDL_Rect *rect, Uint32 color)   \
+    {                                                                         \
+        SETUP_AVX2_FILLER({})                                                 \
+        RUN_AVX2_FILLER(FILL_CODE)                                            \
+        return 0;                                                             \
     }
 
-#define FILLERS_SHUFF(NAME, COLOR_PROCESS_CODE, FILL_CODE)                  \
-    int surface_fill_blend_##NAME##_avx2(SDL_Surface *surface,              \
-                                         SDL_Rect *rect, Uint32 color)      \
-    {                                                                       \
-        SETUP_AVX2_FILLER(COLOR_PROCESS_CODE)                               \
-        SETUP_SHUFFLE                                                       \
-        RUN_AVX2_FILLER(RUN_16BIT_SHUFFLE_OUT(FILL_CODE))                   \
-        return 0;                                                           \
-    }                                                                       \
-    int surface_fill_blend_rgba_##NAME##_avx2(SDL_Surface *surface,         \
-                                              SDL_Rect *rect, Uint32 color) \
-    {                                                                       \
-        SETUP_AVX2_FILLER({})                                               \
-        SETUP_SHUFFLE                                                       \
-        RUN_AVX2_FILLER(RUN_16BIT_SHUFFLE_OUT(FILL_CODE))                   \
-        return 0;                                                           \
+#define FILLERS_SHUFF(NAME, COLOR_PROCESS_CODE, FILL_CODE)                    \
+    int surface_fill_blend_##NAME##_avx2(SDL_Surface *surface,                \
+                                         PG_PixelFormat *surface_format,      \
+                                         SDL_Rect *rect, Uint32 color)        \
+    {                                                                         \
+        SETUP_AVX2_FILLER(COLOR_PROCESS_CODE)                                 \
+        SETUP_SHUFFLE                                                         \
+        RUN_AVX2_FILLER(RUN_16BIT_SHUFFLE_OUT(FILL_CODE))                     \
+        return 0;                                                             \
+    }                                                                         \
+    int surface_fill_blend_rgba_##NAME##_avx2(SDL_Surface *surface,           \
+                                              PG_PixelFormat *surface_format, \
+                                              SDL_Rect *rect, Uint32 color)   \
+    {                                                                         \
+        SETUP_AVX2_FILLER({})                                                 \
+        SETUP_SHUFFLE                                                         \
+        RUN_AVX2_FILLER(RUN_16BIT_SHUFFLE_OUT(FILL_CODE))                     \
+        return 0;                                                             \
     }
 
-#define INVALID_DEFS(NAME)                                                  \
-    int surface_fill_blend_##NAME##_avx2(SDL_Surface *surface,              \
-                                         SDL_Rect *rect, Uint32 color)      \
-    {                                                                       \
-        BAD_AVX2_FUNCTION_CALL;                                             \
-        return -1;                                                          \
-    }                                                                       \
-    int surface_fill_blend_rgba_##NAME##_avx2(SDL_Surface *surface,         \
-                                              SDL_Rect *rect, Uint32 color) \
-    {                                                                       \
-        BAD_AVX2_FUNCTION_CALL;                                             \
-        return -1;                                                          \
+#define INVALID_DEFS(NAME)                                                    \
+    int surface_fill_blend_##NAME##_avx2(SDL_Surface *surface,                \
+                                         PG_PixelFormat *surface_format,      \
+                                         SDL_Rect *rect, Uint32 color)        \
+    {                                                                         \
+        BAD_AVX2_FUNCTION_CALL;                                               \
+        return -1;                                                            \
+    }                                                                         \
+    int surface_fill_blend_rgba_##NAME##_avx2(SDL_Surface *surface,           \
+                                              PG_PixelFormat *surface_format, \
+                                              SDL_Rect *rect, Uint32 color)   \
+    {                                                                         \
+        BAD_AVX2_FUNCTION_CALL;                                               \
+        return -1;                                                            \
     }
 
 #define ADD_CODE mm256_dst = _mm256_adds_epu8(mm256_dst, mm256_color);

--- a/src_c/simd_surface_fill_sse2.c
+++ b/src_c/simd_surface_fill_sse2.c
@@ -41,7 +41,7 @@ _pg_HasSSE_NEON()
                                                                               \
     __m128i mm128_dst;                                                        \
     /* prep and load the color */                                             \
-    Uint32 amask = surface->format->Amask;                                    \
+    Uint32 amask = surface_format->Amask;                                     \
     if (amask) {                                                              \
         {                                                                     \
             COLOR_PROCESS_CODE                                                \
@@ -96,52 +96,58 @@ _pg_HasSSE_NEON()
     /* ==== recombine A and B pixels ==== */                   \
     mm128_dst = _mm_packus_epi16(_shuff16_temp, shuff_dst);
 
-#define FILLERS(NAME, COLOR_PROCESS_CODE, FILL_CODE)                        \
-    int surface_fill_blend_##NAME##_sse2(SDL_Surface *surface,              \
-                                         SDL_Rect *rect, Uint32 color)      \
-    {                                                                       \
-        SETUP_SSE2_FILLER(COLOR_PROCESS_CODE)                               \
-        RUN_SSE2_FILLER(FILL_CODE)                                          \
-        return 0;                                                           \
-    }                                                                       \
-    int surface_fill_blend_rgba_##NAME##_sse2(SDL_Surface *surface,         \
-                                              SDL_Rect *rect, Uint32 color) \
-    {                                                                       \
-        SETUP_SSE2_FILLER({})                                               \
-        RUN_SSE2_FILLER(FILL_CODE)                                          \
-        return 0;                                                           \
+#define FILLERS(NAME, COLOR_PROCESS_CODE, FILL_CODE)                          \
+    int surface_fill_blend_##NAME##_sse2(SDL_Surface *surface,                \
+                                         PG_PixelFormat *surface_format,      \
+                                         SDL_Rect *rect, Uint32 color)        \
+    {                                                                         \
+        SETUP_SSE2_FILLER(COLOR_PROCESS_CODE)                                 \
+        RUN_SSE2_FILLER(FILL_CODE)                                            \
+        return 0;                                                             \
+    }                                                                         \
+    int surface_fill_blend_rgba_##NAME##_sse2(SDL_Surface *surface,           \
+                                              PG_PixelFormat *surface_format, \
+                                              SDL_Rect *rect, Uint32 color)   \
+    {                                                                         \
+        SETUP_SSE2_FILLER({})                                                 \
+        RUN_SSE2_FILLER(FILL_CODE)                                            \
+        return 0;                                                             \
     }
 
-#define FILLERS_SHUFF(NAME, COLOR_PROCESS_CODE, FILL_CODE)                  \
-    int surface_fill_blend_##NAME##_sse2(SDL_Surface *surface,              \
-                                         SDL_Rect *rect, Uint32 color)      \
-    {                                                                       \
-        SETUP_SSE2_FILLER(COLOR_PROCESS_CODE)                               \
-        SETUP_SHUFFLE                                                       \
-        RUN_SSE2_FILLER(RUN_16BIT_SHUFFLE_OUT(FILL_CODE))                   \
-        return 0;                                                           \
-    }                                                                       \
-    int surface_fill_blend_rgba_##NAME##_sse2(SDL_Surface *surface,         \
-                                              SDL_Rect *rect, Uint32 color) \
-    {                                                                       \
-        SETUP_SSE2_FILLER({})                                               \
-        SETUP_SHUFFLE                                                       \
-        RUN_SSE2_FILLER(RUN_16BIT_SHUFFLE_OUT(FILL_CODE))                   \
-        return 0;                                                           \
+#define FILLERS_SHUFF(NAME, COLOR_PROCESS_CODE, FILL_CODE)                    \
+    int surface_fill_blend_##NAME##_sse2(SDL_Surface *surface,                \
+                                         PG_PixelFormat *surface_format,      \
+                                         SDL_Rect *rect, Uint32 color)        \
+    {                                                                         \
+        SETUP_SSE2_FILLER(COLOR_PROCESS_CODE)                                 \
+        SETUP_SHUFFLE                                                         \
+        RUN_SSE2_FILLER(RUN_16BIT_SHUFFLE_OUT(FILL_CODE))                     \
+        return 0;                                                             \
+    }                                                                         \
+    int surface_fill_blend_rgba_##NAME##_sse2(SDL_Surface *surface,           \
+                                              PG_PixelFormat *surface_format, \
+                                              SDL_Rect *rect, Uint32 color)   \
+    {                                                                         \
+        SETUP_SSE2_FILLER({})                                                 \
+        SETUP_SHUFFLE                                                         \
+        RUN_SSE2_FILLER(RUN_16BIT_SHUFFLE_OUT(FILL_CODE))                     \
+        return 0;                                                             \
     }
 
-#define INVALID_DEFS(NAME)                                                  \
-    int surface_fill_blend_##NAME##_sse2(SDL_Surface *surface,              \
-                                         SDL_Rect *rect, Uint32 color)      \
-    {                                                                       \
-        BAD_SSE2_FUNCTION_CALL;                                             \
-        return -1;                                                          \
-    }                                                                       \
-    int surface_fill_blend_rgba_##NAME##_sse2(SDL_Surface *surface,         \
-                                              SDL_Rect *rect, Uint32 color) \
-    {                                                                       \
-        BAD_SSE2_FUNCTION_CALL;                                             \
-        return -1;                                                          \
+#define INVALID_DEFS(NAME)                                                    \
+    int surface_fill_blend_##NAME##_sse2(SDL_Surface *surface,                \
+                                         PG_PixelFormat *surface_format,      \
+                                         SDL_Rect *rect, Uint32 color)        \
+    {                                                                         \
+        BAD_SSE2_FUNCTION_CALL;                                               \
+        return -1;                                                            \
+    }                                                                         \
+    int surface_fill_blend_rgba_##NAME##_sse2(SDL_Surface *surface,           \
+                                              PG_PixelFormat *surface_format, \
+                                              SDL_Rect *rect, Uint32 color)   \
+    {                                                                         \
+        BAD_SSE2_FUNCTION_CALL;                                               \
+        return -1;                                                            \
     }
 
 #define ADD_CODE mm128_dst = _mm_adds_epu8(mm128_dst, mm128_color);

--- a/src_c/simd_transform.h
+++ b/src_c/simd_transform.h
@@ -1,24 +1,6 @@
 #define NO_PYGAME_C_API
 #include "_surface.h"
 
-/* TODO: This compat code should probably go in some place like simd_shared.h
- * That header file however is inconsistently used at the moment and not
- * included wherever it should be.
- * this block will be needed by simd_blitters and simd_fill */
-
-#if PG_SDL3
-// SDL3 no longer includes intrinsics by default, we need to do it explicitly
-#include <SDL3/SDL_intrin.h>
-
-/* If SDL_AVX2_INTRINSICS is defined by SDL3, we need to set macros that our
- * code checks for avx2 build time support */
-#ifdef SDL_AVX2_INTRINSICS
-#ifndef HAVE_IMMINTRIN_H
-#define HAVE_IMMINTRIN_H 1
-#endif /* HAVE_IMMINTRIN_H*/
-#endif /* SDL_AVX2_INTRINSICS*/
-#endif /* PG_SDL3 */
-
 /**
  * MACRO borrowed from SSE2NEON - useful for making the shuffling family of
  * intrinsics easier to understand by indicating clearly what will go where.

--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -90,7 +90,8 @@ surface_respect_clip_rect(SDL_Surface *surface, SDL_Rect *rect)
 }
 
 static int
-surface_fill_blend_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
+surface_fill_blend_add(SDL_Surface *surface, PG_PixelFormat *fmt,
+                       SDL_Palette *palette, SDL_Rect *rect, Uint32 color)
 {
     Uint8 *pixels;
     int width = rect->w;
@@ -105,11 +106,7 @@ surface_fill_blend_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
-    PG_PixelFormat *fmt;
-    SDL_Palette *palette;
-    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
-        return -1;
-    }
+
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -182,7 +179,8 @@ surface_fill_blend_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 }
 
 static int
-surface_fill_blend_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
+surface_fill_blend_sub(SDL_Surface *surface, PG_PixelFormat *fmt,
+                       SDL_Palette *palette, SDL_Rect *rect, Uint32 color)
 {
     Uint8 *pixels;
     int width = rect->w;
@@ -197,11 +195,7 @@ surface_fill_blend_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
-    PG_PixelFormat *fmt;
-    SDL_Palette *palette;
-    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
-        return -1;
-    }
+
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -274,7 +268,8 @@ surface_fill_blend_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 }
 
 static int
-surface_fill_blend_mult(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
+surface_fill_blend_mult(SDL_Surface *surface, PG_PixelFormat *fmt,
+                        SDL_Palette *palette, SDL_Rect *rect, Uint32 color)
 {
     Uint8 *pixels;
     int width = rect->w;
@@ -288,11 +283,7 @@ surface_fill_blend_mult(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
-    PG_PixelFormat *fmt;
-    SDL_Palette *palette;
-    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
-        return -1;
-    }
+
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -365,7 +356,8 @@ surface_fill_blend_mult(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 }
 
 static int
-surface_fill_blend_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
+surface_fill_blend_min(SDL_Surface *surface, PG_PixelFormat *fmt,
+                       SDL_Palette *palette, SDL_Rect *rect, Uint32 color)
 {
     Uint8 *pixels;
     int width = rect->w;
@@ -379,11 +371,7 @@ surface_fill_blend_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
-    PG_PixelFormat *fmt;
-    SDL_Palette *palette;
-    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
-        return -1;
-    }
+
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -456,7 +444,8 @@ surface_fill_blend_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 }
 
 static int
-surface_fill_blend_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
+surface_fill_blend_max(SDL_Surface *surface, PG_PixelFormat *fmt,
+                       SDL_Palette *palette, SDL_Rect *rect, Uint32 color)
 {
     Uint8 *pixels;
     int width = rect->w;
@@ -470,11 +459,7 @@ surface_fill_blend_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
-    PG_PixelFormat *fmt;
-    SDL_Palette *palette;
-    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
-        return -1;
-    }
+
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -549,7 +534,8 @@ surface_fill_blend_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 /* ------------------------- */
 
 static int
-surface_fill_blend_rgba_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
+surface_fill_blend_rgba_add(SDL_Surface *surface, PG_PixelFormat *fmt,
+                            SDL_Palette *palette, SDL_Rect *rect, Uint32 color)
 {
     Uint8 *pixels;
     int width = rect->w;
@@ -564,15 +550,11 @@ surface_fill_blend_rgba_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
-    PG_PixelFormat *fmt;
-    SDL_Palette *palette;
-    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
-        return -1;
-    }
+
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     if (!ppa) {
-        return surface_fill_blend_add(surface, rect, color);
+        return surface_fill_blend_add(surface, fmt, palette, rect, color);
     }
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -623,7 +605,8 @@ surface_fill_blend_rgba_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 }
 
 static int
-surface_fill_blend_rgba_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
+surface_fill_blend_rgba_sub(SDL_Surface *surface, PG_PixelFormat *fmt,
+                            SDL_Palette *palette, SDL_Rect *rect, Uint32 color)
 {
     Uint8 *pixels;
     int width = rect->w;
@@ -638,15 +621,11 @@ surface_fill_blend_rgba_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
-    PG_PixelFormat *fmt;
-    SDL_Palette *palette;
-    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
-        return -1;
-    }
+
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     if (!ppa) {
-        return surface_fill_blend_sub(surface, rect, color);
+        return surface_fill_blend_sub(surface, fmt, palette, rect, color);
     }
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -697,7 +676,8 @@ surface_fill_blend_rgba_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 }
 
 static int
-surface_fill_blend_rgba_mult(SDL_Surface *surface, SDL_Rect *rect,
+surface_fill_blend_rgba_mult(SDL_Surface *surface, PG_PixelFormat *fmt,
+                             SDL_Palette *palette, SDL_Rect *rect,
                              Uint32 color)
 {
     Uint8 *pixels;
@@ -712,15 +692,11 @@ surface_fill_blend_rgba_mult(SDL_Surface *surface, SDL_Rect *rect,
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
-    PG_PixelFormat *fmt;
-    SDL_Palette *palette;
-    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
-        return -1;
-    }
+
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     if (!ppa) {
-        return surface_fill_blend_mult(surface, rect, color);
+        return surface_fill_blend_mult(surface, fmt, palette, rect, color);
     }
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -771,7 +747,8 @@ surface_fill_blend_rgba_mult(SDL_Surface *surface, SDL_Rect *rect,
 }
 
 static int
-surface_fill_blend_rgba_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
+surface_fill_blend_rgba_min(SDL_Surface *surface, PG_PixelFormat *fmt,
+                            SDL_Palette *palette, SDL_Rect *rect, Uint32 color)
 {
     Uint8 *pixels;
     int width = rect->w;
@@ -785,15 +762,11 @@ surface_fill_blend_rgba_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
-    PG_PixelFormat *fmt;
-    SDL_Palette *palette;
-    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
-        return -1;
-    }
+
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     if (!ppa) {
-        return surface_fill_blend_min(surface, rect, color);
+        return surface_fill_blend_min(surface, fmt, palette, rect, color);
     }
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -844,7 +817,8 @@ surface_fill_blend_rgba_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
 }
 
 static int
-surface_fill_blend_rgba_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
+surface_fill_blend_rgba_max(SDL_Surface *surface, PG_PixelFormat *fmt,
+                            SDL_Palette *palette, SDL_Rect *rect, Uint32 color)
 {
     Uint8 *pixels;
     int width = rect->w;
@@ -858,15 +832,11 @@ surface_fill_blend_rgba_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int ppa;
     SDL_BlendMode mode;
     SDL_GetSurfaceBlendMode(surface, &mode);
-    PG_PixelFormat *fmt;
-    SDL_Palette *palette;
-    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
-        return -1;
-    }
+
     ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 
     if (!ppa) {
-        return surface_fill_blend_max(surface, rect, color);
+        return surface_fill_blend_max(surface, fmt, palette, rect, color);
     }
 
     pixels = (Uint8 *)surface->pixels + (Uint16)rect->y * surface->pitch +
@@ -933,25 +903,34 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
         locked = 1;
     }
 
+    PG_PixelFormat *fmt;
+    SDL_Palette *palette;
+    if (!PG_GetSurfaceDetails(surface, &fmt, &palette)) {
+        return -1;
+    }
+
     switch (blendargs) {
         case PYGAME_BLEND_ADD: {
 #if !defined(__EMSCRIPTEN__)
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
             if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
-                    result = surface_fill_blend_add_avx2(surface, rect, color);
+                    result =
+                        surface_fill_blend_add_avx2(surface, fmt, rect, color);
                     break;
                 }
 #if PG_ENABLE_SSE_NEON
                 if (_pg_HasSSE_NEON()) {
-                    result = surface_fill_blend_add_sse2(surface, rect, color);
+                    result =
+                        surface_fill_blend_add_sse2(surface, fmt, rect, color);
                     break;
                 }
 #endif /* PG_ENABLE_SSE_NEON */
             }
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
-            result = surface_fill_blend_add(surface, rect, color);
+            result =
+                surface_fill_blend_add(surface, fmt, palette, rect, color);
             break;
         }
         case PYGAME_BLEND_SUB: {
@@ -959,19 +938,22 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
             if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
-                    result = surface_fill_blend_sub_avx2(surface, rect, color);
+                    result =
+                        surface_fill_blend_sub_avx2(surface, fmt, rect, color);
                     break;
                 }
 #if PG_ENABLE_SSE_NEON
                 if (_pg_HasSSE_NEON()) {
-                    result = surface_fill_blend_sub_sse2(surface, rect, color);
+                    result =
+                        surface_fill_blend_sub_sse2(surface, fmt, rect, color);
                     break;
                 }
 #endif /* PG_ENABLE_SSE_NEON */
             }
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
-            result = surface_fill_blend_sub(surface, rect, color);
+            result =
+                surface_fill_blend_sub(surface, fmt, palette, rect, color);
             break;
         }
         case PYGAME_BLEND_MULT: {
@@ -979,21 +961,22 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
             if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
-                    result =
-                        surface_fill_blend_mult_avx2(surface, rect, color);
+                    result = surface_fill_blend_mult_avx2(surface, fmt, rect,
+                                                          color);
                     break;
                 }
 #if PG_ENABLE_SSE_NEON
                 if (_pg_HasSSE_NEON()) {
-                    result =
-                        surface_fill_blend_mult_sse2(surface, rect, color);
+                    result = surface_fill_blend_mult_sse2(surface, fmt, rect,
+                                                          color);
                     break;
                 }
 #endif /* PG_ENABLE_SSE_NEON */
             }
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
-            result = surface_fill_blend_mult(surface, rect, color);
+            result =
+                surface_fill_blend_mult(surface, fmt, palette, rect, color);
             break;
         }
         case PYGAME_BLEND_MIN: {
@@ -1001,19 +984,22 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
             if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
-                    result = surface_fill_blend_min_avx2(surface, rect, color);
+                    result =
+                        surface_fill_blend_min_avx2(surface, fmt, rect, color);
                     break;
                 }
 #if PG_ENABLE_SSE_NEON
                 if (_pg_HasSSE_NEON()) {
-                    result = surface_fill_blend_min_sse2(surface, rect, color);
+                    result =
+                        surface_fill_blend_min_sse2(surface, fmt, rect, color);
                     break;
                 }
 #endif /* PG_ENABLE_SSE_NEON */
             }
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
-            result = surface_fill_blend_min(surface, rect, color);
+            result =
+                surface_fill_blend_min(surface, fmt, palette, rect, color);
             break;
         }
         case PYGAME_BLEND_MAX: {
@@ -1021,19 +1007,22 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
             if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
-                    result = surface_fill_blend_max_avx2(surface, rect, color);
+                    result =
+                        surface_fill_blend_max_avx2(surface, fmt, rect, color);
                     break;
                 }
 #if PG_ENABLE_SSE_NEON
                 if (_pg_HasSSE_NEON()) {
-                    result = surface_fill_blend_max_sse2(surface, rect, color);
+                    result =
+                        surface_fill_blend_max_sse2(surface, fmt, rect, color);
                     break;
                 }
 #endif /* PG_ENABLE_SSE_NEON */
             }
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
-            result = surface_fill_blend_max(surface, rect, color);
+            result =
+                surface_fill_blend_max(surface, fmt, palette, rect, color);
             break;
         }
 
@@ -1042,21 +1031,22 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
             if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
-                    result =
-                        surface_fill_blend_rgba_add_avx2(surface, rect, color);
+                    result = surface_fill_blend_rgba_add_avx2(surface, fmt,
+                                                              rect, color);
                     break;
                 }
 #if PG_ENABLE_SSE_NEON
                 if (_pg_HasSSE_NEON()) {
-                    result =
-                        surface_fill_blend_rgba_add_sse2(surface, rect, color);
+                    result = surface_fill_blend_rgba_add_sse2(surface, fmt,
+                                                              rect, color);
                     break;
                 }
 #endif /* PG_ENABLE_SSE_NEON */
             }
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
-            result = surface_fill_blend_rgba_add(surface, rect, color);
+            result = surface_fill_blend_rgba_add(surface, fmt, palette, rect,
+                                                 color);
             break;
         }
         case PYGAME_BLEND_RGBA_SUB: {
@@ -1064,21 +1054,22 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
             if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
-                    result =
-                        surface_fill_blend_rgba_sub_avx2(surface, rect, color);
+                    result = surface_fill_blend_rgba_sub_avx2(surface, fmt,
+                                                              rect, color);
                     break;
                 }
 #if PG_ENABLE_SSE_NEON
                 if (_pg_HasSSE_NEON()) {
-                    result =
-                        surface_fill_blend_rgba_sub_sse2(surface, rect, color);
+                    result = surface_fill_blend_rgba_sub_sse2(surface, fmt,
+                                                              rect, color);
                     break;
                 }
 #endif /* PG_ENABLE_SSE_NEON */
             }
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
-            result = surface_fill_blend_rgba_sub(surface, rect, color);
+            result = surface_fill_blend_rgba_sub(surface, fmt, palette, rect,
+                                                 color);
             break;
         }
         case PYGAME_BLEND_RGBA_MULT: {
@@ -1086,21 +1077,22 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
             if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
-                    result = surface_fill_blend_rgba_mult_avx2(surface, rect,
-                                                               color);
+                    result = surface_fill_blend_rgba_mult_avx2(surface, fmt,
+                                                               rect, color);
                     break;
                 }
 #if PG_ENABLE_SSE_NEON
                 if (_pg_HasSSE_NEON()) {
-                    result = surface_fill_blend_rgba_mult_sse2(surface, rect,
-                                                               color);
+                    result = surface_fill_blend_rgba_mult_sse2(surface, fmt,
+                                                               rect, color);
                     break;
                 }
 #endif /* PG_ENABLE_SSE_NEON */
             }
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
-            result = surface_fill_blend_rgba_mult(surface, rect, color);
+            result = surface_fill_blend_rgba_mult(surface, fmt, palette, rect,
+                                                  color);
             break;
         }
         case PYGAME_BLEND_RGBA_MIN: {
@@ -1108,21 +1100,22 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
             if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
-                    result =
-                        surface_fill_blend_rgba_min_avx2(surface, rect, color);
+                    result = surface_fill_blend_rgba_min_avx2(surface, fmt,
+                                                              rect, color);
                     break;
                 }
 #if PG_ENABLE_SSE_NEON
                 if (_pg_HasSSE_NEON()) {
-                    result =
-                        surface_fill_blend_rgba_min_sse2(surface, rect, color);
+                    result = surface_fill_blend_rgba_min_sse2(surface, fmt,
+                                                              rect, color);
                     break;
                 }
 #endif /* PG_ENABLE_SSE_NEON */
             }
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
-            result = surface_fill_blend_rgba_min(surface, rect, color);
+            result = surface_fill_blend_rgba_min(surface, fmt, palette, rect,
+                                                 color);
             break;
         }
         case PYGAME_BLEND_RGBA_MAX: {
@@ -1130,21 +1123,22 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
             if (PG_SURF_BytesPerPixel(surface) == 4) {
                 if (_pg_has_avx2()) {
-                    result =
-                        surface_fill_blend_rgba_max_avx2(surface, rect, color);
+                    result = surface_fill_blend_rgba_max_avx2(surface, fmt,
+                                                              rect, color);
                     break;
                 }
 #if PG_ENABLE_SSE_NEON
                 if (_pg_HasSSE_NEON()) {
-                    result =
-                        surface_fill_blend_rgba_max_sse2(surface, rect, color);
+                    result = surface_fill_blend_rgba_max_sse2(surface, fmt,
+                                                              rect, color);
                     break;
                 }
 #endif /* PG_ENABLE_SSE_NEON */
             }
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
-            result = surface_fill_blend_rgba_max(surface, rect, color);
+            result = surface_fill_blend_rgba_max(surface, fmt, palette, rect,
+                                                 color);
             break;
         }
 


### PR DESCRIPTION
This PR consists of 4 commits, and it gets the surface module to compile with SDL3. It still fails lots of tests when run in SDL3 mode, but there is lots of SDL-function porting to be done with int->bool stuff.

#### Commit 1 focuses on Surface.c

This commit does not change the SDL2 codepath at all, except for a cliprect thing similar to what I've done in other PRs.

The RLEaccel stuff is confusing, even digging through the SDL2 source it's hard to understand. Our code uses `surf->flags & SDL_RLEACCEL` to check, interchangeably with `SDL_SurfaceHasRLE(surf)`, but if you check the source SDL_SurfaceHasRLE does not check the same flags. However, in testing it seems to be equivalent, somehow.

I also just declined to port a whole section that covers a blitting edge case, we'll get to it later, for now I think it will be valuable to have people able to compile at all.

EDIT: also added a commit 5 for surface.c.

#### Commit 2 and 3 focus on filling and blitting respectively

There are a lot of lines changed but it's just passing formats around, nothing complex

#### Commit 4 makes intrinsics compile properly

I took Ankith's prior work on this and moved it up to _surface.h, as well as making sure it defines __SSE2__ and __AVX2__ itself if necessary. On my (Windows) system it doesn't compile at least the SSE2 stuff without this, so in SDL2 we must be getting that define from SDL itself.
