### PR TITLE
Update CIBW setting to prevent warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,11 @@ skip = "*-musllinux_*"
 # build[uv] is verbose by default, so below flag is not needed here
 # build-verbosity = 3
 
+# In CIBW 2, defaults to pypy-enabled, but is throwing warnings about the
+# default changing in CIBW 3. So since we use pypy, lets explicitly enable it.
+# https://cibuildwheel.pypa.io/en/stable/options/#enable
+enable = ["pypy"]
+
 environment = { SDL_VIDEODRIVER="dummy", SDL_AUDIODRIVER="disk" }
 test-command = "python -m pygame.tests -v --exclude opengl,music,timing --time_out 300"
 test-requires = ["numpy"]


### PR DESCRIPTION
Check out this recent actions run, it has annotations warning us about the change:
https://github.com/pygame-community/pygame-ce/actions/runs/15180508177?pr=3434

The same run from this PR does not have the warning:
https://github.com/pygame-community/pygame-ce/actions/runs/15225063961?pr=3438

