### PR TITLE
Use `namedtuple` for `pygame.image.load_animation`

### DIFF
--- a/buildconfig/stubs/pygame/image.pyi
+++ b/buildconfig/stubs/pygame/image.pyi
@@ -62,9 +62,8 @@ following formats.
 .. versionaddedold:: 1.8 Saving PNG and JPEG files.
 """
 
-from typing import Literal, Optional, Union
+from typing import Literal, NamedTuple, Optional
 
-from pygame.bufferproxy import BufferProxy
 from pygame.surface import Surface
 from pygame.typing import FileLike, IntPoint, Point
 from typing_extensions import (
@@ -77,6 +76,10 @@ _to_bytes_format = Literal[
     "P", "RGB", "RGBX", "RGBA", "ARGB", "BGRA", "ABGR", "RGBA_PREMULT", "ARGB_PREMULT"
 ]
 _from_bytes_format = Literal["P", "RGB", "RGBX", "RGBA", "ARGB", "BGRA", "ABGR"]
+
+class _AnimationFrame(NamedTuple):
+    surface: Surface
+    delay: int
 
 def load(file: FileLike, namehint: str = "") -> Surface:
     """Load new image from a file (or file-like object).
@@ -136,7 +139,7 @@ def load_sized_svg(file: FileLike, size: Point) -> Surface:
     .. versionadded:: 2.4.0
     """
 
-def load_animation(file: FileLike, namehint: str = "") -> list[tuple[Surface, int]]:
+def load_animation(file: FileLike, namehint: str = "") -> list[_AnimationFrame]:
     """Load an animation (GIF/WEBP) from a file (or file-like object).
 
     Load an animation (GIF/WEBP) from a file source. You can pass either a
@@ -145,8 +148,9 @@ def load_animation(file: FileLike, namehint: str = "") -> list[tuple[Surface, in
     namehint argument so that the file extension can be used to infer the file
     format.
 
-    This returns a list of tuples (corresponding to every frame of the animation),
-    where each tuple is a (surface, delay) pair for that frame.
+    This returns a list of named tuples (corresponding to every frame of the animation),
+    where each tuple is a (surface, delay) pair for that frame. Being named tuples,
+    the items can be accessed as frame.surface and frame.delay.
 
     This function requires SDL_image 2.6.0 or above. If pygame was compiled with
     an older version, ``pygame.error`` will be raised when this function is

--- a/buildconfig/stubs/pygame/image.pyi
+++ b/buildconfig/stubs/pygame/image.pyi
@@ -79,7 +79,7 @@ _from_bytes_format = Literal["P", "RGB", "RGBX", "RGBA", "ARGB", "BGRA", "ABGR"]
 
 class _AnimationFrame(NamedTuple):
     surface: Surface
-    delay_ms: int
+    delay_ms: float
 
 def load(file: FileLike, namehint: str = "") -> Surface:
     """Load new image from a file (or file-like object).
@@ -140,7 +140,7 @@ def load_sized_svg(file: FileLike, size: Point) -> Surface:
     """
 
 def load_animation(file: FileLike, namehint: str = "") -> list[_AnimationFrame]:
-    """Load an animation (GIF/WEBP) from a file (or file-like object).
+    """Load an animation (GIF/WEBP) from a file (or file-like object) as a list of frames.
 
     Load an animation (GIF/WEBP) from a file source. You can pass either a
     filename, a Python file-like object, or a pathlib.Path. If you pass a raw

--- a/buildconfig/stubs/pygame/image.pyi
+++ b/buildconfig/stubs/pygame/image.pyi
@@ -79,7 +79,7 @@ _from_bytes_format = Literal["P", "RGB", "RGBX", "RGBA", "ARGB", "BGRA", "ABGR"]
 
 class _AnimationFrame(NamedTuple):
     surface: Surface
-    delay: int
+    delay_ms: int
 
 def load(file: FileLike, namehint: str = "") -> Surface:
     """Load new image from a file (or file-like object).
@@ -149,8 +149,8 @@ def load_animation(file: FileLike, namehint: str = "") -> list[_AnimationFrame]:
     format.
 
     This returns a list of named tuples (corresponding to every frame of the animation),
-    where each tuple is a (surface, delay) pair for that frame. Being named tuples,
-    the items can be accessed as frame.surface and frame.delay.
+    where each tuple is a (surface, delay in milliseconds) pair for that frame. Being
+    named tuples, the items can be accessed as frame.surface and frame.delay_ms.
 
     This function requires SDL_image 2.6.0 or above. If pygame was compiled with
     an older version, ``pygame.error`` will be raised when this function is

--- a/src_c/doc/image_doc.h
+++ b/src_c/doc/image_doc.h
@@ -2,7 +2,7 @@
 #define DOC_IMAGE "Pygame module for image transfer."
 #define DOC_IMAGE_LOAD "load(file, namehint='') -> Surface\nLoad new image from a file (or file-like object)."
 #define DOC_IMAGE_LOADSIZEDSVG "load_sized_svg(file, size) -> Surface\nLoad an SVG image from a file (or file-like object) with the given size."
-#define DOC_IMAGE_LOADANIMATION "load_animation(file, namehint='') -> list[tuple[Surface, int]]\nLoad an animation (GIF/WEBP) from a file (or file-like object)."
+#define DOC_IMAGE_LOADANIMATION "load_animation(file, namehint='') -> list[_AnimationFrame]\nLoad an animation (GIF/WEBP) from a file (or file-like object)."
 #define DOC_IMAGE_SAVE "save(surface, file, namehint='') -> None\nSave an image to file (or file-like object)."
 #define DOC_IMAGE_GETSDLIMAGEVERSION "get_sdl_image_version(linked=True) -> Optional[tuple[int, int, int]]\nGet version number of the SDL_Image library being used."
 #define DOC_IMAGE_GETEXTENDED "get_extended() -> bool\nTest if extended image formats can be loaded."

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -217,8 +217,6 @@ imageext_load_animation(PyObject *self, PyObject *arg, PyObject *kwargs)
     SDL_RWops *rw = NULL;
     static char *kwds[] = {"file", "namehint", NULL};
 
-    assert(animation_frame_type);
-
     if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O|s", kwds, &obj, &name)) {
         return NULL;
     }
@@ -257,6 +255,10 @@ imageext_load_animation(PyObject *self, PyObject *arg, PyObject *kwargs)
     }
 
     for (int i = 0; i < surfs->count; i++) {
+        PyObject *delay_obj = PyLong_FromLong(surfs->delays[i]);
+        if (!delay_obj) {
+            goto error;
+        }
         PyObject *frame = (PyObject *)pgSurface_New(surfs->frames[i]);
         if (!frame) {
             /* IMG_FreeAnimation takes care of freeing of member SDL surfaces
@@ -273,15 +275,7 @@ imageext_load_animation(PyObject *self, PyObject *arg, PyObject *kwargs)
         }
 
         PyStructSequence_SetItem(listentry, 0, frame);
-        PyObject *delay_obj = PyLong_FromLong(surfs->delays[i]);
-        if (!delay_obj) {
-            Py_DECREF(listentry);
-            Py_DECREF(frame);
-            goto error;
-        }
         PyStructSequence_SetItem(listentry, 1, delay_obj);
-        Py_DECREF(delay_obj);
-
         PyList_SET_ITEM(ret, i, listentry);
     }
     IMG_FreeAnimation(surfs);
@@ -492,7 +486,7 @@ MODINIT_DEFINE(imageext)
         {"surface", NULL}, {"delay", NULL}, {NULL, NULL}};
 
     static struct PyStructSequence_Desc _namedtuple_descr = {
-        .name = "AnimationFrame",
+        .name = "_AnimationFrame",
         .doc = NULL,
         .fields = _namedtuple_fields,
         .n_in_sequence = 2,

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -489,7 +489,7 @@ MODINIT_DEFINE(imageext)
     */
 
     static PyStructSequence_Field _namedtuple_fields[] = {
-        {"surface", NULL}, {"delay", NULL}, NULL};
+        {"surface", NULL}, {"delay", NULL}, {NULL, NULL}};
 
     static struct PyStructSequence_Desc _namedtuple_descr = {
         .name = "AnimationFrame",

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -446,6 +446,16 @@ static PyMethodDef _imageext_methods[] = {
 /*DOC*/ static char _imageext_doc[] =
     /*DOC*/ "additional image loaders";
 
+static PyStructSequence_Field _namedtuple_fields[] = {
+    {"surface", NULL}, {"delay_ms", NULL}, {NULL, NULL}};
+
+static struct PyStructSequence_Desc _namedtuple_descr = {
+    .name = "_AnimationFrame",
+    .doc = NULL,
+    .fields = _namedtuple_fields,
+    .n_in_sequence = 2,
+};
+
 MODINIT_DEFINE(imageext)
 {
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
@@ -483,16 +493,6 @@ MODINIT_DEFINE(imageext)
         }
     #endif
     */
-
-    static PyStructSequence_Field _namedtuple_fields[] = {
-        {"surface", NULL}, {"delay_ms", NULL}, {NULL, NULL}};
-
-    static struct PyStructSequence_Desc _namedtuple_descr = {
-        .name = "_AnimationFrame",
-        .doc = NULL,
-        .fields = _namedtuple_fields,
-        .n_in_sequence = 2,
-    };
 
     animation_frame_type = PyStructSequence_NewType(&_namedtuple_descr);
     if (animation_frame_type == NULL) {

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -496,7 +496,6 @@ MODINIT_DEFINE(imageext)
     if (animation_frame_type == NULL) {
         return NULL;  // exception set
     }
-    Py_INCREF(animation_frame_type);
 
     /* create the module */
     return PyModule_Create(&_module);

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -255,7 +255,7 @@ imageext_load_animation(PyObject *self, PyObject *arg, PyObject *kwargs)
     }
 
     for (int i = 0; i < surfs->count; i++) {
-        PyObject *delay_obj = PyLong_FromLong(surfs->delays[i]);
+        PyObject *delay_obj = PyFloat_FromDouble((double)surfs->delays[i]);
         if (!delay_obj) {
             goto error;
         }

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -485,7 +485,7 @@ MODINIT_DEFINE(imageext)
     */
 
     static PyStructSequence_Field _namedtuple_fields[] = {
-        {"surface", NULL}, {"delay", NULL}, {NULL, NULL}};
+        {"surface", NULL}, {"delay_ms", NULL}, {NULL, NULL}};
 
     static struct PyStructSequence_Desc _namedtuple_descr = {
         .name = "_AnimationFrame",

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -263,6 +263,7 @@ imageext_load_animation(PyObject *self, PyObject *arg, PyObject *kwargs)
         if (!frame) {
             /* IMG_FreeAnimation takes care of freeing of member SDL surfaces
              */
+            Py_DECREF(delay_obj);
             goto error;
         }
         /* The python surface object now "owns" the sdl surface, so set it
@@ -271,6 +272,7 @@ imageext_load_animation(PyObject *self, PyObject *arg, PyObject *kwargs)
         PyObject *listentry = PyStructSequence_New(animation_frame_type);
         if (!listentry) {
             Py_DECREF(frame);
+            Py_DECREF(delay_obj);
             goto error;
         }
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1388,6 +1388,9 @@ class ImageModuleTest(unittest.TestCase):
                 for val in s:
                     self.assertIsInstance(val, tuple)
                     frame, delay = val
+                    frameattr, delayattr = val.surface, val.delay
+                    self.assertEqual(frame, frameattr)
+                    self.assertEqual(delay, delayattr)
                     self.assertIsInstance(frame, pygame.Surface)
                     self.assertEqual(frame.size, SAMPLE_SIZE)
                     self.assertIsInstance(delay, int)

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1388,7 +1388,7 @@ class ImageModuleTest(unittest.TestCase):
                 for val in s:
                     self.assertIsInstance(val, tuple)
                     frame, delay = val
-                    frameattr, delayattr = val.surface, val.delay
+                    frameattr, delayattr = val.surface, val.delay_ms
                     self.assertEqual(frame, frameattr)
                     self.assertEqual(delay, delayattr)
                     self.assertIsInstance(frame, pygame.Surface)


### PR DESCRIPTION
As requested in the pygame discord server, I made load_animation return a list of namedtuples so frame.surface and frame.delay are possible. The typehinting ensures proper types for both attribute access and item access.