### PR TITLE
Use float for `load_animation` delay, improve docs

### DIFF
--- a/buildconfig/stubs/pygame/image.pyi
+++ b/buildconfig/stubs/pygame/image.pyi
@@ -136,8 +136,8 @@ def load_sized_svg(file: FileLike, size: Point) -> Surface:
     .. versionadded:: 2.4.0
     """
 
-def load_animation(file: FileLike, namehint: str = "") -> list[tuple[Surface, int]]:
-    """Load an animation (GIF/WEBP) from a file (or file-like object).
+def load_animation(file: FileLike, namehint: str = "") -> list[tuple[Surface, float]]:
+    """Load an animation (GIF/WEBP) from a file (or file-like object) as a list of frames.
 
     Load an animation (GIF/WEBP) from a file source. You can pass either a
     filename, a Python file-like object, or a pathlib.Path. If you pass a raw
@@ -146,7 +146,7 @@ def load_animation(file: FileLike, namehint: str = "") -> list[tuple[Surface, in
     format.
 
     This returns a list of tuples (corresponding to every frame of the animation),
-    where each tuple is a (surface, delay) pair for that frame.
+    where each tuple is a (surface, delay in milliseconds) pair for that frame.
 
     This function requires SDL_image 2.6.0 or above. If pygame was compiled with
     an older version, ``pygame.error`` will be raised when this function is

--- a/src_c/doc/image_doc.h
+++ b/src_c/doc/image_doc.h
@@ -2,7 +2,7 @@
 #define DOC_IMAGE "Pygame module for image transfer."
 #define DOC_IMAGE_LOAD "load(file, namehint='') -> Surface\nLoad new image from a file (or file-like object)."
 #define DOC_IMAGE_LOADSIZEDSVG "load_sized_svg(file, size) -> Surface\nLoad an SVG image from a file (or file-like object) with the given size."
-#define DOC_IMAGE_LOADANIMATION "load_animation(file, namehint='') -> list[tuple[Surface, int]]\nLoad an animation (GIF/WEBP) from a file (or file-like object)."
+#define DOC_IMAGE_LOADANIMATION "load_animation(file, namehint='') -> list[tuple[Surface, float]]\nLoad an animation (GIF/WEBP) from a file (or file-like object) as a list of frames."
 #define DOC_IMAGE_SAVE "save(surface, file, namehint='') -> None\nSave an image to file (or file-like object)."
 #define DOC_IMAGE_GETSDLIMAGEVERSION "get_sdl_image_version(linked=True) -> Optional[tuple[int, int, int]]\nGet version number of the SDL_Image library being used."
 #define DOC_IMAGE_GETEXTENDED "get_extended() -> bool\nTest if extended image formats can be loaded."

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -264,7 +264,8 @@ imageext_load_animation(PyObject *self, PyObject *arg, PyObject *kwargs)
          * to null in the animation to prevent double free */
         surfs->frames[i] = NULL;
 
-        PyObject *listentry = Py_BuildValue("(Oi)", frame, surfs->delays[i]);
+        PyObject *listentry =
+            Py_BuildValue("(Of)", frame, (float)surfs->delays[i]);
         Py_DECREF(frame);
         if (!listentry) {
             goto error;

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1369,7 +1369,7 @@ class ImageModuleTest(unittest.TestCase):
     def test_load_animation(self):
         # test loading from a file
         SAMPLE_FRAMES = 10
-        SAMPLE_DELAY = 150
+        SAMPLE_DELAY = 150.0
         SAMPLE_SIZE = (312, 312)
         gif_path = pathlib.Path(example_path("data/animated_sample.gif"))
         for inp in (
@@ -1390,7 +1390,7 @@ class ImageModuleTest(unittest.TestCase):
                     frame, delay = val
                     self.assertIsInstance(frame, pygame.Surface)
                     self.assertEqual(frame.size, SAMPLE_SIZE)
-                    self.assertIsInstance(delay, int)
+                    self.assertIsInstance(delay, float)
                     self.assertEqual(delay, SAMPLE_DELAY)
 
     def test_load_pathlib(self):


### PR DESCRIPTION
Since we are still in time, convert to using floats as the delay for animation frames. SDL has started using floats after int multiple times when changing version so this future proofs us. Since the docs specify milliseconds (and, if the named tuple is added, also the attribute) there is no ambiguity.