### PR TITLE
Deprecate all Surface format related methods

### DIFF
--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -776,18 +776,24 @@ class Surface:
         ..versionadded:: 2.3.0
         """
 
+    @deprecated("since 2.5.5. Not needed for pygame usage")
     def get_bitsize(self) -> int:
         """Get the bit depth of the Surface pixel format.
 
         Returns the number of bits used to represent each pixel. This value may
         not exactly fill the number of bytes used per pixel. For example a 15 bit
         Surface still requires a full 2 bytes.
+
+        .. deprecated: 2.5.5 This value is not needed for normal pygame usage.
         """
 
+    @deprecated("since 2.5.5. Not needed for pygame usage")
     def get_bytesize(self) -> int:
         """Get the bytes used per Surface pixel.
 
         Return the number of bytes used per pixel.
+
+        .. deprecated: 2.5.5 This value is not needed for normal pygame usage.
         """
 
     def get_flags(self) -> int:
@@ -821,6 +827,7 @@ class Surface:
             PREALLOC       0x01000000    # Surface uses preallocated memory
         """
 
+    @deprecated("since 2.5.5. Not needed for pygame usage")
     def get_pitch(self) -> int:
         """Get the number of bytes used per Surface row.
 
@@ -828,15 +835,16 @@ class Surface:
         in video memory are not always linearly packed. Subsurfaces will also
         have a larger pitch than their real width.
 
-        This value is not needed for normal pygame usage.
+        .. deprecated: 2.5.5 This value is not needed for normal pygame usage.
         """
 
+    @deprecated("since 2.5.5. Not needed for pygame usage")
     def get_masks(self) -> tuple[int, int, int, int]:
         """The bitmasks needed to convert between a color and a mapped integer.
 
         Returns the bitmasks used to isolate each color in a mapped integer.
 
-        This value is not needed for normal pygame usage.
+        .. deprecated: 2.5.5 This value is not needed for normal pygame usage.
         """
 
     @deprecated("since 2.0.0. Immutable in SDL2")
@@ -853,13 +861,14 @@ class Surface:
         .. versionaddedold:: 1.8.1
         """
 
+    @deprecated("since 2.5.5. Not needed for pygame usage")
     def get_shifts(self) -> tuple[int, int, int, int]:
         """The bit shifts needed to convert between a color and a mapped integer.
 
         Returns the pixel shifts need to convert between each color and a mapped
         integer.
 
-        This value is not needed for normal pygame usage.
+        .. deprecated: 2.5.5 This value is not needed for normal pygame usage.
         """
 
     @deprecated("since 2.0.0. Immutable in SDL2")
@@ -876,13 +885,14 @@ class Surface:
         .. versionaddedold:: 1.8.1
         """
 
+    @deprecated("since 2.5.5. Not needed for pygame usage")
     def get_losses(self) -> tuple[int, int, int, int]:
         """The significant bits used to convert between a color and a mapped integer.
 
         Return the least significant number of bits stripped from each color in a
         mapped integer.
 
-        This value is not needed for normal pygame usage.
+        .. deprecated: 2.5.5 This value is not needed for normal pygame usage.
         """
 
     def get_bounding_rect(self, min_alpha: int = 1) -> Rect:

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3042,6 +3042,12 @@ surf_get_flags(PyObject *self, PyObject *_null)
 static PyObject *
 surf_get_pitch(PyObject *self, PyObject *_null)
 {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "The pitch information is not needed for pygame usage",
+                     1) == -1) {
+        return NULL;
+    }
+
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
     SURF_INIT_CHECK(surf)
@@ -3102,6 +3108,12 @@ surf_get_frect(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
 static PyObject *
 surf_get_bitsize(PyObject *self, PyObject *_null)
 {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "The bitsize information is not needed for pygame usage",
+                     1) == -1) {
+        return NULL;
+    }
+
     SDL_Surface *surf = pgSurface_AsSurface(self);
     SURF_INIT_CHECK(surf)
 
@@ -3111,6 +3123,12 @@ surf_get_bitsize(PyObject *self, PyObject *_null)
 static PyObject *
 surf_get_bytesize(PyObject *self, PyObject *_null)
 {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "The bytesize information is not needed for pygame usage",
+                     1) == -1) {
+        return NULL;
+    }
+
     SDL_Surface *surf = pgSurface_AsSurface(self);
     SURF_INIT_CHECK(surf)
 
@@ -3120,6 +3138,12 @@ surf_get_bytesize(PyObject *self, PyObject *_null)
 static PyObject *
 surf_get_masks(PyObject *self, PyObject *_null)
 {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "The masks information is not needed for pygame usage",
+                     1) == -1) {
+        return NULL;
+    }
+
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
     SURF_INIT_CHECK(surf)
@@ -3142,6 +3166,12 @@ surf_set_masks(PyObject *self, PyObject *args)
 static PyObject *
 surf_get_shifts(PyObject *self, PyObject *_null)
 {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "The shifts information is not needed for pygame usage",
+                     1) == -1) {
+        return NULL;
+    }
+
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
     SURF_INIT_CHECK(surf)
@@ -3164,6 +3194,12 @@ surf_set_shifts(PyObject *self, PyObject *args)
 static PyObject *
 surf_get_losses(PyObject *self, PyObject *_null)
 {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "The losses information is not needed for pygame usage",
+                     1) == -1) {
+        return NULL;
+    }
+
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
     SURF_INIT_CHECK(surf)


### PR DESCRIPTION
The docs were already static "not needed for pygame usage" - then, why keep? SDL3 went in a direction of simplifying, it makes sense for us to do the same. As @ankith26 pointed out, while that information exists, you don't quite have the chance to use it. To remove this methods in pygame 3, it makes sense to deprecate them now, unless you have a reason not to do that.
[edit:]
Maybe some of the data, like the masks, could be useful. But I don't think they are all useful, perhaps we can choose what we deprecate and what not. If we do care about pixel information I originally thought about a PixelFormat class, but I don't know anymore.

I also want to bring the attention towards locking - Surfaces have 5 separate methods related to locking - but when do users actually lock them? Is this much method cluttering useful? I guess if the amounts of sequential operations are great for an hardware surface only locking once does indeed make sense - but at least `mustlock`, `get_locks` and `get_locked` could go away, as I still don't find a use for them (calling lock/unlock multiple times does no harm!). If you want I can "reduce" them to two, deprecating the others (to be removed in pygame 3). Thanks for the attention.