### PR TITLE
Port over more SDL functions to SDL3

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -136,6 +136,7 @@ PG_GetSurfaceFormat(SDL_Surface *surf)
 #define PG_GetSurfaceBlendMode SDL_GetSurfaceBlendMode
 #define PG_GetSurfaceAlphaMod SDL_GetSurfaceAlphaMod
 #define PG_SetSurfaceAlphaMod SDL_SetSurfaceAlphaMod
+#define PG_FillSurfaceRect SDL_FillSurfaceRect
 
 #define PG_GetRGBA SDL_GetRGBA
 #define PG_GetRGB SDL_GetRGB
@@ -267,6 +268,12 @@ static inline bool
 PG_SetSurfaceAlphaMod(SDL_Surface *surface, Uint8 alpha)
 {
     return SDL_SetSurfaceAlphaMod(surface, alpha) == 0;
+}
+
+static inline bool
+PG_FillSurfaceRect(SDL_Surface *dst, const SDL_Rect *rect, Uint32 color)
+{
+    return SDL_FillRect(dst, rect, color) == 0;
 }
 
 // NOTE:

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -137,6 +137,7 @@ PG_GetSurfaceFormat(SDL_Surface *surf)
 #define PG_GetSurfaceAlphaMod SDL_GetSurfaceAlphaMod
 #define PG_SetSurfaceAlphaMod SDL_SetSurfaceAlphaMod
 #define PG_FillSurfaceRect SDL_FillSurfaceRect
+#define PG_LockSurface SDL_LockSurface
 
 #define PG_GetRGBA SDL_GetRGBA
 #define PG_GetRGB SDL_GetRGB
@@ -274,6 +275,12 @@ static inline bool
 PG_FillSurfaceRect(SDL_Surface *dst, const SDL_Rect *rect, Uint32 color)
 {
     return SDL_FillRect(dst, rect, color) == 0;
+}
+
+static inline bool
+PG_LockSurface(SDL_Surface *surface)
+{
+    return SDL_LockSurface(surface) == 0;
 }
 
 // NOTE:

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -80,7 +80,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
     /* Lock the destination if it's in hardware */
     dst_locked = 0;
     if (SDL_MUSTLOCK(dst)) {
-        if (SDL_LockSurface(dst) < 0) {
+        if (!PG_LockSurface(dst)) {
             okay = 0;
         }
         else {
@@ -90,7 +90,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
     /* Lock the source if it's in hardware */
     src_locked = 0;
     if (SDL_MUSTLOCK(src)) {
-        if (SDL_LockSurface(src) < 0) {
+        if (!PG_LockSurface(src)) {
             okay = 0;
         }
         else {

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1178,7 +1178,6 @@ rect(PyObject *self, PyObject *args, PyObject *kwargs)
     int top_left_radius = -1, top_right_radius = -1, bottom_left_radius = -1,
         bottom_right_radius = -1;
     SDL_Rect sdlrect;
-    int result;
     SDL_Rect clipped;
     int drawn_area[4] = {INT_MAX, INT_MAX, INT_MIN,
                          INT_MIN}; /* Used to store bounding box values */
@@ -1248,10 +1247,10 @@ rect(PyObject *self, PyObject *args, PyObject *kwargs)
         else {
             pgSurface_Prep(surfobj);
             pgSurface_Lock(surfobj);
-            result = SDL_FillRect(surf, &clipped, color);
+            bool success = PG_FillSurfaceRect(surf, &clipped, color);
             pgSurface_Unlock(surfobj);
             pgSurface_Unprep(surfobj);
-            if (result != 0) {
+            if (!success) {
                 return RAISE(pgExc_SDLError, SDL_GetError());
             }
         }

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -286,7 +286,7 @@ _PGFT_Render_ExistingSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
     Layout *font_text;
 
     if (SDL_MUSTLOCK(surface)) {
-        if (SDL_LockSurface(surface) == -1) {
+        if (!PG_LockSurface(surface)) {
             SDL_FreeSurface(surface);
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             return -1;
@@ -445,7 +445,7 @@ _PGFT_Render_NewSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
     }
 
     if (SDL_MUSTLOCK(surface)) {
-        if (SDL_LockSurface(surface) == -1) {
+        if (!PG_LockSurface(surface)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(surface);
             return 0;

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2198,7 +2198,7 @@ surf_fill(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
     else {
         pgSurface_Prep(self);
         pgSurface_Lock((pgSurfaceObject *)self);
-        result = SDL_FillRect(surf, &sdlrect, color);
+        result = PG_FillSurfaceRect(surf, &sdlrect, color) - 1;
         pgSurface_Unlock((pgSurfaceObject *)self);
         pgSurface_Unprep(self);
     }
@@ -2938,7 +2938,7 @@ surf_scroll(PyObject *self, PyObject *args, PyObject *keywds)
     if (!repeat) {
         if (dx >= w || dx <= -w || dy >= h || dy <= -h) {
             if (erase) {
-                if (SDL_FillRect(surf, NULL, 0) == -1) {
+                if (!PG_FillSurfaceRect(surf, NULL, 0)) {
                     PyErr_SetString(pgExc_SDLError, SDL_GetError());
                     return NULL;
                 }

--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -927,7 +927,7 @@ surface_fill_blend(SDL_Surface *surface, SDL_Rect *rect, Uint32 color,
 
     /* Lock the surface, if needed */
     if (SDL_MUSTLOCK(surface)) {
-        if (SDL_LockSurface(surface) < 0) {
+        if (!PG_LockSurface(surface)) {
             return -1;
         }
         locked = 1;

--- a/src_c/surflock.c
+++ b/src_c/surflock.c
@@ -99,12 +99,7 @@ pgSurface_LockBy(pgSurfaceObject *surfobj, PyObject *lockobj)
     if (surf->subsurface != NULL) {
         pgSurface_Prep(surfobj);
     }
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-    if (!SDL_LockSurface(surf->surf))
-#else
-    if (SDL_LockSurface(surf->surf) == -1)
-#endif
-    {
+    if (!PG_LockSurface(surf->surf)) {
         PyErr_SetString(PyExc_RuntimeError, "error locking surface");
         return 0;
     }

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -2420,20 +2420,10 @@ solid_overlay(pgSurfaceObject *srcobj, Uint32 color, pgSurfaceObject *dstobj,
     int src_lock = SDL_MUSTLOCK(src);
     int dst_lock = src != newsurf && SDL_MUSTLOCK(newsurf);
 
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-    if (src_lock && !SDL_LockSurface(src))
-#else
-    if (src_lock && SDL_LockSurface(src) < 0)
-#endif
-    {
+    if (src_lock && !PG_LockSurface(src)) {
         return NULL;
     }
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-    if (dst_lock && !SDL_LockSurface(newsurf))
-#else
-    if (dst_lock && SDL_LockSurface(newsurf) < 0)
-#endif
-    {
+    if (dst_lock && !PG_LockSurface(newsurf)) {
         if (src_lock) {
             SDL_UnlockSurface(src);
         }
@@ -2696,13 +2686,13 @@ modify_hsl(SDL_Surface *surf, PG_PixelFormat *fmt, SDL_Surface *dst,
 {
     int surf_locked = 0;
     if (SDL_MUSTLOCK(surf)) {
-        if (SDL_LockSurface(surf) == 0) {
+        if (PG_LockSurface(surf)) {
             surf_locked = 1;
         }
     }
     int dst_locked = 0;
     if (SDL_MUSTLOCK(dst)) {
-        if (SDL_LockSurface(dst) == 0) {
+        if (PG_LockSurface(dst)) {
             dst_locked = 1;
         }
     }


### PR DESCRIPTION
This PR handles SDL_LockSurface and SDL_FillRect.

This is a prerequisite to https://github.com/pygame-community/pygame-ce/pull/3435, since that one is giving me warnings (that I don't get locally) related to these functions.

This is similar to https://github.com/pygame-community/pygame-ce/pull/3434