### PR TITLE
Optimize vector-number math by avoiding RealNumber_Check

### DIFF
--- a/src_c/math.c
+++ b/src_c/math.c
@@ -688,7 +688,7 @@ vector_generic_math(PyObject *o1, PyObject *o2, int op)
     Py_ssize_t i, dim;
     double *vec_coords;
     double other_coords[VECTOR_MAX_SIZE] = {0};
-    double tmp;
+    double tmp = 0.0;
     PyObject *other;
     pgVector *vec, *ret = NULL;
     if (pgVector_Check(o1)) {
@@ -712,11 +712,15 @@ vector_generic_math(PyObject *o1, PyObject *o2, int op)
     if (pg_VectorCoordsFromObj(other, dim, other_coords)) {
         op |= OP_ARG_VECTOR;
     }
-    else if (RealNumber_Check(other)) {
-        op |= OP_ARG_NUMBER;
-    }
     else {
-        op |= OP_ARG_UNKNOWN;
+        tmp = PyFloat_AsDouble(other);
+        if (tmp == -1.0 && PyErr_Occurred()) {
+            PyErr_Clear();
+            op |= OP_ARG_UNKNOWN;
+        }
+        else {
+            op |= OP_ARG_NUMBER;
+        }
     }
 
     if (op & OP_INPLACE) {
@@ -761,14 +765,12 @@ vector_generic_math(PyObject *o1, PyObject *o2, int op)
         case OP_MUL | OP_ARG_NUMBER:
         case OP_MUL | OP_ARG_NUMBER | OP_ARG_REVERSE:
         case OP_MUL | OP_ARG_NUMBER | OP_INPLACE:
-            tmp = PyFloat_AsDouble(other);
             for (i = 0; i < dim; i++) {
                 ret->coords[i] = vec_coords[i] * tmp;
             }
             break;
         case OP_DIV | OP_ARG_NUMBER:
         case OP_DIV | OP_ARG_NUMBER | OP_INPLACE:
-            tmp = PyFloat_AsDouble(other);
             if (tmp == 0.) {
                 PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
                 Py_DECREF(ret);
@@ -781,7 +783,6 @@ vector_generic_math(PyObject *o1, PyObject *o2, int op)
             break;
         case OP_FLOOR_DIV | OP_ARG_NUMBER:
         case OP_FLOOR_DIV | OP_ARG_NUMBER | OP_INPLACE:
-            tmp = PyFloat_AsDouble(other);
             if (tmp == 0.) {
                 PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
                 Py_DECREF(ret);
@@ -3971,12 +3972,15 @@ vector_elementwiseproxy_generic_math(PyObject *o1, PyObject *o2, int op)
             return NULL;
         }
     }
-    else if (RealNumber_Check(other)) {
-        op |= OP_ARG_NUMBER;
-        other_value = PyFloat_AsDouble(other);
-    }
     else {
-        op |= OP_ARG_UNKNOWN;
+        other_value = PyFloat_AsDouble(other);
+        if (other_value == -1.0 && PyErr_Occurred()) {
+            PyErr_Clear();
+            op |= OP_ARG_UNKNOWN;
+        }
+        else {
+            op |= OP_ARG_NUMBER;
+        }
     }
 
     ret = _vector_subtype_new(vec);


### PR DESCRIPTION
Take the code `pygame.Vector2((10,20)) * 30`. This operation is handled in the function `vector_generic_math`.

Before this PR, the code checks if `PyFloat_AsDouble` will work using the `RealNumber_Check` function, then it calls `PyFloat_AsDouble`. After this PR, it checks if `PyFloat_AsDouble` will work by calling `PyFloat_AsDouble` and handling the error if it fails. This avoids a call by us into `RealNumber_Check` (`PyNumber_Check` and `!PyComplex_Check`). I checked the Python source code, the code in `PyNumber_Check` is checking the same things `PyFloat_AsDouble` does, and PyComplex doesn't provide the right internal functions to be converted to a float/double.

Test results:
| Code                        | Speedup |
|-----------------------------|---------|
| Vector2 * float             | 5.7%    |
| Vector2.elementwise + float | 5.8%    |

Results are quite noisy, especially since this is a relatively small optimization. I still it's worth checking in though!

<details>
  <summary>Basic testing script</summary>

```py
import pygame
import time
import random

l = [pygame.Vector2(random.random() * 100, random.random() * 100) for _ in range(200)]
le = [v.elementwise() for v in l]

start = time.time()
for _ in range(10000):
    for v in le:
        v + 3.956
print(time.time()-start)

start = time.time()
for _ in range(10000):
    for v in l:
        v * 3.956
print(time.time()-start)
```
</details>

