### PR TITLE
Optimize vector creation/update using pg_VectorCoordsFromObj

### DIFF
--- a/src_c/math.c
+++ b/src_c/math.c
@@ -2340,13 +2340,8 @@ static int
 _vector2_set(pgVector *self, PyObject *xOrSequence, PyObject *y)
 {
     if (xOrSequence) {
-        if (pgVectorCompatible_Check(xOrSequence, self->dim)) {
-            if (!PySequence_AsVectorCoords(xOrSequence, self->coords, 2)) {
-                return -1;
-            }
-            else {
-                return 0;
-            }
+        if (pg_VectorCoordsFromObj(xOrSequence, 2, self->coords)) {
+            return 0;
         }
         else if (RealNumber_Check(xOrSequence)) {
             self->coords[0] = PyFloat_AsDouble(xOrSequence);
@@ -2788,13 +2783,8 @@ static int
 _vector3_set(pgVector *self, PyObject *xOrSequence, PyObject *y, PyObject *z)
 {
     if (xOrSequence) {
-        if (pgVectorCompatible_Check(xOrSequence, self->dim)) {
-            if (!PySequence_AsVectorCoords(xOrSequence, self->coords, 3)) {
-                return -1;
-            }
-            else {
-                return 0;
-            }
+        if (pg_VectorCoordsFromObj(xOrSequence, 3, self->coords)) {
+            return 0;
         }
         else if (RealNumber_Check(xOrSequence)) {
             self->coords[0] = PyFloat_AsDouble(xOrSequence);


### PR DESCRIPTION
Rather than using `pgVectorCompatible_Check` and then `PySequence_AsVectorCoords`, which have duplicative operations, we can use `pg_VectorCoordsFromObj` to try to unpack directly, for a speedup when processing sequence input.

This also shrinks the code (nice for an optimization to do that).

I ran benchmarks and averaged results, here are the benchmarks that changed by 3% or more.

| Code                          | Speedup |
|-------------------------------|---------|
| Vector2(int tuple)            | 22%     |
| Vector2(float tuple)          | 29%     |
| Vector2(Vector2)              | 12%     |
| Vector3(int, int, int)        | -9%     |
| Vector3(float, float, float)  | -4%     |
| Vector3(int tuple)            | 25%     |
| Vector3(float tuple)          | 32%     |
| Vector3(int broadcast)        | -7%     |
| Vector3(float broadcast)      | -5%     |
| Vector3(Vector3)              | 6%      |
| Vector2.update(int tuple)     | 23%     |
| Vector2.update(int broadcast) | 4%      |
| Vector2.update(Vector2)       | 13%     |
| Vector3.update(int, int, int) | 3%      |
| Vector3.update(int tuple)     | 28%     |
| Vector3.update(Vector3)       | 11%     |

I don't understand the slowdowns seen in Vector3 construction, because they don't happen in Vector2/3 update or Vector2 creation. If you read through the code of the 3 helper methods in the scope of this PR it should be unequivocally faster. But I didn't think it was worth just changing vector2, and I think the improvement is worth it overall. I'm interested if somebody not on MSVC gets the same results there.

<details>
  <summary>Basic testing script</summary>

```py
import pygame
import time


def test_create(cls, *args, iterations=1000000):
    start = time.time()
    for _ in range(iterations):
        x = cls(*args)
    return time.time() - start


print("Vector2()\t\t", test_create(pygame.Vector2))
print("Vector2(int, int)\t", test_create(pygame.Vector2, 24,12))
print("Vector2(float, float)\t", test_create(pygame.Vector2, 24.2,12.9))
print("Vector2(int tuple)\t", test_create(pygame.Vector2, (24,12)))
print("Vector2(float tuple)\t", test_create(pygame.Vector2, (24.2,12.9)))
print("Vector2(int)\t\t", test_create(pygame.Vector2, 24))
print("Vector2(float)\t\t", test_create(pygame.Vector2, 24.2))
print("Vector2(Vector2)\t", test_create(pygame.Vector2, pygame.Vector2(24.2,12.9)))
print("Vector2(str)\t\t", test_create(pygame.Vector2, repr(pygame.Vector2(24.2,12.9))))

print("Vector3()\t\t", test_create(pygame.Vector3))
print("Vector3(int, int)\t", test_create(pygame.Vector3, 24,12,4))
print("Vector3(float, float)\t", test_create(pygame.Vector3, 24.2,12.9,4.2))
print("Vector3(int tuple)\t", test_create(pygame.Vector3, (24,12,4)))
print("Vector3(float tuple)\t", test_create(pygame.Vector3, (24.2,12.9,4.2)))
print("Vector3(int)\t\t", test_create(pygame.Vector3, 24))
print("Vector3(float)\t\t", test_create(pygame.Vector3, 24.2))
print("Vector3(Vector3)\t", test_create(pygame.Vector3, pygame.Vector3(24.2,12.9,4.2)))
print("Vector3(str)\t\t", test_create(pygame.Vector3, repr(pygame.Vector3(24.2,12.9,4.2))))


def test_update(instance, *args, iterations=1000000):
    start = time.time()
    for _ in range(iterations):
        instance.update(*args)
    return time.time() - start


print("Vector2.update(int, int)\t", test_update(pygame.Vector2(24.2,12.9), 27.2, 23.1))
print("Vector2.update(int tuple)\t", test_update(pygame.Vector2(24.2,12.9), (27.2, 23.1)))
print("Vector2.update(int)\t\t", test_update(pygame.Vector2(24.2,12.9), 27.2))
print("Vector2.update(Vector2)\t\t", test_update(pygame.Vector2(24.2,12.9), pygame.Vector2(14.2,10.9)))
print("Vector3.update(int, int)\t", test_update(pygame.Vector3(24.2,12.9,4.2), 27.2, 23.1, 62.9))
print("Vector3.update(int tuple)\t", test_update(pygame.Vector3(24.2,12.9,4.2), (27.2, 23.1, 62.9)))
print("Vector3.update(int)\t\t", test_update(pygame.Vector3(24.2,12.9,4.2), 27.2))
print("Vector3.update(Vector3)\t\t", test_update(pygame.Vector3(24.2,12.9,4.2), pygame.Vector3(14.2,10.9,42.2)))
```
</details>