### PR TITLE
Fix palettes in `newsurf_fromsurf`

### DIFF
--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -136,7 +136,7 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
     /* Copy palette, colorkey, etc info */
     if (SDL_ISPIXELFORMAT_INDEXED(PG_SURF_FORMATENUM(surf))) {
         SDL_Palette *newsurf_palette = PG_GetSurfacePalette(newsurf);
-        SDL_Palette *surf_palette = PG_GetSurfacePalette(newsurf);
+        SDL_Palette *surf_palette = PG_GetSurfacePalette(surf);
 
         if (newsurf_palette == NULL) {
             PyErr_SetString(

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1449,6 +1449,39 @@ class TransformModuleTest(unittest.TestCase):
         for pt, color in gradient:
             self.assertTrue(s.get_at(pt) == color)
 
+    def test_rotate_after_convert_regression(self):
+        # Tests a regression found from https://github.com/pygame-community/pygame-ce/pull/3314
+        # Reported in https://github.com/pygame-community/pygame-ce/issues/3463
+
+        pygame.display.set_mode((1, 1))
+
+        output1 = pygame.transform.rotate(
+            pygame.image.load(
+                os.path.join(
+                    os.path.abspath(os.path.dirname(__file__)),
+                    "../examples/data/alien1.png",
+                )
+            ).convert_alpha(),
+            180,
+        )
+        output2 = pygame.transform.rotate(
+            pygame.image.load(
+                os.path.join(
+                    os.path.abspath(os.path.dirname(__file__)),
+                    "../examples/data/alien1.png",
+                )
+            ),
+            180,
+        ).convert_alpha()
+
+        for x in range(50):
+            for y in range(50):
+                color1 = pygame.Color(output1.get_at((x, y)))
+                color2 = pygame.Color(output2.get_at((x, y)))
+                self.assertEqual(color1, color2)
+
+        pygame.quit()
+
     def test_scale2x(self):
         # __doc__ (as of 2008-06-25) for pygame.transform.scale2x:
 


### PR DESCRIPTION
#3314 had an uncaught issue that means `newsurf_fromsurf` instantiates palettes incorrectly, causing .... white. I reported this before when I was trying to revive #2354, but I could only point to the specific PR that broke it. Now that #3463 has been opened, I investigated further and finally found the source of the problem. I haven't tested it on my `pixelate` problem, but I suspect this is the cause there as well because it's the same symptom

Closes #3463 and should also close #3370, but I'll verify that one manually at a later date