### PR TITLE
Add conditional skip to testSavePaletteAsPNG8

### DIFF
--- a/test/image_test.py
+++ b/test/image_test.py
@@ -268,6 +268,11 @@ class ImageModuleTest(unittest.TestCase):
             del reader
             os.remove(f_path)
 
+    @unittest.skipIf(
+        "PG_DEPS_FROM_SYSTEM" in os.environ,
+        "If we are using system dependencies, we don't know the backend used "
+        "for PNG saving, and this test only works with libpng.",
+    )
     def testSavePaletteAsPNG8(self):
         """see if we can save a png with color values in the proper channels."""
         # Create a PNG file with known colors


### PR DESCRIPTION
Some of our unit tests currently fail when SDL2_image doesn't use the libpng backend.

I opened 2 PRs on SDL2_image to fix most of these fails (https://github.com/libsdl-org/SDL_image/pull/560 and https://github.com/libsdl-org/SDL_image/pull/559) but there's still one remaining test that just cannot be fixed easily with the miniz backend (the backend that SDL2_image uses when libpng isn't used). This test tests that PNG images with a palette are saving retaining the exact same palette in the PNG.

For now I will just add a conditional skip in the same style that we use for a few of our mixer/music tests.