### PR TITLE
Remove redundant tp_getattro sets

### DIFF
--- a/src_c/math.c
+++ b/src_c/math.c
@@ -3732,7 +3732,6 @@ static PyTypeObject pgVectorIter_Type = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "pygame.math.VectorIterator",
     .tp_basicsize = sizeof(vectoriter),
     .tp_dealloc = (destructor)vectoriter_dealloc,
-    .tp_getattro = PyObject_GenericGetAttr,
     /* VectorIterator is not subtypable for now, no Py_TPFLAGS_BASETYPE */
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_iter = PyObject_SelfIter,

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -1941,7 +1941,6 @@ MODINIT_DEFINE(pixelarray)
         Py_DECREF(module);
         return NULL;
     }
-    pgPixelArray_Type.tp_getattro = PyObject_GenericGetAttr;
 
     c_api[0] = &pgPixelArray_Type;
     c_api[1] = pgPixelArray_New;


### PR DESCRIPTION
tp_getattro = PyObject_GenericGetAttr is the default, so we don't need to set it.

See https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_getattro

I verified this by printf-ing the value of tp_getattro before it gets set, it's already been set to the address of PyObject_GenericGetAttr by PyType_Ready.

For the curious, this the pixelarray one was originally committed in https://github.com/pygame-community/pygame-ce/commit/284267bb114c3ee0bc74006f4973c99203941727