### PR TITLE
Add versionchanged note to Mask.to_surface

### DIFF
--- a/docs/reST/ref/mask.rst
+++ b/docs/reST/ref/mask.rst
@@ -641,6 +641,8 @@ to store which parts collide.
 
       .. versionaddedold:: 2.0.0
 
+      .. versionchanged:: 2.5.6 Added the area keyword argument.
+
       .. ## Mask.to_surface ##
 
    .. ## pygame.mask.Mask ##


### PR DESCRIPTION
I approved and merged #2670 but immediately realised that there was no addition of a versionchanged note... so here it is