### PR TITLE
Use macro for exception raising

### DIFF
--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -1890,9 +1890,8 @@ camera_init(pgCameraObject *self, PyObject *arg, PyObject *kwargs)
     p = windows_device_from_name(dev_name);
 
     if (!p) {
-        PyErr_SetString(PyExc_ValueError,
-                        "Couldn't find a camera with that name");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "Couldn't find a camera with that name",
+                    -1);
     }
 
     if (color) {
@@ -1928,9 +1927,8 @@ camera_init(pgCameraObject *self, PyObject *arg, PyObject *kwargs)
 
     return 0;
 #else
-    PyErr_SetString(PyExc_RuntimeError,
-                    "_camera backend not available on your platform");
-    return -1;
+    RAISERETURN(PyExc_RuntimeError,
+                "_camera backend not available on your platform", -1);
 #endif
 }
 

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -580,8 +580,7 @@ typedef enum {
 #define DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value)                           \
     do {                                                                      \
         if (!value) {                                                         \
-            PyErr_SetString(PyExc_AttributeError, "Cannot delete attribute"); \
-            return -1;                                                        \
+            RAISERETURN(PyExc_AttributeError, "Cannot delete attribute", -1); \
         }                                                                     \
     } while (0)
 

--- a/src_c/_sdl2/controller.c
+++ b/src_c/_sdl2/controller.c
@@ -485,8 +485,7 @@ controller_init(pgControllerObject *self, PyObject *args, PyObject *kwargs)
     if (self->controller == NULL) {
         controller = SDL_GameControllerOpen(self->id);
         if (controller == NULL) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
-            return -1;
+            RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
         }
         self->controller = controller;
     }

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -909,7 +909,7 @@ pgGetArrayStruct(PyObject *obj, PyObject **cobj_p, PyArrayInterface **inter_p)
     if (cobj == NULL) {
         if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
             PyErr_Clear();
-            PyErr_SetString(PyExc_ValueError, "no C-struct array interface");
+            RAISERETURN(PyExc_ValueError, "no C-struct array interface", -1);
         }
         return -1;
     }
@@ -920,8 +920,7 @@ pgGetArrayStruct(PyObject *obj, PyObject **cobj_p, PyArrayInterface **inter_p)
 
     if (inter == NULL || inter->two != 2 /* conditional or */) {
         Py_DECREF(cobj);
-        PyErr_SetString(PyExc_ValueError, "invalid array interface");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid array interface", -1);
     }
 
     *cobj_p = cobj;
@@ -944,10 +943,9 @@ pgArrayStruct_AsDict(PyArrayInterface *inter_p)
     if (inter_p->flags & PAI_ARR_HAS_DESCR) {
         if (!inter_p->descr) {
             Py_DECREF(dictobj);
-            PyErr_SetString(PyExc_ValueError,
-                            "Array struct has descr flag set"
-                            " but no descriptor");
-            return 0;
+            RAISERETURN(PyExc_ValueError,
+                        "Array struct has descr flag set  but no descriptor",
+                        0);
         }
         if (PyDict_SetItemString(dictobj, "descr", inter_p->descr)) {
             Py_DECREF(dictobj);
@@ -1332,15 +1330,13 @@ pgObject_GetBuffer(PyObject *obj, pg_buffer *pg_view_p, int flags)
                 break;
             default:
                 pgBuffer_Release(pg_view_p);
-                PyErr_SetString(PyExc_ValueError,
-                                "Unsupported array element type");
-                return -1;
+                RAISERETURN(PyExc_ValueError, "Unsupported array element type",
+                            -1);
         }
         if (*fchar_p != '\0') {
             pgBuffer_Release(pg_view_p);
-            PyErr_SetString(PyExc_ValueError,
-                            "Arrays of records are unsupported");
-            return -1;
+            RAISERETURN(PyExc_ValueError, "Arrays of records are unsupported",
+                        -1);
         }
         success = 1;
     }
@@ -1476,7 +1472,7 @@ pgGetArrayInterface(PyObject **dict, PyObject *obj)
     if (inter == NULL) {
         if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
             PyErr_Clear();
-            PyErr_SetString(PyExc_ValueError, "no array interface");
+            RAISERETURN(PyExc_ValueError, "no array interface", -1)
         }
         return -1;
     }
@@ -1517,29 +1513,25 @@ _pg_arraystruct_as_buffer(Py_buffer *view_p, PyObject *cobj,
     view_p->obj = 0;
     view_p->internal = 0;
     if (PyBUF_HAS_FLAG(flags, PyBUF_WRITABLE) && readonly) {
-        PyErr_SetString(pgExc_BufferError,
-                        "require writable buffer, but it is read-only");
-        return -1;
+        RAISERETURN(pgExc_BufferError,
+                    "require writable buffer, but it is read-only", -1);
     }
     if (PyBUF_HAS_FLAG(flags, PyBUF_ANY_CONTIGUOUS)) {
         if (!(inter_p->flags & (PAI_CONTIGUOUS | PAI_FORTRAN))) {
-            PyErr_SetString(pgExc_BufferError,
-                            "buffer data is not contiguous");
-            return -1;
+            RAISERETURN(pgExc_BufferError, "buffer data is not contiguous",
+                        -1);
         }
     }
     else if (PyBUF_HAS_FLAG(flags, PyBUF_C_CONTIGUOUS)) {
         if (!(inter_p->flags & PAI_CONTIGUOUS)) {
-            PyErr_SetString(pgExc_BufferError,
-                            "buffer data is not C contiguous");
-            return -1;
+            RAISERETURN(pgExc_BufferError, "buffer data is not C contiguous",
+                        -1);
         }
     }
     else if (PyBUF_HAS_FLAG(flags, PyBUF_F_CONTIGUOUS)) {
         if (!(inter_p->flags & PAI_FORTRAN)) {
-            PyErr_SetString(pgExc_BufferError,
-                            "buffer data is not F contiguous");
-            return -1;
+            RAISERETURN(pgExc_BufferError, "buffer data is not F contiguous",
+                        -1);
         }
     }
     internal_p = (pgViewInternals *)PyMem_Malloc(sz);
@@ -1573,9 +1565,8 @@ _pg_arraystruct_as_buffer(Py_buffer *view_p, PyObject *cobj,
         view_p->shape = 0;
     }
     else {
-        PyErr_SetString(pgExc_BufferError,
-                        "buffer data is not C contiguous, shape needed");
-        return -1;
+        RAISERETURN(pgExc_BufferError,
+                    "buffer data is not C contiguous, shape needed", -1);
     }
     if (PyBUF_HAS_FLAG(flags, PyBUF_STRIDES)) {
         view_p->strides = view_p->shape + inter_p->nd;
@@ -1587,9 +1578,8 @@ _pg_arraystruct_as_buffer(Py_buffer *view_p, PyObject *cobj,
         view_p->strides = 0;
     }
     else {
-        PyErr_SetString(pgExc_BufferError,
-                        "buffer is not contiguous, strides needed");
-        return -1;
+        RAISERETURN(pgExc_BufferError,
+                    "buffer is not contiguous, strides needed", -1);
     }
     view_p->suboffsets = 0;
     view_p->len = view_p->itemsize;
@@ -1757,18 +1747,15 @@ static int
 _pg_shape_check(PyObject *op)
 {
     if (!op) {
-        PyErr_SetString(PyExc_ValueError, "required 'shape' item is missing");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "required 'shape' item is missing", -1);
     }
     if (!_pg_is_int_tuple(op)) {
-        PyErr_SetString(PyExc_ValueError,
-                        "expected a tuple of ints for 'shape'");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "expected a tuple of ints for 'shape'",
+                    -1);
     }
     if (PyTuple_GET_SIZE(op) == 0) {
-        PyErr_SetString(PyExc_ValueError,
-                        "expected 'shape' to be at least one-dimensional");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "expected 'shape' to be at least one-dimensional", -1);
     }
     return 0;
 }
@@ -1777,28 +1764,23 @@ static int
 _pg_typestr_check(PyObject *op)
 {
     if (!op) {
-        PyErr_SetString(PyExc_ValueError,
-                        "required 'typestr' item is missing");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "required 'typestr' item is missing",
+                    -1);
     }
     if (PyUnicode_Check(op)) {
-        Py_ssize_t len = PyUnicode_GET_LENGTH(op);
-        if (len != 3) {
-            PyErr_SetString(PyExc_ValueError,
-                            "expected 'typestr' to be length 3");
-            return -1;
+        if (PyUnicode_GET_LENGTH(op) != 3) {
+            RAISERETURN(PyExc_ValueError, "expected 'typestr' to be length 3",
+                        -1);
         }
     }
     else if (PyBytes_Check(op)) {
         if (PyBytes_GET_SIZE(op) != 3) {
-            PyErr_SetString(PyExc_ValueError,
-                            "expected 'typestr' to be length 3");
-            return -1;
+            RAISERETURN(PyExc_ValueError, "expected 'typestr' to be length 3",
+                        -1);
         }
     }
     else {
-        PyErr_SetString(PyExc_ValueError, "expected a string for 'typestr'");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "expected a string for 'typestr'", -1);
     }
     return 0;
 }
@@ -1809,23 +1791,19 @@ _pg_data_check(PyObject *op)
     PyObject *item;
 
     if (!op) {
-        PyErr_SetString(PyExc_ValueError, "required 'data' item is missing");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "required 'data' item is missing", -1);
     }
     if (!PyTuple_Check(op)) {
-        PyErr_SetString(PyExc_ValueError, "expected a tuple for 'data'");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "expected a tuple for 'data'", -1);
     }
     if (PyTuple_GET_SIZE(op) != 2) {
-        PyErr_SetString(PyExc_ValueError,
-                        "expected a length 2 tuple for 'data'");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "expected a length 2 tuple for 'data'",
+                    -1);
     }
     item = PyTuple_GET_ITEM(op, 0);
     if (!PyLong_Check(item)) {
-        PyErr_SetString(PyExc_ValueError,
-                        "expected an int for item 0 of 'data'");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "expected an int for item 0 of 'data'",
+                    -1);
     }
     return 0;
 }
@@ -1834,9 +1812,8 @@ static int
 _pg_strides_check(PyObject *op)
 {
     if (op && !_pg_is_int_tuple(op) /* Conditional && */) {
-        PyErr_SetString(PyExc_ValueError,
-                        "expected a tuple of ints for 'strides'");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "expected a tuple of ints for 'strides'",
+                    -1);
     }
     return 0;
 }
@@ -1873,9 +1850,8 @@ _pg_values_as_buffer(Py_buffer *view_p, int flags, PyObject *typestr,
     view_p->obj = 0;
     view_p->internal = 0;
     if (strides && PyTuple_GET_SIZE(strides) != ndim /* Cond. && */) {
-        PyErr_SetString(PyExc_ValueError,
-                        "'shape' and 'strides' are not the same length");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "'shape' and 'strides' are not the same length", -1);
     }
     view_p->ndim = (int)ndim;
     view_p->buf = PyLong_AsVoidPtr(PyTuple_GET_ITEM(data, 0));
@@ -1887,9 +1863,8 @@ _pg_values_as_buffer(Py_buffer *view_p, int flags, PyObject *typestr,
         return -1;
     }
     if (PyBUF_HAS_FLAG(flags, PyBUF_WRITABLE) && view_p->readonly) {
-        PyErr_SetString(pgExc_BufferError,
-                        "require writable buffer, but it is read-only");
-        return -1;
+        RAISERETURN(pgExc_BufferError,
+                    "require writable buffer, but it is read-only", -1);
     }
     sz = sizeof(pgViewInternals) + (2 * ndim - 1) * sizeof(Py_ssize_t);
     internal_p = (pgViewInternals *)PyMem_Malloc(sz);
@@ -1928,23 +1903,20 @@ _pg_values_as_buffer(Py_buffer *view_p, int flags, PyObject *typestr,
     }
     if (PyBUF_HAS_FLAG(flags, PyBUF_ANY_CONTIGUOUS)) {
         if (!PyBuffer_IsContiguous(view_p, 'A')) {
-            PyErr_SetString(pgExc_BufferError,
-                            "buffer data is not contiguous");
-            return -1;
+            RAISERETURN(pgExc_BufferError, "buffer data is not contiguous",
+                        -1);
         }
     }
     else if (PyBUF_HAS_FLAG(flags, PyBUF_C_CONTIGUOUS)) {
         if (!PyBuffer_IsContiguous(view_p, 'C')) {
-            PyErr_SetString(pgExc_BufferError,
-                            "buffer data is not C contiguous");
-            return -1;
+            RAISERETURN(pgExc_BufferError, "buffer data is not C contiguous",
+                        -1);
         }
     }
     else if (PyBUF_HAS_FLAG(flags, PyBUF_F_CONTIGUOUS)) {
         if (!PyBuffer_IsContiguous(view_p, 'F')) {
-            PyErr_SetString(pgExc_BufferError,
-                            "buffer data is not F contiguous");
-            return -1;
+            RAISERETURN(pgExc_BufferError, "buffer data is not F contiguous",
+                        -1);
         }
     }
     if (!PyBUF_HAS_FLAG(flags, PyBUF_STRIDES)) {
@@ -1952,9 +1924,8 @@ _pg_values_as_buffer(Py_buffer *view_p, int flags, PyObject *typestr,
             view_p->strides = 0;
         }
         else {
-            PyErr_SetString(pgExc_BufferError,
-                            "buffer data is not C contiguous, strides needed");
-            return -1;
+            RAISERETURN(pgExc_BufferError,
+                        "buffer data is not C contiguous, strides needed", -1);
         }
     }
     if (!PyBUF_HAS_FLAG(flags, PyBUF_ND)) {
@@ -1962,9 +1933,8 @@ _pg_values_as_buffer(Py_buffer *view_p, int flags, PyObject *typestr,
             view_p->shape = 0;
         }
         else {
-            PyErr_SetString(pgExc_BufferError,
-                            "buffer data is not C contiguous, shape needed");
-            return -1;
+            RAISERETURN(pgExc_BufferError,
+                        "buffer data is not C contiguous, shape needed", -1);
         }
     }
     if (!PyBUF_HAS_FLAG(flags, PyBUF_FORMAT)) {

--- a/src_c/bufferproxy.c
+++ b/src_c/bufferproxy.c
@@ -349,8 +349,7 @@ proxy_get_raw(pgBufferProxyObject *self, PyObject *closure)
     }
     if (!PyBuffer_IsContiguous(view_p, 'A')) {
         _proxy_release_view(self);
-        PyErr_SetString(PyExc_ValueError, "the bytes are not contiguous");
-        return 0;
+        RAISERETURN(PyExc_ValueError, "the bytes are not contiguous", 0);
     }
     py_raw = PyBytes_FromStringAndSize((char *)view_p->buf, view_p->len);
     if (!py_raw) {
@@ -414,22 +413,19 @@ proxy_write(pgBufferProxyObject *self, PyObject *args, PyObject *kwds)
     if (!PyBuffer_IsContiguous(&view, 'A')) {
         proxy_releasebuffer(self, &view);
         Py_DECREF(self);
-        PyErr_SetString(PyExc_ValueError,
-                        "the BufferProxy bytes are not contiguous");
-        return 0;
+        RAISERETURN(PyExc_ValueError,
+                    "the BufferProxy bytes are not contiguous", 0);
     }
     if (buflen > view.len) {
         proxy_releasebuffer(self, &view);
         Py_DECREF(self);
-        PyErr_SetString(PyExc_ValueError,
-                        "'buffer' object length is too large");
-        return 0;
+        RAISERETURN(PyExc_ValueError, "'buffer' object length is too large",
+                    0);
     }
     if (offset < 0 || buflen + offset > view.len) {
         proxy_releasebuffer(self, &view);
         Py_DECREF(self);
-        PyErr_SetString(PyExc_IndexError, "'offset' is out of range");
-        return 0;
+        RAISERETURN(PyExc_IndexError, "'offset' is out of range", 0);
     }
     memcpy((char *)view.buf + offset, buf, (size_t)buflen);
     proxy_releasebuffer(self, &view);
@@ -534,10 +530,10 @@ pgBufferProxy_New(PyObject *obj, getbufferproc get_buffer)
 {
     if (!get_buffer) {
         if (!obj) {
-            PyErr_SetString(PyExc_ValueError,
-                            "One of arguments 'obj' or 'get_buffer' is "
-                            "required: both NULL instead");
-            return 0;
+            RAISERETURN(PyExc_ValueError,
+                        "One of arguments 'obj' or 'get_buffer' is required: "
+                        "both NULL instead",
+                        0);
         }
         get_buffer = (getbufferproc)pgObject_GetBuffer;
     }

--- a/src_c/camera_windows.c
+++ b/src_c/camera_windows.c
@@ -97,13 +97,13 @@ _check_integrity(pgCameraObject *self)
     if (FAILED(self->t_error)) {
         /* MF_E_HW_MFT_FAILED_START_STREAMING */
         if (self->t_error == (HRESULT)-1072875772) {
-            PyErr_SetString(PyExc_SystemError,
-                            "Camera already in use (Capture Thread Quit)");
+            RAISERETURN(PyExc_SystemError,
+                        "Camera already in use (Capture Thread Quit)", 0);
         }
         /* MF_E_VIDEO_RECORDING_DEVICE_INVALIDATED */
         else if (self->t_error == (HRESULT)-1072873822) {
-            PyErr_SetString(PyExc_SystemError,
-                            "Camera disconnected (Capture Thread Quit)");
+            RAISERETURN(PyExc_SystemError,
+                        "Camera disconnected (Capture Thread Quit)", 0);
         }
         else {
             T_FORMATHR(self->t_error, self->t_error_line)
@@ -321,9 +321,8 @@ _select_source_type(pgCameraObject *self, IMFMediaType **mp)
     }
 
     if (!type_count) {
-        PyErr_SetString(pgExc_SDLError,
-                        "Could not find any video types on this camera");
-        return 0;
+        RAISERETURN(pgExc_SDLError,
+                    "Could not find any video types on this camera", 0);
     }
 
     native_types = malloc(sizeof(IMFMediaType *) * type_count);
@@ -382,9 +381,8 @@ _select_source_type(pgCameraObject *self, IMFMediaType **mp)
     }
 
     if (index == -1) {
-        PyErr_SetString(pgExc_SDLError,
-                        "Could not find a valid video type in any supported"
-                        " format");
+        RAISE(pgExc_SDLError,
+              "Could not find a valid video type in any supported format");
         hr = HR_UPSTREAM_FAILURE;
         goto cleanup;
     }
@@ -803,9 +801,8 @@ windows_read_frame(pgCameraObject *self, SDL_Surface *surf)
     HRESULT hr;
 
     if (!self->open) {
-        PyErr_SetString(pgExc_SDLError,
-                        "Camera needs to be started to read data");
-        return 0;
+        RAISERETURN(pgExc_SDLError, "Camera needs to be started to read data",
+                    0);
     }
 
     if (!_check_integrity(self)) {
@@ -839,9 +836,8 @@ windows_frame_ready(pgCameraObject *self, int *result)
     *result = self->buffer_ready;
 
     if (!self->open) {
-        PyErr_SetString(pgExc_SDLError,
-                        "Camera needs to be started to read data");
-        return 0;
+        RAISERETURN(pgExc_SDLError, "Camera needs to be started to read data",
+                    0);
     }
 
     if (!_check_integrity(self)) {
@@ -858,9 +854,8 @@ windows_read_raw(pgCameraObject *self)
     HRESULT hr;
 
     if (!self->open) {
-        PyErr_SetString(pgExc_SDLError,
-                        "Camera needs to be started to read data");
-        return 0;
+        RAISERETURN(pgExc_SDLError, "Camera needs to be started to read data",
+                    0);
     }
 
     if (!_check_integrity(self)) {
@@ -877,9 +872,8 @@ windows_read_raw(pgCameraObject *self)
 
         data = PyBytes_FromStringAndSize(buf_data, buf_length);
         if (!data) {
-            PyErr_SetString(pgExc_SDLError,
-                            "Error constructing bytes from data");
-            return 0;
+            RAISERETURN(pgExc_SDLError, "Error constructing bytes from data",
+                        0);
         }
 
         hr = self->raw_buf->lpVtbl->Unlock(self->raw_buf);

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -44,12 +44,11 @@ static int
 pg_circle_init(pgCircleObject *self, PyObject *args, PyObject *kwds)
 {
     if (!pgCircle_FromObject(args, &self->circle)) {
-        PyErr_SetString(
-            PyExc_TypeError,
-            "Arguments must be a Circle, a sequence of length 3 or 2, or an "
-            "object with an attribute called 'circle', all with corresponding "
-            "nonnegative radius argument");
-        return -1;
+        RAISERETURN(PyExc_TypeError,
+                    "Arguments must be a Circle, a sequence of length 3 or 2, "
+                    "or an object with an attribute called 'circle', all with "
+                    "corresponding nonnegative radius argument",
+                    -1);
     }
     return 0;
 }
@@ -139,10 +138,8 @@ static PyObject *
 pg_circle_update(pgCircleObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     if (!pgCircle_FromObjectFastcall(args, nargs, &self->circle)) {
-        PyErr_SetString(
-            PyExc_TypeError,
-            "Circle.update requires a circle or CircleLike object");
-        return NULL;
+        return RAISE(PyExc_TypeError,
+                     "Circle.update requires a circle or CircleLike object");
     }
     Py_RETURN_NONE;
 }
@@ -334,18 +331,17 @@ _pg_circle_collideswith(pgCircleBase *scirc, PyObject *arg)
     else if (PySequence_Check(arg)) {
         double x, y;
         if (!pg_TwoDoublesFromObj(arg, &x, &y)) {
-            PyErr_SetString(
+            RAISERETURN(
                 PyExc_TypeError,
-                "Invalid point argument, must be a sequence of two numbers");
-            return -1;
+                "Invalid point argument, must be a sequence of two numbers",
+                -1);
         }
         result = pgCollision_CirclePoint(scirc, x, y);
     }
     else {
-        PyErr_SetString(
-            PyExc_TypeError,
-            "Invalid point argument, must be a sequence of 2 numbers");
-        return -1;
+        RAISERETURN(PyExc_TypeError,
+                    "Invalid point argument, must be a sequence of 2 numbers",
+                    -1);
     }
 
     return result;
@@ -672,8 +668,7 @@ pg_circle_setr(pgCircleObject *self, PyObject *value, void *closure)
     }
 
     if (radius < 0) {
-        PyErr_SetString(PyExc_ValueError, "Radius must be nonnegative");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "Radius must be nonnegative", -1);
     }
 
     self->circle.r = radius;
@@ -695,15 +690,13 @@ pg_circle_setr_sqr(pgCircleObject *self, PyObject *value, void *closure)
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
     if (!pg_DoubleFromObj(value, &radius_squared)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Invalid type for radius squared, must be numeric");
-        return -1;
+        RAISERETURN(PyExc_TypeError,
+                    "Invalid type for radius squared, must be numeric", -1);
     }
 
     if (radius_squared < 0) {
-        PyErr_SetString(PyExc_ValueError,
-                        "Invalid radius squared value, must be nonnegative");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "Invalid radius squared value, must be nonnegative", -1);
     }
 
     self->circle.r = sqrt(radius_squared);
@@ -722,8 +715,7 @@ pg_circle_setcenter(pgCircleObject *self, PyObject *value, void *closure)
 {
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
     if (!pg_TwoDoublesFromObj(value, &self->circle.x, &self->circle.y)) {
-        PyErr_SetString(PyExc_TypeError, "Expected a sequence of 2 numbers");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "Expected a sequence of 2 numbers", -1);
     }
     return 0;
 }
@@ -742,15 +734,13 @@ pg_circle_setarea(pgCircleObject *self, PyObject *value, void *closure)
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
     if (!pg_DoubleFromObj(value, &area)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Invalid type for area, must be numeric");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "Invalid type for area, must be numeric",
+                    -1);
     }
 
     if (area < 0) {
-        PyErr_SetString(PyExc_ValueError,
-                        "Invalid area value, must be nonnegative");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "Invalid area value, must be nonnegative", -1);
     }
 
     self->circle.r = sqrt(area / M_PI);
@@ -773,15 +763,13 @@ pg_circle_setcircumference(pgCircleObject *self, PyObject *value,
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
     if (!pg_DoubleFromObj(value, &circumference)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Invalid type for circumference, must be numeric");
-        return -1;
+        RAISERETURN(PyExc_TypeError,
+                    "Invalid type for circumference, must be numeric", -1);
     }
 
     if (circumference < 0) {
-        PyErr_SetString(PyExc_ValueError,
-                        "Invalid circumference value, must be nonnegative");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "Invalid circumference value, must be nonnegative", -1);
     }
 
     self->circle.r = circumference / M_TWOPI;
@@ -803,15 +791,13 @@ pg_circle_setdiameter(pgCircleObject *self, PyObject *value, void *closure)
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
     if (!pg_DoubleFromObj(value, &diameter)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Invalid type for diameter, must be numeric");
-        return -1;
+        RAISERETURN(PyExc_TypeError,
+                    "Invalid type for diameter, must be numeric", -1);
     }
 
     if (diameter < 0) {
-        PyErr_SetString(PyExc_ValueError,
-                        "Invalid diameter value, must be nonnegative");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "Invalid diameter value, must be nonnegative", -1);
     }
 
     self->circle.r = diameter / 2;
@@ -834,8 +820,7 @@ pg_circle_settop(pgCircleObject *self, PyObject *value, void *closure)
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
     if (!pg_TwoDoublesFromObj(value, &x, &y)) {
-        PyErr_SetString(PyExc_TypeError, "Expected a sequence of 2 numbers");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "Expected a sequence of 2 numbers", -1);
     }
 
     self->circle.y = y + self->circle.r;
@@ -859,8 +844,7 @@ pg_circle_setleft(pgCircleObject *self, PyObject *value, void *closure)
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
     if (!pg_TwoDoublesFromObj(value, &x, &y)) {
-        PyErr_SetString(PyExc_TypeError, "Expected a sequence of 2 numbers");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "Expected a sequence of 2 numbers", -1);
     }
 
     self->circle.x = x + self->circle.r;
@@ -884,8 +868,7 @@ pg_circle_setbottom(pgCircleObject *self, PyObject *value, void *closure)
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
     if (!pg_TwoDoublesFromObj(value, &x, &y)) {
-        PyErr_SetString(PyExc_TypeError, "Expected a sequence of 2 numbers");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "Expected a sequence of 2 numbers", -1);
     }
 
     self->circle.y = y - self->circle.r;
@@ -909,8 +892,7 @@ pg_circle_setright(pgCircleObject *self, PyObject *value, void *closure)
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
     if (!pg_TwoDoublesFromObj(value, &x, &y)) {
-        PyErr_SetString(PyExc_TypeError, "Expected a sequence of 2 numbers");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "Expected a sequence of 2 numbers", -1);
     }
 
     self->circle.x = x - self->circle.r;

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -356,10 +356,9 @@ _get_color_int_component(PyObject *val, Uint8 *color)
     if (PyLong_Check(val)) {
         unsigned long longval = PyLong_AsUnsignedLong(val);
         if (PyErr_Occurred() || (longval > 255)) {
-            PyErr_SetString(
-                PyExc_ValueError,
-                "invalid color component (must be in range [0, 255])");
-            return 0;
+            RAISERETURN(PyExc_ValueError,
+                        "invalid color component (must be in range [0, 255])",
+                        0);
         }
         *color = (Uint8)longval;
         return 1;
@@ -624,8 +623,7 @@ _parse_color_from_text(PyObject *str_obj, Uint8 *rgba)
         color = PyDict_GetItem(_COLORDICT, name2);
         Py_DECREF(name2);
         if (!color) {
-            PyErr_SetString(PyExc_ValueError, "invalid color name");
-            return -1;
+            RAISERETURN(PyExc_ValueError, "invalid color name", -1);
         }
     }
 
@@ -1035,8 +1033,7 @@ _color_set_hsva(pgColorObject *color, PyObject *value, void *closure)
 
     if (!PySequence_Check(value) || PySequence_Size(value) < 3 ||
         PySequence_Size(value) > 4) {
-        PyErr_SetString(PyExc_ValueError, "invalid HSVA value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid HSVA value", -1);
     }
 
     /* H */
@@ -1044,8 +1041,7 @@ _color_set_hsva(pgColorObject *color, PyObject *value, void *closure)
     if (!item || !_get_double(item, &(hsva[0])) || hsva[0] < 0 ||
         hsva[0] > 360) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid HSVA value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid HSVA value", -1);
     }
     Py_DECREF(item);
 
@@ -1054,8 +1050,7 @@ _color_set_hsva(pgColorObject *color, PyObject *value, void *closure)
     if (!item || !_get_double(item, &(hsva[1])) || hsva[1] < 0 ||
         hsva[1] > 100) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid HSVA value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid HSVA value", -1);
     }
     Py_DECREF(item);
 
@@ -1064,8 +1059,7 @@ _color_set_hsva(pgColorObject *color, PyObject *value, void *closure)
     if (!item || !_get_double(item, &(hsva[2])) || hsva[2] < 0 ||
         hsva[2] > 100) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid HSVA value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid HSVA value", -1);
     }
     Py_DECREF(item);
 
@@ -1075,8 +1069,7 @@ _color_set_hsva(pgColorObject *color, PyObject *value, void *closure)
         if (!item || !_get_double(item, &(hsva[3])) || hsva[3] < 0 ||
             hsva[3] > 100) {
             Py_XDECREF(item);
-            PyErr_SetString(PyExc_ValueError, "invalid HSVA value");
-            return -1;
+            RAISERETURN(PyExc_ValueError, "invalid HSVA value", -1);
         }
         Py_DECREF(item);
     }
@@ -1201,8 +1194,7 @@ _color_set_hsla(pgColorObject *color, PyObject *value, void *closure)
 
     if (!PySequence_Check(value) || PySequence_Size(value) < 3 ||
         PySequence_Size(value) > 4) {
-        PyErr_SetString(PyExc_ValueError, "invalid HSLA value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid HSLA value", -1);
     }
 
     /* H */
@@ -1210,8 +1202,7 @@ _color_set_hsla(pgColorObject *color, PyObject *value, void *closure)
     if (!item || !_get_double(item, &(hsla[0])) || hsla[0] < 0 ||
         hsla[0] > 360) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid HSLA value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid HSLA value", -1);
     }
     Py_DECREF(item);
 
@@ -1220,8 +1211,7 @@ _color_set_hsla(pgColorObject *color, PyObject *value, void *closure)
     if (!item || !_get_double(item, &(hsla[1])) || hsla[1] < 0 ||
         hsla[1] > 100) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid HSLA value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid HSLA value", -1);
     }
     Py_DECREF(item);
 
@@ -1230,8 +1220,7 @@ _color_set_hsla(pgColorObject *color, PyObject *value, void *closure)
     if (!item || !_get_double(item, &(hsla[2])) || hsla[2] < 0 ||
         hsla[2] > 100) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid HSLA value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid HSLA value", -1);
     }
     Py_DECREF(item);
 
@@ -1241,8 +1230,7 @@ _color_set_hsla(pgColorObject *color, PyObject *value, void *closure)
         if (!item || !_get_double(item, &(hsla[3])) || hsla[3] < 0 ||
             hsla[3] > 100) {
             Py_XDECREF(item);
-            PyErr_SetString(PyExc_ValueError, "invalid HSLA value");
-            return -1;
+            RAISERETURN(PyExc_ValueError, "invalid HSLA value", -1);
         }
         Py_DECREF(item);
     }
@@ -1366,8 +1354,7 @@ _color_set_i1i2i3(pgColorObject *color, PyObject *value, void *closure)
     DEL_ATTR_NOT_SUPPORTED_CHECK("i1i2i3", value);
 
     if (!PySequence_Check(value) || PySequence_Size(value) != 3) {
-        PyErr_SetString(PyExc_ValueError, "invalid I1I2I3 value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid I1I2I3 value", -1);
     }
 
     /* I1 */
@@ -1375,8 +1362,7 @@ _color_set_i1i2i3(pgColorObject *color, PyObject *value, void *closure)
     if (!item || !_get_double(item, &(i1i2i3[0])) || i1i2i3[0] < 0 ||
         i1i2i3[0] > 1) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid I1I2I3 value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid I1I2I3 value", -1);
     }
     Py_DECREF(item);
 
@@ -1385,8 +1371,7 @@ _color_set_i1i2i3(pgColorObject *color, PyObject *value, void *closure)
     if (!item || !_get_double(item, &(i1i2i3[1])) || i1i2i3[1] < -0.5f ||
         i1i2i3[1] > 0.5f) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid I1I2I3 value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid I1I2I3 value", -1);
     }
     Py_DECREF(item);
 
@@ -1395,8 +1380,7 @@ _color_set_i1i2i3(pgColorObject *color, PyObject *value, void *closure)
     if (!item || !_get_double(item, &(i1i2i3[2])) || i1i2i3[2] < -0.5f ||
         i1i2i3[2] > 0.5f) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid I1I2I3 value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid I1I2I3 value", -1);
     }
     Py_DECREF(item);
 
@@ -1438,16 +1422,14 @@ _color_set_cmy(pgColorObject *color, PyObject *value, void *closure)
     DEL_ATTR_NOT_SUPPORTED_CHECK("cmy", value);
 
     if (!PySequence_Check(value) || PySequence_Size(value) != 3) {
-        PyErr_SetString(PyExc_ValueError, "invalid CMY value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid CMY value", -1);
     }
 
     /* I1 */
     item = PySequence_GetItem(value, 0);
     if (!item || !_get_double(item, &(cmy[0])) || cmy[0] < 0 || cmy[0] > 1) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid CMY value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid CMY value", -1);
     }
     Py_DECREF(item);
 
@@ -1455,8 +1437,7 @@ _color_set_cmy(pgColorObject *color, PyObject *value, void *closure)
     item = PySequence_GetItem(value, 1);
     if (!item || !_get_double(item, &(cmy[1])) || cmy[1] < 0 || cmy[1] > 1) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid CMY value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid CMY value", -1);
     }
     Py_DECREF(item);
 
@@ -1464,8 +1445,7 @@ _color_set_cmy(pgColorObject *color, PyObject *value, void *closure)
     item = PySequence_GetItem(value, 2);
     if (!item || !_get_double(item, &(cmy[2])) || cmy[2] < 0 || cmy[2] > 1) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid CMY value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid CMY value", -1);
     }
     Py_DECREF(item);
 
@@ -1499,16 +1479,14 @@ _color_set_normalized(pgColorObject *color, PyObject *value, void *closure)
 
     if (!PySequence_Check(value) || PySequence_Size(value) < 3 ||
         PySequence_Size(value) > 4) {
-        PyErr_SetString(PyExc_ValueError, "invalid normalized value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid normalized value", -1);
     }
 
     item = PySequence_GetItem(value, 0);
     if (!item || !_get_double(item, &(frgba[0])) || frgba[0] < 0.0 ||
         frgba[0] > 1.0) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid normalized value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid normalized value", -1);
     }
     Py_DECREF(item);
 
@@ -1516,8 +1494,7 @@ _color_set_normalized(pgColorObject *color, PyObject *value, void *closure)
     if (!item || !_get_double(item, &(frgba[1])) || frgba[1] < 0.0 ||
         frgba[1] > 1.0) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid normalized value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid normalized value", -1);
     }
     Py_DECREF(item);
 
@@ -1525,8 +1502,7 @@ _color_set_normalized(pgColorObject *color, PyObject *value, void *closure)
     if (!item || !_get_double(item, &(frgba[2])) || frgba[2] < 0.0 ||
         frgba[2] > 1.0) {
         Py_XDECREF(item);
-        PyErr_SetString(PyExc_ValueError, "invalid normalized value");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "invalid normalized value", -1);
     }
     Py_DECREF(item);
 
@@ -1535,8 +1511,7 @@ _color_set_normalized(pgColorObject *color, PyObject *value, void *closure)
         if (!item || !_get_double(item, &(frgba[3])) || frgba[3] < 0.0 ||
             frgba[3] > 1.0) {
             Py_XDECREF(item);
-            PyErr_SetString(PyExc_ValueError, "invalid normalized value");
-            return -1;
+            RAISERETURN(PyExc_ValueError, "invalid normalized value", -1);
         }
         Py_DECREF(item);
     }
@@ -1563,14 +1538,12 @@ _color_set_hex(pgColorObject *color, PyObject *value, void *closure)
     DEL_ATTR_NOT_SUPPORTED_CHECK("hex", value);
 
     if (!PyUnicode_Check(value)) {
-        PyErr_SetString(PyExc_TypeError, "hex color must be a string");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "hex color must be a string", -1);
     }
 
     switch (_hexcolor(value, color->data)) {
         case TRISTATE_FAIL:
-            PyErr_SetString(PyExc_ValueError, "invalid hex string");
-            return -1;
+            RAISERETURN(PyExc_ValueError, "invalid hex string", -1);
         case TRISTATE_ERROR:
             return -1; /* forward python error */
         default:
@@ -1874,8 +1847,7 @@ _color_ass_item(pgColorObject *color, Py_ssize_t _index, PyObject *value)
         case 3:
             return _color_set_a(color, value, NULL);
         default:
-            PyErr_SetString(PyExc_IndexError, "invalid index");
-            break;
+            RAISERETURN(PyExc_IndexError, "invalid index", -1);
     }
     return -1;
 }
@@ -1946,9 +1918,8 @@ static int
 _color_contains(pgColorObject *self, PyObject *arg)
 {
     if (!PyLong_Check(arg)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "'in <pygame.Color>' requires integer object");
-        return -1;
+        RAISERETURN(PyExc_TypeError,
+                    "'in <pygame.Color>' requires integer object", -1);
     }
 
     long comp = PyLong_AsLong(arg);
@@ -1970,9 +1941,8 @@ static int
 _color_set_slice(pgColorObject *color, PyObject *idx, PyObject *val)
 {
     if (val == NULL) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Color object doesn't support item deletion");
-        return -1;
+        RAISERETURN(PyExc_TypeError,
+                    "Color object doesn't support item deletion", -1);
     }
     if (PyLong_Check(idx)) {
         return _color_ass_item(color, PyLong_AsLong(idx), val);
@@ -2009,16 +1979,14 @@ _color_set_slice(pgColorObject *color, PyObject *idx, PyObject *val)
                 c = PyLong_AsLong(obj);
             }
             else {
-                PyErr_SetString(PyExc_TypeError,
-                                "color components must be integers");
                 Py_DECREF(fastitems);
-                return -1;
+                RAISERETURN(PyExc_TypeError,
+                            "color components must be integers", -1);
             }
             if (c < 0 || c > 255) {
-                PyErr_SetString(PyExc_ValueError,
-                                "color component must be 0-255");
                 Py_DECREF(fastitems);
-                return -1;
+                RAISERETURN(PyExc_TypeError, "color component must be 0-255",
+                            -1);
             }
             color->data[cur] = (Uint8)c;
         }
@@ -2026,8 +1994,7 @@ _color_set_slice(pgColorObject *color, PyObject *idx, PyObject *val)
         Py_DECREF(fastitems);
         return 0;
     }
-    PyErr_SetString(PyExc_IndexError, "Index must be an integer or slice");
-    return -1;
+    RAISERETURN(PyExc_IndexError, "Index must be an integer or slice", -1);
 }
 
 /*
@@ -2080,8 +2047,7 @@ _color_getbuffer(pgColorObject *color, Py_buffer *view, int flags)
     static char format[] = "B";
 
     if (PyBUF_HAS_FLAG(flags, PyBUF_WRITABLE)) {
-        PyErr_SetString(pgExc_BufferError, "color buffer is read-only");
-        return -1;
+        RAISERETURN(pgExc_BufferError, "color buffer is read-only", -1);
     }
     view->buf = color->data;
     view->ndim = 1;
@@ -2275,17 +2241,16 @@ _color_setAttr_swizzle(pgColorObject *self, PyObject *attr_name, PyObject *val)
         }
 
         if (entry_was_set[idx]) {
-            PyErr_SetString(PyExc_AttributeError,
-                            "Attribute assignment conflicts with swizzling");
+            RAISE(PyExc_AttributeError,
+                  "Attribute assignment conflicts with swizzling");
             goto swizzle_error;
         }
 
         entry_was_set[idx] = 1;
         entry_obj = PySequence_GetItem(val, i);
         if (entry_obj == NULL) {
-            PyErr_SetString(
-                PyExc_TypeError,
-                "A sequence of the corresponding elements is expected");
+            RAISE(PyExc_TypeError,
+                  "A sequence of the corresponding elements is expected");
             goto swizzle_error;
         }
 
@@ -2299,9 +2264,8 @@ _color_setAttr_swizzle(pgColorObject *self, PyObject *attr_name, PyObject *val)
             entry[idx] = (Uint8)entry_long;
         }
         else {
-            PyErr_SetString(
-                PyExc_TypeError,
-                "Color element is outside of the range from 0 to 255");
+            RAISE(PyExc_TypeError,
+                  "Color element is outside of the range from 0 to 255");
             goto swizzle_error;
         }
     }
@@ -2383,10 +2347,8 @@ _pg_pylong_to_uint32(PyObject *val, Uint32 *color, int handle_negative)
     return 1;
 
 error:
-    PyErr_SetString(
-        PyExc_ValueError,
-        "invalid color argument (integer out of acceptable range)");
-    return 0;
+    RAISERETURN(PyExc_ValueError,
+                "invalid color argument (integer out of acceptable range)", 0);
 }
 
 static int
@@ -2418,11 +2380,10 @@ pg_RGBAFromObjEx(PyObject *obj, Uint8 *rgba, pgColorHandleFlags handle_flags)
 
     if ((handle_flags & PG_COLOR_HANDLE_RESTRICT_SEQ) && !PyTuple_Check(obj)) {
         /* ValueError (and not TypeError) for backcompat reasons */
-        PyErr_SetString(
-            PyExc_ValueError,
-            "invalid color (here, generic sequences are "
-            "restricted, but pygame.Color and RGB[A] tuples are allowed)");
-        return 0;
+        RAISERETURN(PyExc_ValueError,
+                    "invalid color (here, generic sequences are restricted, "
+                    "but pygame.Color and RGB[A] tuples are allowed)",
+                    0);
     }
 
     if (pg_RGBAFromObj(obj, rgba)) {
@@ -2433,18 +2394,17 @@ pg_RGBAFromObjEx(PyObject *obj, Uint8 *rgba, pgColorHandleFlags handle_flags)
     /* Error */
     if (PySequence_Check(obj)) {
         /* It was a tuple-like; raise a ValueError */
-        PyErr_SetString(
-            PyExc_ValueError,
-            "invalid color (color sequence must have size 3 or "
-            "4, and each element must be an integer in the range [0, "
-            "255])");
+        RAISERETURN(PyExc_ValueError,
+                    "invalid color (color sequence must have size 3 or 4, and "
+                    "each element must be an integer in the range [0, 255])",
+                    0);
     }
     else {
         PyErr_Format(PyExc_TypeError,
                      "unable to interpret object of type '%128s' as a color",
                      Py_TYPE(obj)->tp_name);
+        return 0;
     }
-    return 0;
 }
 
 static int

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -833,14 +833,12 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (!pg_TwoIntsFromObj(posobj, &posx, &posy)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "center argument must be a pair of numbers");
-        return 0;
+        RAISERETURN(PyExc_TypeError,
+                    "center argument must be a pair of numbers", 0)
     }
 
     if (!pg_IntFromObj(radiusobj, &radius)) {
-        PyErr_SetString(PyExc_TypeError, "radius argument must be a number");
-        return 0;
+        RAISERETURN(PyExc_TypeError, "radius argument must be a number", 0);
     }
 
     surf = pgSurface_AsSurface(surfobj);

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -718,9 +718,8 @@ static int
 pg_EnableKeyRepeat(int delay, int interval)
 {
     if (delay < 0 || interval < 0) {
-        PyErr_SetString(PyExc_ValueError,
-                        "delay and interval must equal at least 0");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "delay and interval must equal at least 0", -1);
     }
     PG_LOCK_EVFILTER_MUTEX
     pg_key_repeat_delay = delay;
@@ -1677,8 +1676,7 @@ pg_event_init(pgEventObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (type < 0 || type >= PG_NUMEVENTS) {
-        PyErr_SetString(PyExc_ValueError, "event type out of range");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "event type out of range", -1);
     }
 
     if (!dict) {
@@ -1705,10 +1703,9 @@ pg_event_init(pgEventObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (PyDict_GetItemString(dict, "type")) {
-        PyErr_SetString(PyExc_ValueError,
-                        "redundant type field in event dict");
         Py_DECREF(dict);
-        return -1;
+        RAISERETURN(PyExc_ValueError, "redundant type field in event dict",
+                    -1);
     }
 
     self->type = _pg_pgevent_deproxify(type);
@@ -1939,13 +1936,11 @@ _pg_eventtype_from_seq(PyObject *seq, int ind)
 {
     int val = 0;
     if (!pg_IntFromObjIndex(seq, ind, &val)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "type sequence must contain valid event types");
-        return -1;
+        RAISERETURN(PyExc_TypeError,
+                    "type sequence must contain valid event types", -1);
     }
     if (val < 0 || val >= PG_NUMEVENTS) {
-        PyErr_SetString(PyExc_ValueError, "event type out of range");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "event type out of range", -1);
     }
     return val;
 }
@@ -2101,7 +2096,7 @@ _pg_get_all_events_except(PyObject *obj)
         do {
             ret = PG_PEEP_EVENT(&event, 1, SDL_GETEVENT, type);
             if (ret < 0) {
-                PyErr_SetString(pgExc_SDLError, SDL_GetError());
+                RAISE(pgExc_SDLError, SDL_GetError());
                 goto error;
             }
             else if (ret > 0) {
@@ -2125,7 +2120,7 @@ _pg_get_all_events_except(PyObject *obj)
             ret = PG_PEEP_EVENT(&event, 1, SDL_GETEVENT,
                                 _pg_pgevent_proxify(type));
             if (ret < 0) {
-                PyErr_SetString(pgExc_SDLError, SDL_GetError());
+                RAISE(pgExc_SDLError, SDL_GetError());
                 goto error;
             }
             else if (ret > 0) {
@@ -2151,7 +2146,7 @@ _pg_get_all_events_except(PyObject *obj)
     do {
         len = PG_PEEP_EVENT_ALL(eventbuf, PG_GET_LIST_LEN, SDL_GETEVENT);
         if (len == -1) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
+            RAISE(pgExc_SDLError, SDL_GetError());
             goto error;
         }
 
@@ -2191,7 +2186,7 @@ _pg_get_all_events(void)
     while (len == PG_GET_LIST_LEN) {
         len = PG_PEEP_EVENT_ALL(eventbuf, PG_GET_LIST_LEN, SDL_GETEVENT);
         if (len == -1) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
+            RAISE(pgExc_SDLError, SDL_GetError());
             goto error;
         }
 
@@ -2235,7 +2230,7 @@ _pg_get_seq_events(PyObject *obj)
         do {
             ret = PG_PEEP_EVENT(&event, 1, SDL_GETEVENT, type);
             if (ret < 0) {
-                PyErr_SetString(pgExc_SDLError, SDL_GetError());
+                RAISE(pgExc_SDLError, SDL_GetError());
                 goto error;
             }
             else if (ret > 0) {
@@ -2248,7 +2243,7 @@ _pg_get_seq_events(PyObject *obj)
             ret = PG_PEEP_EVENT(&event, 1, SDL_GETEVENT,
                                 _pg_pgevent_proxify(type));
             if (ret < 0) {
-                PyErr_SetString(pgExc_SDLError, SDL_GetError());
+                RAISE(pgExc_SDLError, SDL_GetError());
                 goto error;
             }
             else if (ret > 0) {

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -536,18 +536,16 @@ font_setter_align(PyObject *self, PyObject *value, void *closure)
 
     long val = PyLong_AsLong(value);
     if (val == -1 && PyErr_Occurred()) {
-        PyErr_SetString(
-            PyExc_TypeError,
-            "font.align must be an integer. "
-            "Must correspond with FONT_LEFT, FONT_CENTER, or FONT_RIGHT.");
-        return -1;
+        RAISERETURN(PyExc_TypeError,
+                    "font.align must be an integer. Must correspond with "
+                    "FONT_LEFT, FONT_CENTER, or FONT_RIGHT.",
+                    -1);
     }
 
     if (val < 0 || val > 2) {
-        PyErr_SetString(pgExc_SDLError,
-                        "font.align must be FONT_LEFT, FONT_CENTER, or "
-                        "FONT_RIGHT.");
-        return -1;
+        RAISERETURN(
+            pgExc_SDLError,
+            "font.align must be FONT_LEFT, FONT_CENTER, or FONT_RIGHT.", -1);
     }
 
 #if SDL_TTF_VERSION_ATLEAST(3, 0, 0)
@@ -557,10 +555,10 @@ font_setter_align(PyObject *self, PyObject *value, void *closure)
 #endif
     return 0;
 #else
-    PyErr_SetString(pgExc_SDLError,
-                    "pygame.font not compiled with a new enough SDL_ttf "
-                    "version. Needs SDL_ttf 2.20.0 or above.");
-    return -1;
+    RAISERETURN(pgExc_SDLError,
+                "pygame.font not compiled with a new enough SDL_ttf version. "
+                "Needs SDL_ttf 2.20.0 or above.",
+                -1);
 #endif
 }
 
@@ -823,9 +821,8 @@ font_setter_point_size(PyFontObject *self, PyObject *value, void *closure)
     }
 
     if (val <= 0) {
-        PyErr_SetString(PyExc_ValueError,
-                        "point_size cannot be equal to, or less than 0");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "point_size cannot be equal to, or less than 0", -1);
     }
 
 #if SDL_TTF_VERSION_ATLEAST(3, 0, 0)
@@ -835,16 +832,14 @@ font_setter_point_size(PyFontObject *self, PyObject *value, void *closure)
     if (TTF_SetFontSize(font, val) == -1)
 #endif
     {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return -1;
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
     }
     self->ptsize = val;
 
     return 0;
 #else
-    PyErr_SetString(pgExc_SDLError,
-                    "Incorrect SDL_TTF version (requires 2.0.18)");
-    return -1;
+    RAISERETURN(pgExc_SDLError, "Incorrect SDL_TTF version (requires 2.0.18)",
+                -1);
 #endif
 }
 
@@ -1243,8 +1238,7 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
     }
 
     if (!font_initialized) {
-        PyErr_SetString(pgExc_SDLError, "font not initialized");
-        return -1;
+        RAISERETURN(pgExc_SDLError, "font not initialized", -1);
     }
 
     /* Incref obj, needs to be decref'd later */

--- a/src_c/freetype/ft_layout.c
+++ b/src_c/freetype/ft_layout.c
@@ -139,8 +139,7 @@ _PGFT_LoadLayout(FreeTypeInstance *ft, pgFontObject *fontobj,
         copy_mode(&ftext->mode, mode);
         font = _PGFT_GetFontSized(ft, fontobj, mode->face_size);
         if (!font) {
-            PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-            return 0;
+            RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), 0);
         }
     }
 
@@ -213,8 +212,7 @@ size_text(Layout *ftext, FreeTypeInstance *ft, TextContext *context,
                                    &slots[length].kerning);
             if (error) {
                 _PGFT_SetError(ft, "Loading glyphs", error);
-                PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-                return -1;
+                RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), -1);
             }
         }
         prev_id = id;

--- a/src_c/freetype/ft_wrap.c
+++ b/src_c/freetype/ft_wrap.c
@@ -99,8 +99,7 @@ _PGFT_Font_IsFixedWidth(FreeTypeInstance *ft, pgFontObject *fontobj)
     FT_Face font = _PGFT_GetFont(ft, fontobj);
 
     if (!font) {
-        PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-        return -1;
+        RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), -1);
     }
     return FT_IS_FIXED_WIDTH(font) ? 1 : 0;
 }
@@ -111,8 +110,7 @@ _PGFT_Font_NumFixedSizes(FreeTypeInstance *ft, pgFontObject *fontobj)
     FT_Face font = _PGFT_GetFont(ft, fontobj);
 
     if (!font) {
-        PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-        return -1;
+        RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), -1);
     }
     return FT_HAS_FIXED_SIZES(font) ? font->num_fixed_sizes : 0;
 }
@@ -126,8 +124,7 @@ _PGFT_Font_GetAvailableSize(FreeTypeInstance *ft, pgFontObject *fontobj,
     FT_Bitmap_Size *bitmap_size_p;
 
     if (!font) {
-        PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-        return -1;
+        RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), -1);
     }
     if (!FT_HAS_FIXED_SIZES(font) ||
         n > font->num_fixed_sizes) /* cond. or */ {
@@ -149,8 +146,7 @@ _PGFT_Font_GetName(FreeTypeInstance *ft, pgFontObject *fontobj)
     font = _PGFT_GetFont(ft, fontobj);
 
     if (!font) {
-        PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-        return 0;
+        RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), 0);
     }
     return font->family_name ? font->family_name : "";
 }
@@ -162,8 +158,7 @@ _PGFT_Font_GetStyleName(FreeTypeInstance *ft, pgFontObject *fontobj)
     font = _PGFT_GetFont(ft, fontobj);
 
     if (!font) {
-        PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-        return 0;
+        RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), 0);
     }
     return font->style_name ? font->style_name : "";
 }
@@ -177,8 +172,7 @@ _PGFT_Font_GetHeight(FreeTypeInstance *ft, pgFontObject *fontobj)
     FT_Face font = _PGFT_GetFont(ft, fontobj);
 
     if (!font) {
-        PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-        return 0;
+        RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), 0);
     }
     return (long)font->height;
 }
@@ -190,8 +184,7 @@ _PGFT_Font_GetHeightSized(FreeTypeInstance *ft, pgFontObject *fontobj,
     FT_Face font = _PGFT_GetFontSized(ft, fontobj, face_size);
 
     if (!font) {
-        PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-        return 0;
+        RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), 0);
     }
     return (long)FX6_TRUNC(FX6_CEIL(font->size->metrics.height));
 }
@@ -202,8 +195,7 @@ _PGFT_Font_GetAscender(FreeTypeInstance *ft, pgFontObject *fontobj)
     FT_Face font = _PGFT_GetFont(ft, fontobj);
 
     if (!font) {
-        PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-        return 0;
+        RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), 0);
     }
     return (long)font->ascender;
 }
@@ -215,8 +207,7 @@ _PGFT_Font_GetAscenderSized(FreeTypeInstance *ft, pgFontObject *fontobj,
     FT_Face font = _PGFT_GetFontSized(ft, fontobj, face_size);
 
     if (!font) {
-        PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-        return 0;
+        RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), 0);
     }
     return (long)FX6_TRUNC(FX6_CEIL(font->size->metrics.ascender));
 }
@@ -227,8 +218,7 @@ _PGFT_Font_GetDescender(FreeTypeInstance *ft, pgFontObject *fontobj)
     FT_Face font = _PGFT_GetFont(ft, fontobj);
 
     if (!font) {
-        PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-        return 0;
+        RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), 0);
     }
     return (long)font->descender;
 }
@@ -240,8 +230,7 @@ _PGFT_Font_GetDescenderSized(FreeTypeInstance *ft, pgFontObject *fontobj,
     FT_Face font = _PGFT_GetFontSized(ft, fontobj, face_size);
 
     if (!font) {
-        PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-        return 0;
+        RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), 0);
     }
     return (long)FX6_TRUNC(FX6_FLOOR(font->size->metrics.descender));
 }
@@ -257,8 +246,7 @@ _PGFT_Font_GetGlyphHeightSized(FreeTypeInstance *ft, pgFontObject *fontobj,
     FT_Size_Metrics *metrics;
 
     if (!font) {
-        PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
-        return 0;
+        RAISERETURN(pgExc_SDLError, _PGFT_GetError(ft), 0);
     }
     metrics = &font->size->metrics;
     return (long)FX6_TRUNC(FX6_CEIL(metrics->ascender) -
@@ -398,8 +386,7 @@ ft_wrap_init(FreeTypeInstance *ft, pgFontObject *fontobj)
 
     font = _PGFT_GetFont(ft, fontobj);
     if (!font) {
-        PyErr_SetString(PyExc_FileNotFoundError, _PGFT_GetError(ft));
-        return -1;
+        RAISERETURN(PyExc_FileNotFoundError, _PGFT_GetError(ft), -1);
     }
     fontobj->is_scalable = FT_IS_SCALABLE(font) ? ~0 : 0;
 
@@ -491,8 +478,7 @@ _PGFT_TryLoadFont_RWops(FreeTypeInstance *ft, pgFontObject *fontobj,
 
     position = SDL_RWtell(src);
     if (position < 0) {
-        PyErr_SetString(pgExc_SDLError, "Failed to seek in font stream");
-        return -1;
+        RAISERETURN(pgExc_SDLError, "Failed to seek in font stream", -1);
     }
 
     stream = _PGFT_calloc(1, sizeof(*stream));
@@ -569,24 +555,21 @@ _PGFT_Init(FreeTypeInstance **_instance, int cache_size)
 
     error = FT_Init_FreeType(&inst->library);
     if (error) {
-        PyErr_SetString(
-            PyExc_RuntimeError,
-            "pygame (_PGFT_Init): failed to initialize FreeType library");
+        RAISE(PyExc_RuntimeError,
+              "pygame (_PGFT_Init): failed to initialize FreeType library");
         goto error_cleanup;
     }
 
     if (FTC_Manager_New(inst->library, 0, 0, 0, &_PGFT_font_request, 0,
                         &inst->cache_manager) != 0) {
-        PyErr_SetString(
-            PyExc_RuntimeError,
-            "pygame (_PGFT_Init): failed to create new FreeType manager");
+        RAISE(PyExc_RuntimeError,
+              "pygame (_PGFT_Init): failed to create new FreeType manager");
         goto error_cleanup;
     }
 
     if (FTC_CMapCache_New(inst->cache_manager, &inst->cache_charmap) != 0) {
-        PyErr_SetString(
-            PyExc_RuntimeError,
-            "pygame (_PGFT_Init): failed to create new FreeType cache");
+        RAISE(PyExc_RuntimeError,
+              "pygame (_PGFT_Init): failed to create new FreeType cache");
         goto error_cleanup;
     }
 

--- a/src_c/freetype/ft_wrap.h
+++ b/src_c/freetype/ft_wrap.h
@@ -241,12 +241,11 @@ extern _FreeTypeState _modstate;
 #define FREETYPE_STATE FREETYPE_MOD_STATE(0)
 #endif /* defined(PYPY_VERSION) */
 
-#define ASSERT_GRAB_FREETYPE(ft_ptr, rvalue)                               \
-    ft_ptr = FREETYPE_STATE->freetype;                                     \
-    if (!ft_ptr) {                                                         \
-        PyErr_SetString(PyExc_RuntimeError,                                \
-                        "The FreeType 2 library hasn't been initialized"); \
-        return (rvalue);                                                   \
+#define ASSERT_GRAB_FREETYPE(ft_ptr, rvalue)                                  \
+    ft_ptr = FREETYPE_STATE->freetype;                                        \
+    if (!ft_ptr) {                                                            \
+        RAISERETURN(PyExc_RuntimeError,                                       \
+                    "The FreeType 2 library hasn't been initialized", rvalue) \
     }
 
 /**********************************************************

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -471,8 +471,7 @@ MODINIT_DEFINE(imageext)
     #ifdef WITH_THREAD
         _pg_img_mutex = SDL_CreateMutex();
         if (!_pg_img_mutex) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
-            return NULL;
+            return RAISE(pgExc_SDLError, SDL_GetError());
         }
     #endif
     */

--- a/src_c/key.c
+++ b/src_c/key.c
@@ -99,9 +99,8 @@ pg_scancodewrapper_subscript(pgScancodeWrapper *self, PyObject *item)
 static PyObject *
 pg_iter_raise(PyObject *self)
 {
-    PyErr_SetString(PyExc_TypeError,
-                    "Iterating over key states is not supported");
-    return NULL;
+    return RAISE(PyExc_TypeError,
+                 "Iterating over key states is not supported");
 }
 
 /**

--- a/src_c/line.c
+++ b/src_c/line.c
@@ -50,10 +50,10 @@ static int
 pg_line_init(pgLineObject *self, PyObject *args, PyObject *kwds)
 {
     if (!pgLine_FromObject(args, &self->line)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Invalid line end points, expected 4 "
-                        "numbers or 2 sequences of 2 numbers");
-        return -1;
+        RAISERETURN(PyExc_TypeError,
+                    "Invalid line end points, expected 4 numbers or 2 "
+                    "sequences of 2 numbers",
+                    -1);
     }
     return 0;
 }
@@ -147,14 +147,12 @@ _line_scale_helper(pgLineBase *line, double factor, double origin)
         return 1;
     }
     else if (factor <= 0.0) {
-        PyErr_SetString(PyExc_ValueError,
-                        "Can only scale by a positive non zero number");
-        return 0;
+        RAISERETURN(PyExc_ValueError,
+                    "Can only scale by a positive non zero number", 0);
     }
 
     if (origin < 0.0 || origin > 1.0) {
-        PyErr_SetString(PyExc_ValueError, "Origin must be between 0 and 1");
-        return 0;
+        RAISERETURN(PyExc_ValueError, "Origin must be between 0 and 1", 0);
     }
 
     double ax = line->ax;
@@ -291,8 +289,7 @@ pg_line_str(pgLineObject *self)
             self->line.name = val;                                        \
             return 0;                                                     \
         }                                                                 \
-        PyErr_SetString(PyExc_TypeError, "Expected a number");            \
-        return -1;                                                        \
+        RAISERETURN(PyExc_TypeError, "Expected a number", -1);            \
     }
 
 __LINE_GETSET_NAME(ax)
@@ -317,8 +314,7 @@ pg_line_seta(pgLineObject *self, PyObject *value, void *closure)
         self->line.ay = y;
         return 0;
     }
-    PyErr_SetString(PyExc_TypeError, "Expected a sequence of 2 numbers");
-    return -1;
+    RAISERETURN(PyExc_TypeError, "Expected a sequence of 2 numbers", -1);
 }
 
 static PyObject *
@@ -337,8 +333,7 @@ pg_line_setb(pgLineObject *self, PyObject *value, void *closure)
         self->line.by = y;
         return 0;
     }
-    PyErr_SetString(PyExc_TypeError, "Expected a sequence of 2 numbers");
-    return -1;
+    RAISERETURN(PyExc_TypeError, "Expected a sequence of 2 numbers", -1);
 }
 
 static PyObject *

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -2201,7 +2201,7 @@ mask_to_surface(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (Py_None != setsurfobj) {
         if (!pgSurface_Check(setsurfobj)) {
-            PyErr_SetString(PyExc_TypeError, "invalid setsurface argument");
+            RAISE(PyExc_TypeError, "invalid setsurface argument");
             goto to_surface_error;
         }
 
@@ -2209,9 +2209,9 @@ mask_to_surface(PyObject *self, PyObject *args, PyObject *kwargs)
 
         if (0 == check_surface_pixel_format(surf, setsurf)) {
             /* Needs to have the same format settings as surface. */
-            PyErr_SetString(PyExc_ValueError,
-                            "setsurface needs to have same "
-                            "bytesize/bitsize/alpha format as surface");
+            RAISE(PyExc_ValueError,
+                  "setsurface needs to have same bytesize/bitsize/alpha "
+                  "format as surface");
             goto to_surface_error;
         }
         else if ((setsurf->h <= 0) || (setsurf->w <= 0)) {
@@ -2225,7 +2225,7 @@ mask_to_surface(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (Py_None != unsetsurfobj) {
         if (!pgSurface_Check(unsetsurfobj)) {
-            PyErr_SetString(PyExc_TypeError, "invalid unsetsurface argument");
+            RAISE(PyExc_TypeError, "invalid unsetsurface argument");
             goto to_surface_error;
         }
 
@@ -2233,9 +2233,9 @@ mask_to_surface(PyObject *self, PyObject *args, PyObject *kwargs)
 
         if (0 == check_surface_pixel_format(surf, unsetsurf)) {
             /* Needs to have the same format settings as surface. */
-            PyErr_SetString(PyExc_ValueError,
-                            "unsetsurface needs to have same "
-                            "bytesize/bitsize/alpha format as surface");
+            RAISE(PyExc_ValueError,
+                  "unsetsurface needs to have same bytesize/bitsize/alpha "
+                  "format as surface");
             goto to_surface_error;
         }
         else if ((unsetsurf->h <= 0) || (unsetsurf->w <= 0)) {
@@ -2285,21 +2285,21 @@ mask_to_surface(PyObject *self, PyObject *args, PyObject *kwargs)
                 y_dest = dest_rect->y;
             }
             else {
-                PyErr_SetString(PyExc_TypeError, "invalid dest argument");
+                RAISE(PyExc_TypeError, "invalid dest argument");
                 goto to_surface_error;
             }
         }
     }
 
     if (!pgSurface_Lock((pgSurfaceObject *)surfobj)) {
-        PyErr_SetString(PyExc_RuntimeError, "cannot lock surface");
+        RAISE(PyExc_RuntimeError, "cannot lock surface");
         goto to_surface_error;
     }
 
     /* Only lock the setsurface if it is being used.
      * i.e. setsurf is non-NULL */
     if (NULL != setsurf && !pgSurface_Lock((pgSurfaceObject *)setsurfobj)) {
-        PyErr_SetString(PyExc_RuntimeError, "cannot lock setsurface");
+        RAISE(PyExc_RuntimeError, "cannot lock setsurface");
         goto to_surface_error;
     }
 
@@ -2307,7 +2307,7 @@ mask_to_surface(PyObject *self, PyObject *args, PyObject *kwargs)
      * i.e.. unsetsurf is non-NULL. */
     if (NULL != unsetsurf &&
         !pgSurface_Lock((pgSurfaceObject *)unsetsurfobj)) {
-        PyErr_SetString(PyExc_RuntimeError, "cannot lock unsetsurface");
+        RAISE(PyExc_RuntimeError, "cannot lock unsetsurface");
         goto to_surface_error;
     }
 
@@ -2321,17 +2321,17 @@ mask_to_surface(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (NULL != unsetsurf &&
         !pgSurface_Unlock((pgSurfaceObject *)unsetsurfobj)) {
-        PyErr_SetString(PyExc_RuntimeError, "cannot unlock unsetsurface");
+        RAISE(PyExc_RuntimeError, "cannot unlock unsetsurface");
         goto to_surface_error;
     }
 
     if (NULL != setsurf && !pgSurface_Unlock((pgSurfaceObject *)setsurfobj)) {
-        PyErr_SetString(PyExc_RuntimeError, "cannot unlock setsurface");
+        RAISE(PyExc_RuntimeError, "cannot unlock setsurface");
         goto to_surface_error;
     }
 
     if (!pgSurface_Unlock((pgSurfaceObject *)surfobj)) {
-        PyErr_SetString(PyExc_RuntimeError, "cannot unlock surface");
+        RAISE(PyExc_RuntimeError, "cannot unlock surface");
         goto to_surface_error;
     }
 
@@ -2488,22 +2488,19 @@ mask_init(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (!pg_TwoIntsFromObj(size, &w, &h)) {
-        PyErr_SetString(PyExc_TypeError, "size must be two numbers");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "size must be two numbers", -1);
     }
 
     if (w < 0 || h < 0) {
-        PyErr_SetString(PyExc_ValueError,
-                        "cannot create mask with negative size");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "cannot create mask with negative size",
+                    -1);
     }
 
     bitmask = bitmask_create(w, h);
 
     if (NULL == bitmask) {
-        PyErr_SetString(PyExc_MemoryError,
-                        "cannot allocate memory for bitmask");
-        return -1;
+        RAISERETURN(PyExc_MemoryError, "cannot allocate memory for bitmask",
+                    -1);
     }
 
     if (fill) {

--- a/src_c/newbuffer.c
+++ b/src_c/newbuffer.c
@@ -307,9 +307,8 @@ buffer_get_buffer(BufferObject *self, PyObject *args, PyObject *kwds)
         return 0;
     }
     if (bufobj_flags & BUFOBJ_FILLED) {
-        PyErr_SetString(PyExc_ValueError,
-                        "The Py_buffer struct is already filled in");
-        return 0;
+        RAISERETURN(PyExc_ValueError,
+                    "The Py_buffer struct is already filled in", 0);
     }
     self->flags = BUFOBJ_MUTABLE & bufobj_flags;
     if (!self->view_p) {
@@ -751,8 +750,7 @@ Buffer_New(Py_buffer *view_p, int filled, int preserve)
 static PyObject *
 mixin__get_buffer(PyObject *self, PyObject *args)
 {
-    PyErr_SetString(PyExc_NotImplementedError, "abstract method");
-    return 0;
+    RAISERETURN(PyExc_NotImplementedError, "abstract method", 0);
 }
 
 static PyObject *
@@ -788,9 +786,9 @@ mixin_getbuffer(PyObject *self, Py_buffer *view_p, int flags)
             Py_DECREF(py_rval);
         }
         else if (py_rval) {
-            PyErr_SetString(PyExc_ValueError,
-                            "_get_buffer method return value was not None");
             Py_DECREF(py_rval);
+            RAISE(PyExc_ValueError,
+                  "_get_buffer method return value was not None");
         }
     }
     return rval;

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -301,10 +301,10 @@ _pxarray_new_internal(PyTypeObject *type, pgSurfaceObject *surface,
     if (!parent) {
         if (!surface) {
             Py_TYPE(self)->tp_free((PyObject *)self);
-            PyErr_SetString(PyExc_SystemError,
-                            "Pygame internal error in _pxarray_new_internal: "
-                            "no parent or surface.");
-            return 0;
+            RAISERETURN(PyExc_SystemError,
+                        "Pygame internal error in _pxarray_new_internal: no "
+                        "parent or surface.",
+                        0);
         }
         self->parent = 0;
         self->surface = surface;
@@ -540,8 +540,7 @@ _pxarray_getbuffer(pgPixelArrayObject *self, Py_buffer *view_p, int flags)
     Py_ssize_t len;
 
     if (self->surface == NULL) {
-        PyErr_SetString(PyExc_ValueError, "Operation on closed PixelArray.");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "Operation on closed PixelArray.", -1);
     }
 
     itemsize = PG_SURF_BytesPerPixel(pgSurface_AsSurface(self->surface));
@@ -550,21 +549,18 @@ _pxarray_getbuffer(pgPixelArrayObject *self, Py_buffer *view_p, int flags)
     view_p->obj = 0;
     if (PyBUF_HAS_FLAG(flags, PyBUF_C_CONTIGUOUS) &&
         !array_is_contiguous(self, 'C')) {
-        PyErr_SetString(pgExc_BufferError,
-                        "this pixel array is not C contiguous");
-        return -1;
+        RAISERETURN(pgExc_BufferError, "this pixel array is not C contiguous",
+                    -1);
     }
     if (PyBUF_HAS_FLAG(flags, PyBUF_F_CONTIGUOUS) &&
         !array_is_contiguous(self, 'F')) {
-        PyErr_SetString(pgExc_BufferError,
-                        "this pixel array is not F contiguous");
-        return -1;
+        RAISERETURN(pgExc_BufferError, "this pixel array is not F contiguous",
+                    -1);
     }
     if (PyBUF_HAS_FLAG(flags, PyBUF_ANY_CONTIGUOUS) &&
         !array_is_contiguous(self, 'A')) {
-        PyErr_SetString(pgExc_BufferError,
-                        "this pixel array is not contiguous");
-        return -1;
+        RAISERETURN(pgExc_BufferError, "this pixel array is not contiguous",
+                    -1);
     }
     if (PyBUF_HAS_FLAG(flags, PyBUF_ND)) {
         shape = self->shape;
@@ -572,19 +568,17 @@ _pxarray_getbuffer(pgPixelArrayObject *self, Py_buffer *view_p, int flags)
             strides = self->strides;
         }
         else if (!array_is_contiguous(self, 'C')) {
-            PyErr_SetString(
-                pgExc_BufferError,
-                "this pixel array is not contiguous: need strides");
-            return -1;
+            RAISERETURN(pgExc_BufferError,
+                        "this pixel array is not contiguous: need strides",
+                        -1);
         }
     }
     else if (array_is_contiguous(self, 'F')) {
         ndim = 0;
     }
     else {
-        PyErr_SetString(pgExc_BufferError,
-                        "this pixel array is not C contiguous: need strides");
-        return -1;
+        RAISERETURN(pgExc_BufferError,
+                    "this pixel array is not C contiguous: need strides", -1);
     }
     if (PyBUF_HAS_FLAG(flags, PyBUF_FORMAT)) {
         /* Find the appropriate format for given pixel size */
@@ -931,8 +925,7 @@ _array_assign_array(pgPixelArrayObject *array, Py_ssize_t low, Py_ssize_t high,
     int sizes_match = 0;
 
     if (array->surface == NULL) {
-        PyErr_SetString(PyExc_ValueError, "Operation on closed PixelArray.");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "Operation on closed PixelArray.", -1);
     }
 
     surf = pgSurface_AsSurface(array->surface);
@@ -959,8 +952,7 @@ _array_assign_array(pgPixelArrayObject *array, Py_ssize_t low, Py_ssize_t high,
     }
     if (!sizes_match) {
         /* Bounds do not match. */
-        PyErr_SetString(PyExc_ValueError, "array sizes do not match");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "array sizes do not match", -1);
     }
 
     bpp = PG_SURF_BytesPerPixel(surf);
@@ -968,15 +960,13 @@ _array_assign_array(pgPixelArrayObject *array, Py_ssize_t low, Py_ssize_t high,
     if (val_bpp != bpp) {
         /* bpp do not match. We cannot guarantee that the padding and columns
          * would be set correctly. */
-        PyErr_SetString(PyExc_ValueError, "bit depths do not match");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "bit depths do not match", -1);
     }
 
     PG_PixelFormat *surf_format = PG_GetSurfaceFormat(surf);
     PG_PixelFormat *val_surf_format = PG_GetSurfaceFormat(val_surf);
     if (surf_format == NULL || val_surf_format == NULL) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return -1;
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
     }
 
     /* If we reassign the same array, we need to copy the pixels
@@ -1103,14 +1093,12 @@ _array_assign_sequence(pgPixelArrayObject *array, Py_ssize_t low,
     PyObject *item;
 
     if (val_dim0 != dim0) {
-        PyErr_SetString(PyExc_ValueError, "sequence size mismatch");
-        return -1;
+        RAISERETURN(PyExc_ValueError, "sequence size mismatch", -1);
     }
 
     PG_PixelFormat *surf_format = PG_GetSurfaceFormat(surf);
     if (surf_format == NULL) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return -1;
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
     }
 
     bpp = PG_FORMAT_BytesPerPixel(surf_format);
@@ -1223,8 +1211,7 @@ _array_assign_slice(pgPixelArrayObject *array, Py_ssize_t low, Py_ssize_t high,
 
     PG_PixelFormat *surf_format = PG_GetSurfaceFormat(surf);
     if (surf_format == NULL) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return -1;
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
     }
 
     bpp = PG_FORMAT_BytesPerPixel(surf_format);
@@ -1340,10 +1327,9 @@ _pxarray_ass_item(pgPixelArrayObject *array, Py_ssize_t index, PyObject *value)
                 return -1;
             }
             if (!pgPixelArrayObject_Check(tmparray)) {
-                PyErr_SetString(
-                    PyExc_ValueError,
-                    "cannot assign a pixel sequence to a single pixel");
-                return -1;
+                RAISERETURN(PyExc_ValueError,
+                            "cannot assign a pixel sequence to a single pixel",
+                            -1);
             }
             retval =
                 _array_assign_sequence(tmparray, 0, tmparray->shape[0], value);
@@ -1358,13 +1344,11 @@ _pxarray_ass_item(pgPixelArrayObject *array, Py_ssize_t index, PyObject *value)
     if (index < 0) {
         index += dim0;
         if (index < 0) {
-            PyErr_SetString(PyExc_IndexError, "array index out of range");
-            return -1;
+            RAISERETURN(PyExc_IndexError, "array index out of range", -1);
         }
     }
     if (index >= dim0) {
-        PyErr_SetString(PyExc_IndexError, "array index out of range");
-        return -1;
+        RAISERETURN(PyExc_IndexError, "array index out of range", -1);
     }
     pixels += index * stride0;
 
@@ -1375,8 +1359,7 @@ _pxarray_ass_item(pgPixelArrayObject *array, Py_ssize_t index, PyObject *value)
 
     PG_PixelFormat *surf_format = PG_GetSurfaceFormat(surf);
     if (surf_format == NULL) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return -1;
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
     }
 
     Py_BEGIN_ALLOW_THREADS;
@@ -1588,8 +1571,7 @@ _get_subslice(PyObject *op, Py_ssize_t length, Py_ssize_t *start,
             *start += length;
         }
         if (*start >= length || *start < 0) {
-            PyErr_SetString(PyExc_IndexError, "invalid index");
-            return -1;
+            RAISERETURN(PyExc_IndexError, "invalid index", -1);
         }
         *stop = (*start) + 1;
         *step = 0;
@@ -1735,9 +1717,8 @@ _pxarray_ass_subscript(pgPixelArrayObject *array, PyObject *op,
         int retval;
 
         if (size > 2 || (size == 2 && !dim1)) {
-            PyErr_SetString(PyExc_IndexError,
-                            "too many indices for the array");
-            return -1;
+            RAISERETURN(PyExc_IndexError, "too many indices for the array",
+                        -1);
         }
 
         obj = PyTuple_GET_ITEM(op, 0);
@@ -1832,9 +1813,8 @@ _pxarray_ass_subscript(pgPixelArrayObject *array, PyObject *op,
             return -1;
         }
         if (slicelen < 0) {
-            PyErr_SetString(PyExc_IndexError,
-                            "Unable to handle negative slice");
-            return -1;
+            RAISERETURN(PyExc_IndexError, "Unable to handle negative slice",
+                        -1);
         }
         if (slicelen == 0) {
             return 0;
@@ -1857,10 +1837,8 @@ _pxarray_ass_subscript(pgPixelArrayObject *array, PyObject *op,
         }
         return _pxarray_ass_item(array, i, value);
     }
-
-    PyErr_SetString(PyExc_TypeError,
-                    "index must be an integer, sequence or slice");
-    return -1;
+    RAISERETURN(PyExc_TypeError, "index must be an integer, sequence or slice",
+                -1);
 }
 
 /**** C API interfaces ****/

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -257,12 +257,11 @@ _get_weights(PyObject *weights, float *wr, float *wg, float *wb)
     }
 
     if (!PySequence_Check(weights)) {
-        PyErr_SetString(PyExc_TypeError, "weights must be a sequence");
+        RAISE(PyExc_TypeError, "weights must be a sequence");
         success = 0;
     }
     else if (PySequence_Size(weights) < 3) {
-        PyErr_SetString(PyExc_TypeError,
-                        "weights must contain at least 3 values");
+        RAISE(PyExc_TypeError, "weights must contain at least 3 values");
         success = 0;
     }
     else {
@@ -302,7 +301,7 @@ _get_weights(PyObject *weights, float *wr, float *wg, float *wb)
                 }
             }
             else {
-                PyErr_SetString(PyExc_TypeError, "invalid weights");
+                RAISE(PyExc_TypeError, "invalid weights");
                 success = 0;
             }
             Py_XDECREF(item);
@@ -320,9 +319,8 @@ _get_weights(PyObject *weights, float *wr, float *wg, float *wb)
         *wb = rgb[2];
         if ((*wr < 0 || *wg < 0 || *wb < 0) ||
             (*wr == 0 && *wg == 0 && *wb == 0)) {
-            PyErr_SetString(PyExc_ValueError,
-                            "weights must be positive and greater than 0");
-            return 0;
+            RAISERETURN(PyExc_ValueError,
+                        "weights must be positive and greater than 0", 0);
         }
         /* Build the average weight values. */
         sum = *wr + *wg + *wb;
@@ -810,8 +808,7 @@ _compare(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
 
     if (other_array->shape[0] != dim0 || other_array->shape[1] != dim1) {
         /* Bounds do not match. */
-        PyErr_SetString(PyExc_ValueError, "array sizes do not match");
-        return 0;
+        RAISERETURN(PyExc_ValueError, "array sizes do not match", 0);
     }
 
     other_surf = pgSurface_AsSurface(other_array->surface);
@@ -830,8 +827,7 @@ _compare(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
     if (PG_FORMAT_BytesPerPixel(other_format) != bpp) {
         /* bpp do not match. We cannot guarantee that the padding and co
          * would be set correctly. */
-        PyErr_SetString(PyExc_ValueError, "bit depths do not match");
-        return 0;
+        RAISERETURN(PyExc_ValueError, "bit depths do not match", 0);
     }
 
     other_stride0 = other_array->strides[0];

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -323,9 +323,8 @@ four_ints_from_obj(PyObject *obj, int *val1, int *val2, int *val3, int *val4)
         Py_DECREF(item);
 
         if (!result) {
-            PyErr_SetString(PyExc_TypeError,
-                            "number pair expected for first argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError,
+                        "number pair expected for first argument", 0);
         }
 
         /* Get the other end of the line. */
@@ -339,34 +338,29 @@ four_ints_from_obj(PyObject *obj, int *val1, int *val2, int *val3, int *val4)
         Py_DECREF(item);
 
         if (!result) {
-            PyErr_SetString(PyExc_TypeError,
-                            "number pair expected for second argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError,
+                        "number pair expected for second argument", 0);
         }
     }
     else if (length == 4) {
         if (!pg_IntFromObjIndex(obj, 0, val1)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "number expected for first argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError, "number expected for first argument",
+                        0);
         }
 
         if (!pg_IntFromObjIndex(obj, 1, val2)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "number expected for second argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError, "number expected for second argument",
+                        0);
         }
 
         if (!pg_IntFromObjIndex(obj, 2, val3)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "number expected for third argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError, "number expected for third argument",
+                        0);
         }
 
         if (!pg_IntFromObjIndex(obj, 3, val4)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "number expected for fourth argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError, "number expected for fourth argument",
+                        0);
         }
     }
     else {
@@ -402,9 +396,8 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
         Py_DECREF(item);
 
         if (!result) {
-            PyErr_SetString(PyExc_TypeError,
-                            "number pair expected for first argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError,
+                        "number pair expected for first argument", 0);
         }
 
         /* Get the other end of the line. */
@@ -418,34 +411,29 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
         Py_DECREF(item);
 
         if (!result) {
-            PyErr_SetString(PyExc_TypeError,
-                            "number pair expected for second argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError,
+                        "number pair expected for second argument", 0);
         }
     }
     else if (length == 4) {
         if (!pg_FloatFromObjIndex(obj, 0, val1)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "number expected for first argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError, "number expected for first argument",
+                        0);
         }
 
         if (!pg_FloatFromObjIndex(obj, 1, val2)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "number expected for second argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError, "number expected for second argument",
+                        0);
         }
 
         if (!pg_FloatFromObjIndex(obj, 2, val3)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "number expected for third argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError, "number expected for third argument",
+                        0);
         }
 
         if (!pg_FloatFromObjIndex(obj, 3, val4)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "number expected for fourth argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError, "number expected for fourth argument",
+                        0);
         }
     }
     else {

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -878,8 +878,7 @@ RectExport_init(RectObject *self, PyObject *args, PyObject *kwds)
     InnerRect *argrect, temp;
 
     if (!(argrect = RectFromObject(args, &temp))) {
-        PyErr_SetString(PyExc_TypeError, "Argument must be rect style object");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "Argument must be rect style object", -1);
     }
 
     self->r = *argrect;
@@ -1995,9 +1994,9 @@ RectExport_containsSeq(RectObject *self, PyObject *arg)
     }
     int ret = RectExport_contains_internal(self, (PyObject *const *)&arg, 1);
     if (ret < 0) {
-        PyErr_SetString(PyExc_TypeError, "'in <" ObjectName
-                                         ">' requires rect style object"
-                                         " or int as left operand");
+        RAISE(PyExc_TypeError,
+              "'in <" ObjectName
+              ">' requires rect style object or int as left operand");
     }
     return ret;
 }
@@ -2148,8 +2147,7 @@ RectExport_assItem(RectObject *self, Py_ssize_t i, PyObject *v)
     PrimitiveType *data = (PrimitiveType *)&self->r;
 
     if (!v) {
-        PyErr_SetString(PyExc_TypeError, "item deletion is not supported");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "item deletion is not supported", -1);
     }
 
     if (i < 0 || i > 3) {
@@ -2157,13 +2155,11 @@ RectExport_assItem(RectObject *self, Py_ssize_t i, PyObject *v)
             i += 4;
         }
         else {
-            PyErr_SetString(PyExc_IndexError, "Invalid rect Index");
-            return -1;
+            RAISERETURN(PyExc_IndexError, "Invalid rect Index", -1);
         }
     }
     if (!PrimitiveFromObj(v, &val)) {
-        PyErr_SetString(PyExc_TypeError, "Must assign numeric values");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "Must assign numeric values", -1);
     }
     data[i] = val;
     return 0;
@@ -2220,8 +2216,7 @@ static int
 RectExport_assSubscript(RectObject *self, PyObject *op, PyObject *value)
 {
     if (!value) {
-        PyErr_SetString(PyExc_TypeError, "item deletion is not supported");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "item deletion is not supported", -1);
     }
     if (PyIndex_Check(op)) {
         Py_ssize_t i = PyNumber_AsSsize_t(op, NULL);
@@ -2253,8 +2248,7 @@ RectExport_assSubscript(RectObject *self, PyObject *op, PyObject *value)
             Py_ssize_t i;
 
             if (PySequence_Size(value) != 4) {
-                PyErr_SetString(PyExc_TypeError, "Expect a length 4 sequence");
-                return -1;
+                RAISERETURN(PyExc_TypeError, "Expect a length 4 sequence", -1);
             }
             for (i = 0; i < 4; ++i) {
                 item = PySequence_ITEM(value, i);
@@ -2270,9 +2264,8 @@ RectExport_assSubscript(RectObject *self, PyObject *op, PyObject *value)
             self->r.h = values[3];
         }
         else {
-            PyErr_SetString(PyExc_TypeError,
-                            "Expected an integer or sequence");
-            return -1;
+            RAISERETURN(PyExc_TypeError, "Expected an integer or sequence",
+                        -1);
         }
     }
     else if (PySlice_Check(op)) {
@@ -2316,14 +2309,12 @@ RectExport_assSubscript(RectObject *self, PyObject *op, PyObject *value)
             }
         }
         else {
-            PyErr_SetString(PyExc_TypeError,
-                            "Expected an integer or sequence");
-            return -1;
+            RAISERETURN(PyExc_TypeError, "Expected an integer or sequence",
+                        -1);
         }
     }
     else {
-        PyErr_SetString(PyExc_TypeError, "Invalid Rect slice");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "Invalid Rect slice", -1);
     }
     return 0;
 }
@@ -2402,13 +2393,11 @@ RectExport_setwidth(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!PrimitiveFromObj(value, &val1)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.w = val1;
     return 0;
@@ -2428,13 +2417,11 @@ RectExport_setheight(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!PrimitiveFromObj(value, &val1)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.h = val1;
     return 0;
@@ -2454,13 +2441,11 @@ RectExport_settop(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!PrimitiveFromObj(value, &val1)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.y = val1;
     return 0;
@@ -2480,13 +2465,11 @@ RectExport_setleft(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!PrimitiveFromObj(value, &val1)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.x = val1;
     return 0;
@@ -2506,13 +2489,11 @@ RectExport_setright(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!PrimitiveFromObj(value, &val1)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.x = val1 - self->r.w;
     return 0;
@@ -2532,13 +2513,11 @@ RectExport_setbottom(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!PrimitiveFromObj(value, &val1)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.y = val1 - self->r.h;
     return 0;
@@ -2558,13 +2537,11 @@ RectExport_setcenterx(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!PrimitiveFromObj(value, &val1)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.x = val1 - (self->r.w / 2);
     return 0;
@@ -2584,13 +2561,11 @@ RectExport_setcentery(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!PrimitiveFromObj(value, &val1)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.y = val1 - (self->r.h / 2);
     return 0;
@@ -2610,13 +2585,11 @@ RectExport_settopleft(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!twoPrimitivesFromObj(value, &val1, &val2)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.x = val1;
     self->r.y = val2;
@@ -2637,13 +2610,11 @@ RectExport_settopright(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!twoPrimitivesFromObj(value, &val1, &val2)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.x = val1 - self->r.w;
     self->r.y = val2;
@@ -2664,13 +2635,11 @@ RectExport_setbottomleft(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!twoPrimitivesFromObj(value, &val1, &val2)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.x = val1;
     self->r.y = val2 - self->r.h;
@@ -2692,13 +2661,11 @@ RectExport_setbottomright(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!twoPrimitivesFromObj(value, &val1, &val2)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.x = val1 - self->r.w;
     self->r.y = val2 - self->r.h;
@@ -2719,13 +2686,11 @@ RectExport_setmidtop(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!twoPrimitivesFromObj(value, &val1, &val2)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.x += val1 - (self->r.x + (self->r.w / 2));
     self->r.y = val2;
@@ -2746,13 +2711,11 @@ RectExport_setmidleft(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!twoPrimitivesFromObj(value, &val1, &val2)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.x = val1;
     self->r.y += val2 - (self->r.y + (self->r.h / 2));
@@ -2774,13 +2737,11 @@ RectExport_setmidbottom(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!twoPrimitivesFromObj(value, &val1, &val2)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.x += val1 - (self->r.x + (self->r.w / 2));
     self->r.y = val2 - self->r.h;
@@ -2802,13 +2763,11 @@ RectExport_setmidright(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!twoPrimitivesFromObj(value, &val1, &val2)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.x = val1 - self->r.w;
     self->r.y += val2 - (self->r.y + (self->r.h / 2));
@@ -2830,13 +2789,11 @@ RectExport_setcenter(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!twoPrimitivesFromObj(value, &val1, &val2)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.x += val1 - (self->r.x + (self->r.w / 2));
     self->r.y += val2 - (self->r.y + (self->r.h / 2));
@@ -2857,13 +2814,11 @@ RectExport_setsize(RectObject *self, PyObject *value, void *closure)
 
     if (NULL == value) {
         /* Attribute deletion not supported. */
-        PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
-        return -1;
+        RAISERETURN(PyExc_AttributeError, "can't delete attribute", -1);
     }
 
     if (!twoPrimitivesFromObj(value, &val1, &val2)) {
-        PyErr_SetString(PyExc_TypeError, "invalid rect assignment");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid rect assignment", -1);
     }
     self->r.w = val1;
     self->r.h = val2;

--- a/src_c/render.c
+++ b/src_c/render.c
@@ -523,8 +523,7 @@ renderer_init(pgRendererObject *self, PyObject *args, PyObject *kwargs)
     }
     renderer = SDL_CreateRenderer(window->_win, index, flags);
     if (!renderer) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return -1;
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
     }
     self->renderer = renderer;
     self->window = window;

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -86,17 +86,15 @@ _pg_is_exception_class(PyObject *obj, void **optr)
         !PyObject_IsSubclass(obj, PyExc_BaseException)) {
         oname = PyObject_Str(obj);
         if (oname == NULL) {
-            PyErr_SetString(PyExc_TypeError,
-                            "invalid exception class argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError, "invalid exception class argument",
+                        0);
         }
         tmp = PyUnicode_AsEncodedString(oname, "ascii", "replace");
         Py_DECREF(oname);
 
         if (tmp == NULL) {
-            PyErr_SetString(PyExc_TypeError,
-                            "invalid exception class argument");
-            return 0;
+            RAISERETURN(PyExc_TypeError, "invalid exception class argument",
+                        0);
         }
 
         oname = tmp;
@@ -131,8 +129,7 @@ fetch_object_methods(pgRWHelper *helper, PyObject *obj)
         }
     }
     if (!helper->read && !helper->write) {
-        PyErr_SetString(PyExc_TypeError, "not a file object");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "not a file object", -1);
     }
     if (PyObject_HasAttrString(obj, "seek")) {
         helper->seek = PyObject_GetAttrString(obj, "seek");
@@ -212,7 +209,7 @@ pg_EncodeString(PyObject *obj, const char *encoding, const char *errors,
             Py_DECREF(exc_type);
             Py_XDECREF(exc_trace);
             if (exc_value == NULL) {
-                PyErr_SetString(eclass, "Unicode encoding error");
+                RAISE(eclass, "Unicode encoding error");
             }
             else {
                 str = PyObject_Str(exc_value);
@@ -272,7 +269,7 @@ pg_EncodeFilePath(PyObject *obj, PyObject *eclass)
     /* End code replacement section */
 
     if (obj == NULL) {
-        PyErr_SetString(PyExc_SyntaxError, "Forwarded exception");
+        RAISE(PyExc_SyntaxError, "Forwarded exception");
     }
 
     PyObject *result =
@@ -699,7 +696,7 @@ _rwops_from_pystr(PyObject *obj, char **extptr)
 #else
                     if (SDL_RWclose(rw) < 0) {
 #endif
-                        PyErr_SetString(PyExc_IOError, SDL_GetError());
+                        RAISE(PyExc_IOError, SDL_GetError());
                     }
                     return (SDL_RWops *)PyErr_NoMemory();
                 }
@@ -816,7 +813,7 @@ pg_encode_string(PyObject *self, PyObject *args, PyObject *keywds)
     }
 
     if (obj == NULL) {
-        PyErr_SetString(PyExc_SyntaxError, "Forwarded exception");
+        RAISE(PyExc_SyntaxError, "Forwarded exception");
     }
     return pg_EncodeString(obj, encoding, errors, eclass);
 }

--- a/src_c/scrap.h
+++ b/src_c/scrap.h
@@ -27,6 +27,7 @@
 #undef _POSIX_C_SOURCE
 #endif
 
+#include "pygame.h"
 #include <Python.h>
 
 /* Handle clipboard text and data in arbitrary formats */
@@ -54,10 +55,10 @@ typedef enum {
 /**
  * Macro for initialization checks.
  */
-#define PYGAME_SCRAP_INIT_CHECK()                                             \
-    if (!pygame_scrap_initialized())                                          \
-    return (PyErr_SetString(pgExc_SDLError, "scrap system not initialized."), \
-            NULL)
+#define PYGAME_SCRAP_INIT_CHECK()                                      \
+    if (!pygame_scrap_initialized()) {                                 \
+        return RAISE(pgExc_SDLError, "scrap system not initialized."); \
+    }
 
 /**
  * \brief Checks, whether the pygame scrap module was initialized.

--- a/src_c/scrap_sdl2.c
+++ b/src_c/scrap_sdl2.c
@@ -1,3 +1,4 @@
+#include "pygame.h"
 #ifdef PG_SDL3
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_clipboard.h>
@@ -44,8 +45,7 @@ char **
 pygame_scrap_get_types(void)
 {
     if (!pygame_scrap_initialized()) {
-        PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");
-        return NULL;
+        return RAISE(pgExc_SDLError, "scrap system not initialized.");
     }
 
     return pygame_scrap_types;
@@ -78,8 +78,7 @@ int
 pygame_scrap_put(char *type, Py_ssize_t srclen, char *src)
 {
     if (!pygame_scrap_initialized()) {
-        PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");
-        return 0;
+        RAISERETURN(pgExc_SDLError, "scrap system not initialized.", 0);
     }
 
     if (strcmp(type, pygame_scrap_plaintext_type) == 0) {

--- a/src_c/scrap_win.c
+++ b/src_c/scrap_win.c
@@ -18,6 +18,7 @@
     License along with this library; if not, write to the Free
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
+#include "scrap.h"
 #include <Windows.h>
 
 #if !defined(CF_DIBV5)
@@ -201,8 +202,7 @@ int
 pygame_scrap_lost(void)
 {
     if (!pygame_scrap_initialized()) {
-        PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");
-        return 0;
+        RAISERETURN(pgExc_SDLError, "scrap system not initialized.", 0);
     }
     return (GetClipboardOwner() != window_handle);
 }
@@ -215,8 +215,7 @@ pygame_scrap_put(char *type, Py_ssize_t srclen, char *src)
     HANDLE hMem;
 
     if (!pygame_scrap_initialized()) {
-        PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");
-        return 0;
+        RAISERETURN(pgExc_SDLError, "scrap system not initialized.", 0);
     }
 
     format = _convert_internal_type(type);

--- a/src_c/surflock.c
+++ b/src_c/surflock.c
@@ -100,8 +100,7 @@ pgSurface_LockBy(pgSurfaceObject *surfobj, PyObject *lockobj)
         pgSurface_Prep(surfobj);
     }
     if (!PG_LockSurface(surf->surf)) {
-        PyErr_SetString(PyExc_RuntimeError, "error locking surface");
-        return 0;
+        RAISERETURN(PyExc_RuntimeError, "error locking surface", 0);
     }
     return 1;
 }

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -326,8 +326,7 @@ accurate_delay(Sint64 ticks)
 #if !SDL_VERSION_ATLEAST(3, 0, 0)
     if (!SDL_WasInit(SDL_INIT_TIMER)) {
         if (SDL_InitSubSystem(SDL_INIT_TIMER)) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
-            return -1;
+            RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
         }
     }
 #endif

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -139,74 +139,63 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
         SDL_Palette *surf_palette = PG_GetSurfacePalette(surf);
 
         if (newsurf_palette == NULL) {
-            PyErr_SetString(
-                pgExc_SDLError,
-                "Palette expected (newsurf) but no palette found.");
             SDL_FreeSurface(newsurf);
-            return NULL;
+            return RAISE(pgExc_SDLError,
+                         "Palette expected (newsurf) but no palette found.");
         }
 
         if (surf_palette == NULL) {
-            PyErr_SetString(pgExc_SDLError,
-                            "Palette expected (surf) but no palette found.");
             SDL_FreeSurface(newsurf);
-            return NULL;
+            return RAISE(pgExc_SDLError,
+                         "Palette expected (surf) but no palette found.");
         }
 
         if (!PG_SetPaletteColors(newsurf_palette, surf_palette->colors, 0,
                                  surf_palette->ncolors)) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
-            return NULL;
+            return RAISE(pgExc_SDLError, SDL_GetError());
         }
     }
 
     if (!PG_GetSurfaceAlphaMod(surf, &alpha)) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
         SDL_FreeSurface(newsurf);
-        return NULL;
+        return RAISE(pgExc_SDLError, SDL_GetError());
     }
     if (alpha != 255) {
         if (!PG_SetSurfaceAlphaMod(newsurf, alpha)) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
-            return NULL;
+            return RAISE(pgExc_SDLError, SDL_GetError());
         }
     }
 
     isalpha = _PgSurface_SrcAlpha(surf);
     if (isalpha == 1) {
         if (!PG_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_BLEND)) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
-            return NULL;
+            return RAISE(pgExc_SDLError, SDL_GetError());
         }
     }
     else if (isalpha == -1) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
         SDL_FreeSurface(newsurf);
-        return NULL;
+        return RAISE(pgExc_SDLError, SDL_GetError());
     }
     else {
         if (!PG_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_NONE)) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
-            return NULL;
+            return RAISE(pgExc_SDLError, SDL_GetError());
         }
     }
 
     if (SDL_HasColorKey(surf)) {
         SDL_GetColorKey(surf, &colorkey);
         if (SDL_SetColorKey(newsurf, SDL_TRUE, colorkey) != 0) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
-            return NULL;
+            return RAISE(pgExc_SDLError, SDL_GetError());
         }
         if (PG_SurfaceHasRLE(surf) &&
             SDL_SetSurfaceRLE(newsurf, SDL_TRUE) != 0) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
-            return NULL;
+            return RAISE(pgExc_SDLError, SDL_GetError());
         }
     }
 
@@ -966,8 +955,7 @@ surf_rotozoom(PyObject *self, PyObject *args, PyObject *kwargs)
     newsurf = rotozoomSurface(surf32, angle, scale, 1);
     Py_END_ALLOW_THREADS;
     if (newsurf == NULL) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return NULL;
+        return RAISE(pgExc_SDLError, SDL_GetError());
     }
 
     if (surf32 == surf) {

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -236,12 +236,10 @@ _window_opengl_set_viewport(SDL_Window *window, SDL_GLContext context,
     if (SDL_GL_MakeCurrent(window, context) < 0)
 #endif
     {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return -1;
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
     }
     if (p_glViewport == NULL) {
-        PyErr_SetString(pgExc_SDLError, "glViewport function is unavailable");
-        return -1;
+        RAISERETURN(pgExc_SDLError, "glViewport function is unavailable", -1);
     }
     p_glViewport(0, 0, wnew, hnew);
     return 0;
@@ -578,9 +576,8 @@ window_set_title(pgWindowObject *self, PyObject *arg, void *v)
 {
     const char *title;
     if (!PyUnicode_Check(arg)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Argument to set_title must be a str.");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "Argument to set_title must be a str.",
+                    -1);
     }
     title = PyUnicode_AsUTF8(arg);
     SDL_SetWindowTitle(self->_win, title);
@@ -678,17 +675,15 @@ window_set_mouse_rect(pgWindowObject *self, PyObject *arg, void *v)
     SDL_Rect tmp_rect;
     SDL_Rect *mouse_rect_p = pgRect_FromObject(arg, &tmp_rect);
     if (mouse_rect_p == NULL && arg != Py_None) {
-        PyErr_SetString(PyExc_TypeError,
-                        "mouse_rect should be a Rect-like object or None");
-        return -1;
+        RAISERETURN(PyExc_TypeError,
+                    "mouse_rect should be a Rect-like object or None", -1);
     }
 #if SDL_VERSION_ATLEAST(3, 0, 0)
     if (!SDL_SetWindowMouseRect(self->_win, mouse_rect_p)) {
 #else
     if (SDL_SetWindowMouseRect(self->_win, mouse_rect_p) < 0) {
 #endif
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return -1;
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
     }
 #else
     if (PyErr_WarnEx(PyExc_Warning,
@@ -723,15 +718,13 @@ window_set_size(pgWindowObject *self, PyObject *arg, void *v)
     int w, h;
 
     if (!pg_TwoIntsFromObj(arg, &w, &h)) {
-        PyErr_SetString(PyExc_TypeError, "invalid size argument");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid size argument", -1);
     }
 
     if (w <= 0 || h <= 0) {
-        PyErr_SetString(
-            PyExc_ValueError,
-            "width or height should not be less than or equal to zero");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "width or height should not be less than or equal to zero",
+                    -1);
     }
 
     SDL_SetWindowSize(self->_win, w, h);
@@ -767,23 +760,21 @@ window_set_minimum_size(pgWindowObject *self, PyObject *arg, void *v)
     int max_w, max_h;
 
     if (!pg_TwoIntsFromObj(arg, &w, &h)) {
-        PyErr_SetString(PyExc_TypeError, "invalid size argument");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid size argument", -1);
     }
 
     if (w < 0 || h < 0) {
-        PyErr_SetString(
-            PyExc_ValueError,
-            "minimum width or height should not be less than zero");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "minimum width or height should not be less than zero",
+                    -1);
     }
 
     SDL_GetWindowMaximumSize(self->_win, &max_w, &max_h);
     if ((max_w > 0 && max_h > 0) && (w > max_w || h > max_h)) {
-        PyErr_SetString(PyExc_ValueError,
-                        "minimum width or height should not be greater than "
-                        "maximum width or height respectively");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "minimum width or height should not be greater than "
+                    "maximum width or height respectively",
+                    -1);
     }
 
     SDL_SetWindowMinimumSize(self->_win, w, h);
@@ -807,23 +798,21 @@ window_set_maximum_size(pgWindowObject *self, PyObject *arg, void *v)
     int min_w, min_h;
 
     if (!pg_TwoIntsFromObj(arg, &w, &h)) {
-        PyErr_SetString(PyExc_TypeError, "invalid size argument");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid size argument", -1);
     }
 
     if (w < 0 || h < 0) {
-        PyErr_SetString(
-            PyExc_ValueError,
-            "maximum width or height should not be less than zero");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "maximum width or height should not be less than zero",
+                    -1);
     }
 
     SDL_GetWindowMinimumSize(self->_win, &min_w, &min_h);
     if (w < min_w || h < min_h) {
-        PyErr_SetString(PyExc_ValueError,
-                        "maximum width or height should not be less than "
-                        "minimum width or height respectively");
-        return -1;
+        RAISERETURN(PyExc_ValueError,
+                    "maximum width or height should not be less than minimum "
+                    "width or height respectively",
+                    -1);
     }
 
     SDL_SetWindowMaximumSize(self->_win, w, h);
@@ -848,13 +837,11 @@ window_set_position(pgWindowObject *self, PyObject *arg, void *v)
     if (PyLong_Check(arg)) {
         x = y = PyLong_AsLong(arg);
         if (x != SDL_WINDOWPOS_CENTERED && x != SDL_WINDOWPOS_UNDEFINED) {
-            PyErr_SetString(PyExc_TypeError, "invalid position argument");
-            return -1;
+            RAISERETURN(PyExc_TypeError, "invalid position argument", -1);
         }
     }
     else if (!pg_TwoIntsFromObj(arg, &x, &y)) {
-        PyErr_SetString(PyExc_TypeError, "invalid position argument");
-        return -1;
+        RAISERETURN(PyExc_TypeError, "invalid position argument", -1);
     }
 
     SDL_SetWindowPosition(self->_win, x, y);
@@ -880,8 +867,7 @@ window_set_opacity(pgWindowObject *self, PyObject *arg, void *v)
         return -1;
     }
     if (SDL_SetWindowOpacity(self->_win, opacity)) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return -1;
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
     }
     return 0;
 }
@@ -1016,8 +1002,7 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
     if (kwargs) {
         while (PyDict_Next(kwargs, &dict_pos, &_key, &_value)) {
             if (!PyUnicode_Check(_key)) {
-                PyErr_SetString(PyExc_TypeError, "keywords must be strings");
-                return -1;
+                RAISERETURN(PyExc_TypeError, "keywords must be strings", -1);
             }
 
             _key_str = PyUnicode_AsUTF8(_key);
@@ -1183,16 +1168,14 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
 
     if (size) {
         if (!pg_TwoIntsFromObj(size, &size_w, &size_h)) {
-            PyErr_SetString(PyExc_TypeError, "invalid size argument");
-            return -1;
+            RAISERETURN(PyExc_TypeError, "invalid size argument", -1);
         }
     }
 
     if (size_w <= 0 || size_h <= 0) {
-        PyErr_SetString(
+        RAISERETURN(
             PyExc_ValueError,
-            "width or height should not be less than or equal to zero.");
-        return -1;
+            "width or height should not be less than or equal to zero.", -1);
     }
 
     if (position) {
@@ -1200,26 +1183,22 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
             pos_x = pos_y = PyLong_AsLong(position);
             if (pos_x != SDL_WINDOWPOS_CENTERED &&
                 pos_x != SDL_WINDOWPOS_UNDEFINED) {
-                PyErr_SetString(PyExc_TypeError, "invalid position argument");
-                return -1;
+                RAISERETURN(PyExc_TypeError, "invalid position argument", -1);
             }
         }
         else if (!pg_TwoIntsFromObj(position, &pos_x, &pos_y)) {
-            PyErr_SetString(PyExc_TypeError, "invalid position argument");
-            return -1;
+            RAISERETURN(PyExc_TypeError, "invalid position argument", -1);
         }
     }
 
     _win = PG_CreateWindow(title, pos_x, pos_y, size_w, size_h, flags);
     if (!_win) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return -1;
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
     }
 #if SDL_VERSION_ATLEAST(3, 0, 0)
     if (fullscreen_non_desktop) {
         if (!pg_window_set_fullscreen(_win, 0)) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
-            return -1;
+            RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
         }
     }
 #endif
@@ -1230,8 +1209,7 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
     if (flags & SDL_WINDOW_OPENGL) {
         SDL_GLContext context = SDL_GL_CreateContext(self->_win);
         if (context == NULL) {
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
-            return -1;
+            RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
         }
         /* As stated in the 'Remarks' of the docs
          * (https://wiki.libsdl.org/SDL2/SDL_GL_GetProcAddress) on Windows
@@ -1258,8 +1236,7 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
         if (SDL_SetColorKey(pgSurface_AsSurface(icon), SDL_TRUE,
                             icon_colorkey) < 0) {
 #endif
-            PyErr_SetString(pgExc_SDLError, SDL_GetError());
-            return -1;
+            RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
         }
     }
     SDL_SetWindowIcon(self->_win, pgSurface_AsSurface(icon));


### PR DESCRIPTION
In #2371 we added support for one liner for setting exception and returning the value from the functions. If the return value is NULL, we have the same support for 10+ years. In this PR I replaced all the calls to PyErr_SetString (and returning the value) with those macros. There is still work to be done with PyErr_Format, but that would make this commit too big, so I will do that in the future.