### PR TITLE
Add stripped option to dev.py

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -210,6 +210,7 @@ class Dev:
         debug = self.args.get("debug", False)
         lax = self.args.get("lax", False)
         sdl3 = self.args.get("sdl3", False)
+        stripped = self.args.get("stripped", False)
         sanitize = self.args.get("sanitize")
         coverage = self.args.get("coverage", False)
         if wheel_dir and coverage:
@@ -248,13 +249,18 @@ class Dev:
         if sdl3:
             install_args.extend(SDL3_ARGS)
 
+        if stripped:
+            install_args.append("-Csetup-args=-Dstripped=true")
+
         if coverage:
             install_args.extend(COVERAGE_ARGS)
 
         if sanitize:
             install_args.append(f"-Csetup-args=-Db_sanitize={sanitize}")
 
-        info_str = f"with {debug=}, {lax=}, {sdl3=}, and {coverage=}"
+        info_str = (
+            f"with {debug=}, {lax=}, {sdl3=}, {stripped=}, {coverage=} and {sanitize=}"
+        )
         if wheel_dir:
             pprint(f"Building wheel at '{wheel_dir}' ({info_str})")
             cmd_run(
@@ -381,6 +387,11 @@ class Dev:
             "--sdl3",
             action="store_true",
             help="Build against SDL3 instead of the default SDL2",
+        )
+        build_parser.add_argument(
+            "--stripped",
+            action="store_true",
+            help="Generate a stripped pygame-ce build (no docs/examples/tests/stubs)",
         )
         build_parser.add_argument(
             "--sanitize",


### PR DESCRIPTION
closes #1056

with the stripped flag a wheel goes from 9.6 MB to 1.5 MB on my system. Once this flag is added in dev.py I can document it in our dev.py wiki as well.