### PR TITLE
Fix display.set_mode segfault after resizing

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -707,6 +707,16 @@ _get_video_window_pos(int *x, int *y, int *center_window)
     return 0;
 }
 
+static void
+_check_window_resized(SDL_Window *window)
+{
+    SDL_Surface *sdl_surface = SDL_GetWindowSurface(window);
+    pgSurfaceObject *old_surface = pg_GetDefaultWindowSurface();
+    if (sdl_surface != old_surface->surf) {
+        old_surface->surf = sdl_surface;
+    }
+}
+
 static int SDLCALL
 pg_ResizeEventWatch(void *userdata, SDL_Event *event)
 {
@@ -786,11 +796,7 @@ pg_ResizeEventWatch(void *userdata, SDL_Event *event)
     }
 
     if (event->window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
-        SDL_Surface *sdl_surface = SDL_GetWindowSurface(window);
-        pgSurfaceObject *old_surface = pg_GetDefaultWindowSurface();
-        if (sdl_surface != old_surface->surf) {
-            old_surface->surf = sdl_surface;
-        }
+        _check_window_resized(window);
     }
     return 0;
 }
@@ -1374,6 +1380,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
             surface = pgSurface_New2(surf, newownedsurf != NULL);
         }
         else {
+            _check_window_resized(win);
             pgSurface_SetSurface(surface, surf, newownedsurf != NULL);
             Py_INCREF(surface);
         }


### PR DESCRIPTION
This should fix the following code that segfaults
```py
import pygame
pygame.display.set_mode([800, 600], flags=pygame.SCALED)
pygame.display.set_mode([800, 598], flags=pygame.RESIZABLE | pygame.SCALED)
```
This also fixes #2571

TLDR: Changing size of the window invalidates surface returned by SDL_GetWindowSurface() as explained in https://wiki.libsdl.org/SDL2/SDL_GetWindowSurface, so this commit makes sure the module always has the reference to the right SDL_Surface (hopefully). There are other possible fixes for this, but this one to me looks the most elegant (unless we rewrite the entire module/function).

And the long explanation is available in our discord server https://discord.com/channels/772505616680878080/772940667231928360/1383591122101604402

Also, if someone knows another place in our code when the resizing could happen, make sure to notify me to add this new helper function there as well