### PR TITLE
Remove unused code in mask/alphablit

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -61,10 +61,6 @@ blit_blend_premultiplied(SDL_BlitInfo *info);
 static int
 SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                SDL_Rect *dstrect, int blend_flags);
-extern int
-SDL_RLESurface(SDL_Surface *surface);
-extern void
-SDL_UnRLESurface(SDL_Surface *surface, int recode);
 
 static int
 SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,

--- a/src_c/include/pygame_mask.h
+++ b/src_c/include/pygame_mask.h
@@ -29,17 +29,4 @@ typedef struct {
 
 #define pgMask_AsBitmap(x) (((pgMaskObject *)x)->mask)
 
-#ifndef PYGAMEAPI_MASK_INTERNAL
-
-#include "pgimport.h"
-
-PYGAMEAPI_DEFINE_SLOTS(mask);
-
-#define pgMask_Type (*(PyTypeObject *)PYGAMEAPI_GET_SLOT(mask, 0))
-#define pgMask_Check(x) ((x)->ob_type == &pgMask_Type)
-
-#define import_pygame_mask() _IMPORT_PYGAME_MODULE(mask)
-
-#endif /* ~PYGAMEAPI_MASK_INTERNAL */
-
 #endif /* ~PGMASK_H */

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -2667,8 +2667,7 @@ static PyMethodDef _mask_methods[] = {
 
 MODINIT_DEFINE(mask)
 {
-    PyObject *module, *apiobj;
-    static void *c_api[PYGAMEAPI_MASK_NUMSLOTS];
+    PyObject *module;
 
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "mask",
@@ -2720,13 +2719,5 @@ MODINIT_DEFINE(mask)
         return NULL;
     }
 
-    /* export the c api */
-    c_api[0] = &pgMask_Type;
-    apiobj = encapsulate_api(c_api, "mask");
-    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
-        Py_XDECREF(apiobj);
-        Py_DECREF(module);
-        return NULL;
-    }
     return module;
 }

--- a/src_c/mask.h
+++ b/src_c/mask.h
@@ -2,6 +2,5 @@
 #define PGMASK_INTERNAL_H
 
 #include "include/pygame_mask.h"
-#define PYGAMEAPI_MASK_NUMSLOTS 1
 
 #endif /* ~PGMASK_INTERNAL_H */


### PR DESCRIPTION
The mask module C API is undocumented and unused within pygame-ce. Also removes two strange extern declarations in alphablit.c for functions that are not referenced in the codebase.