### PR TITLE
Fix aaline width and blend conflict

### DIFF
--- a/buildconfig/stubs/pygame/draw.pyi
+++ b/buildconfig/stubs/pygame/draw.pyi
@@ -508,7 +508,7 @@ def aaline(
     :param int width: (optional) used for line thickness
 
             | if width >= 1, used for line thickness (default is 1)
-            | if width < 1, nothing will be drawn
+            | if width < 1, a line of width == 1 will be drawn
 
     :returns: a rect bounding the changed pixels, if nothing is drawn the
         bounding rect's position will be the ``start_pos`` parameter value (float
@@ -521,8 +521,9 @@ def aaline(
     .. versionchangedold:: 2.0.0 Added support for keyword arguments.
     .. versionchanged:: 2.4.0 Removed deprecated 'blend' argument
     .. versionchanged:: 2.5.0 ``blend`` argument re-added for backcompat, but will
-        always raise a deprecation exception when used
-    .. versionchanged:: 2.5.3 Added line width
+        do nothing different and always raise a deprecation exception when used.
+    .. versionchanged:: 2.5.6 Added ``width`` in place of the deprecated
+        ``blend`` argument in a way that doesn't break backcompat too much.
     """
 
 def aalines(


### PR DESCRIPTION
- blend got removed in 2.4.0
- blend was re-added in 2.5.0 as a no-op
- added a width implementation in 2.5.2 but reverted it for that release only when it should have also been reverted for all upcoming releases.
- 2.5.3, 2.5.4 and 2.5.5 all use the initial width implementation. The problem here is that the width argument is coming in place of the depth argument so we are still breaking compat.
- just got the new width implementation in for 2.5.6.dev1. Still have the same issue as the previous three releases.

I saw 2 potential fixes for this situation:
fix 1: make width keyword only, put it after the blend arg, announce the API as new in 2.5.6 and pretend nothing happened in 2.5.[3-5]
fix 2: roll with whatever we have right now. This somehow works out because old code doing `blend=1` or `blend=True` would now mean `width=1` which is equivalent. We just need to add compat code that handles `width <= 0` like `width=1`. We can then advertise that the "width argument replaces the blend argument" and old code doesn't break too bad.