### PR TITLE
iOS support

### DIFF
--- a/ios-crossbuild.txt
+++ b/ios-crossbuild.txt
@@ -1,0 +1,20 @@
+[binaries]
+c = 'clang'
+cpp = 'clang++'
+ar = 'ar'
+strip = 'strip'
+pkgconfig = 'pkg-config'
+
+[host_machine]
+system = 'ios'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[properties]
+needs_exe_wrapper = true
+sys_root = '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk'
+c_args = ['-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk', '-target', 'arm64-apple-ios']
+cpp_args = ['-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk', '-target', 'arm64-apple-ios']
+c_link_args = ['-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk', '-target', 'arm64-apple-ios']
+cpp_link_args = ['-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk', '-target', 'arm64-apple-ios']

--- a/meson.build
+++ b/meson.build
@@ -52,16 +52,24 @@ cc = meson.get_compiler('c')
 
 fs = import('fs')
 
-py = import('python').find_installation(pure: false)
-py_dep = py.dependency()
+# remove all traces of meson-python, use external framework path instead of finding the host python
+# py = import('python').find_installation(pure: false)
+# py_dep = py.dependency()
 
-is_pypy = py.get_variable('implementation_lower', '') == 'pypy'
+# is_pypy = py.get_variable('implementation_lower', '') == 'pypy'
 
-if not cc.has_header('Python.h', dependencies: py_dep)
-    error(
-        'Cannot use `Python.h`. Perhaps you need to install python-dev|python-devel',
-    )
-endif
+# if not cc.has_header('Python.h', dependencies: py_dep)
+#     error(
+#         'Cannot use `Python.h`. Perhaps you need to install python-dev|python-devel',
+#     )
+# endif
+
+py_framework_dir = '/Users/luke/dev/python/pygame-ios/pygameios/build/pygameios/ios/xcode/Support/Python.xcframework/ios-arm64'
+py_framework_path = py_framework_dir + '/Python.framework'
+py_dep = declare_dependency(
+    include_directories: include_directories(py_framework_path + '/Headers'),
+    link_args: ['-F' + py_framework_dir, '-framework', 'Python']
+)
 
 if get_option('coverage')
     if cc.has_argument('--coverage')
@@ -76,7 +84,7 @@ if get_option('coverage')
     endif
 endif
 
-pg_dir = py.get_install_dir() / pg
+# pg_dir = py.get_install_dir() / pg
 
 sdl_api = get_option('sdl_api')
 sdl = 'SDL@0@'.format(sdl_api)
@@ -90,241 +98,221 @@ endif
 
 pg_inc_dirs = []
 pg_lib_dirs = []
-if plat == 'win' and host_machine.cpu_family().startswith('x86')
-    # yes, this is a bit ugly and hardcoded but it is what it is
-    # TODO (middle-term goal) - Should migrate away from this
-    # consider meson wraps? Hopefully can also get the same build path as below
-    arch_suffix = 'x' + host_machine.cpu_family().substring(-2)
-    base_dir = meson.current_source_dir()
-    prebuilt_dir = base_dir / 'prebuilt-' + arch_suffix
 
-    # download prebuilts (uses legacy builconfig code)
-    if not fs.is_dir(prebuilt_dir)
-        run_command(
-            [
-                find_program('python3', 'python'),
-                'buildconfig/download_win_prebuilt.py',
-            ],
-            check: true,
-        )
-    endif
+# all system lib checking, not needed for iOS
+# if plat == 'win' and host_machine.cpu_family().startswith('x86')
+#     # yes, this is a bit ugly and hardcoded but it is what it is
+#     # TODO (middle-term goal) - Should migrate away from this
+#     # consider meson wraps? Hopefully can also get the same build path as below
+#     arch_suffix = 'x' + host_machine.cpu_family().substring(-2)
+#     base_dir = meson.current_source_dir()
+#     prebuilt_dir = base_dir / 'prebuilt-' + arch_suffix
 
-    sdl_ver = (sdl_api == 3) ? '3.2.10' : '2.32.8'
-    sdl_image_ver = (sdl_api == 3) ? '3.2.4' : '2.8.8'
-    sdl_mixer_ver = '2.8.1'
-    sdl_ttf_ver = (sdl_api == 3) ? '3.2.2' : '2.24.0'
+#     # download prebuilts (uses legacy builconfig code)
+#     if not fs.is_dir(prebuilt_dir)
+#         run_command(
+#             [
+#                 find_program('python3', 'python'),
+#                 'buildconfig/download_win_prebuilt.py',
+#             ],
+#             check: true,
+#         )
+#     endif
 
-    dlls = []
+#     sdl_ver = (sdl_api == 3) ? '3.2.10' : '2.32.8'
+#     sdl_image_ver = (sdl_api == 3) ? '3.2.4' : '2.8.8'
+#     sdl_mixer_ver = '2.8.1'
+#     sdl_ttf_ver = (sdl_api == 3) ? '3.2.2' : '2.24.0'
 
-    # SDL
-    sdl_dir = prebuilt_dir / '@0@-@1@'.format(sdl, sdl_ver)
-    sdl_lib_dir = sdl_dir / 'lib' / arch_suffix
-    pg_inc_dirs += fs.relative_to(sdl_dir / 'include', base_dir)
-    pg_lib_dirs += sdl_lib_dir
-    dlls += sdl_lib_dir / '@0@.dll'.format(sdl)
+#     dlls = []
 
-    # SDL_image
-    if get_option('image').enabled()
-        sdl_image_dir = prebuilt_dir / '@0@-@1@'.format(sdl_image, sdl_image_ver)
-        sdl_image_lib_dir = sdl_image_dir / 'lib' / arch_suffix
-        pg_inc_dirs += fs.relative_to(sdl_image_dir / 'include', base_dir)
-        pg_lib_dirs += sdl_image_lib_dir
-        dlls += [
-            sdl_image_lib_dir / '@0@.dll'.format(sdl_image),
-            sdl_image_lib_dir / 'optional' / (sdl_api == 3 ? 'libtiff-6.dll' : 'libtiff-5.dll'),
-            sdl_image_lib_dir / 'optional' / 'libwebp-7.dll',
-            sdl_image_lib_dir / 'optional' / 'libwebpdemux-2.dll',
-        ]
-        # temporary solution to get things compiling under SDL3_image. In the future
-        # we would want to have libpng and libjpeg on SDL3_image as well.
-        if sdl_api != 3
-            dlls += [
-                sdl_image_lib_dir / 'optional' / 'libjpeg-62.dll',
-                sdl_image_lib_dir / 'optional' / 'libpng16-16.dll',
-            ]
-        endif
-    endif
+#     # SDL
+#     sdl_dir = prebuilt_dir / '@0@-@1@'.format(sdl, sdl_ver)
+#     sdl_lib_dir = sdl_dir / 'lib' / arch_suffix
+#     pg_inc_dirs += fs.relative_to(sdl_dir / 'include', base_dir)
+#     pg_lib_dirs += sdl_lib_dir
+#     dlls += sdl_lib_dir / '@0@.dll'.format(sdl)
 
-    # SDL_mixer
-    if get_option('mixer').enabled()
-        sdl_mixer_dir = prebuilt_dir / '@0@-@1@'.format(sdl_mixer, sdl_mixer_ver)
-        sdl_mixer_lib_dir = sdl_mixer_dir / 'lib' / arch_suffix
-        pg_inc_dirs += fs.relative_to(sdl_mixer_dir / 'include', base_dir)
-        pg_lib_dirs += sdl_mixer_lib_dir
-        dlls += [
-            sdl_mixer_lib_dir / '@0@.dll'.format(sdl_mixer),
-            sdl_mixer_lib_dir / 'optional' / 'libogg-0.dll',
-            sdl_mixer_lib_dir / 'optional' / 'libopus-0.dll',
-            sdl_mixer_lib_dir / 'optional' / 'libopusfile-0.dll',
-            sdl_mixer_lib_dir / 'optional' / 'libwavpack-1.dll',
-            sdl_mixer_lib_dir / 'optional' / 'libxmp.dll',
-        ]
-    endif
+#     # SDL_image
+#     if get_option('image').enabled()
+#         sdl_image_dir = prebuilt_dir / '@0@-@1@'.format(sdl_image, sdl_image_ver)
+#         sdl_image_lib_dir = sdl_image_dir / 'lib' / arch_suffix
+#         pg_inc_dirs += fs.relative_to(sdl_image_dir / 'include', base_dir)
+#         pg_lib_dirs += sdl_image_lib_dir
+#         dlls += [
+#             sdl_image_lib_dir / '@0@.dll'.format(sdl_image),
+#             sdl_image_lib_dir / 'optional' / (sdl_api == 3 ? 'libtiff-6.dll' : 'libtiff-5.dll'),
+#             sdl_image_lib_dir / 'optional' / 'libwebp-7.dll',
+#             sdl_image_lib_dir / 'optional' / 'libwebpdemux-2.dll',
+#         ]
+#         # temporary solution to get things compiling under SDL3_image. In the future
+#         # we would want to have libpng and libjpeg on SDL3_image as well.
+#         if sdl_api != 3
+#             dlls += [
+#                 sdl_image_lib_dir / 'optional' / 'libjpeg-62.dll',
+#                 sdl_image_lib_dir / 'optional' / 'libpng16-16.dll',
+#             ]
+#         endif
+#     endif
 
-    # SDL_ttf
-    if get_option('font').enabled()
-        sdl_ttf_dir = prebuilt_dir / '@0@-@1@'.format(sdl_ttf, sdl_ttf_ver)
-        sdl_ttf_lib_dir = sdl_ttf_dir / 'lib' / arch_suffix
-        pg_inc_dirs += fs.relative_to(sdl_ttf_dir / 'include', base_dir)
-        pg_lib_dirs += sdl_ttf_lib_dir
-        dlls += sdl_ttf_lib_dir / '@0@.dll'.format(sdl_ttf)
-    endif
+#     # SDL_mixer
+#     if get_option('mixer').enabled()
+#         sdl_mixer_dir = prebuilt_dir / '@0@-@1@'.format(sdl_mixer, sdl_mixer_ver)
+#         sdl_mixer_lib_dir = sdl_mixer_dir / 'lib' / arch_suffix
+#         pg_inc_dirs += fs.relative_to(sdl_mixer_dir / 'include', base_dir)
+#         pg_lib_dirs += sdl_mixer_lib_dir
+#         dlls += [
+#             sdl_mixer_lib_dir / '@0@.dll'.format(sdl_mixer),
+#             sdl_mixer_lib_dir / 'optional' / 'libogg-0.dll',
+#             sdl_mixer_lib_dir / 'optional' / 'libopus-0.dll',
+#             sdl_mixer_lib_dir / 'optional' / 'libopusfile-0.dll',
+#             sdl_mixer_lib_dir / 'optional' / 'libwavpack-1.dll',
+#             sdl_mixer_lib_dir / 'optional' / 'libxmp.dll',
+#         ]
+#     endif
 
-    # freetype, portmidi and porttime
-    if get_option('freetype').enabled() and get_option('midi').enabled()
-        common_lib_dir = prebuilt_dir / 'lib'
-        pg_inc_dirs += fs.relative_to(prebuilt_dir / 'include', base_dir)
-        pg_lib_dirs += common_lib_dir
-        dlls += [common_lib_dir / 'freetype.dll', common_lib_dir / 'portmidi.dll']
-    endif
+#     # SDL_ttf
+#     if get_option('font').enabled()
+#         sdl_ttf_dir = prebuilt_dir / '@0@-@1@'.format(sdl_ttf, sdl_ttf_ver)
+#         sdl_ttf_lib_dir = sdl_ttf_dir / 'lib' / arch_suffix
+#         pg_inc_dirs += fs.relative_to(sdl_ttf_dir / 'include', base_dir)
+#         pg_lib_dirs += sdl_ttf_lib_dir
+#         dlls += sdl_ttf_lib_dir / '@0@.dll'.format(sdl_ttf)
+#     endif
 
-    # clean unneeded file that causes build issues
-    unneeded_file = common_lib_dir / 'libportmidi.dll.a'
-    if fs.exists(unneeded_file)
-        run_command(
-            [
-                find_program('python3', 'python'),
-                '-c',
-                'import os; os.remove("@0@")'.format(unneeded_file),
-            ],
-            check: true,
-        )
-    endif
+#     # freetype, portmidi and porttime
+#     if get_option('freetype').enabled() and get_option('midi').enabled()
+#         common_lib_dir = prebuilt_dir / 'lib'
+#         pg_inc_dirs += fs.relative_to(prebuilt_dir / 'include', base_dir)
+#         pg_lib_dirs += common_lib_dir
+#         dlls += [common_lib_dir / 'freetype.dll', common_lib_dir / 'portmidi.dll']
+#     endif
 
-    run_command(
-        [
-            find_program('python3', 'python'),
-            base_dir / 'buildconfig' / '_meson_win_dll.py',
-            dlls,
-        ],
-        check: true,
-    )
+#     # clean unneeded file that causes build issues
+#     unneeded_file = common_lib_dir / 'libportmidi.dll.a'
+#     if fs.exists(unneeded_file)
+#         run_command(
+#             [
+#                 find_program('python3', 'python'),
+#                 '-c',
+#                 'import os; os.remove("@0@")'.format(unneeded_file),
+#             ],
+#             check: true,
+#         )
+#     endif
 
-    foreach lib : dlls
-        if not fs.exists(lib)
-            error(f'''
-            File "@lib@" does not exist.
-            Please try to delete "prebuilt_downloads/", "prebuilt-x64/" and "prebuilt-x86/" directories, and retry the installation.
-            ''')
-        endif
-    endforeach
+#     run_command(
+#         [
+#             find_program('python3', 'python'),
+#             base_dir / 'buildconfig' / '_meson_win_dll.py',
+#             dlls,
+#         ],
+#         check: true,
+#     )
 
-    # put dlls in root of install
-    install_data(dlls, install_dir: pg_dir, install_tag: 'pg-tag')
+#     foreach lib : dlls
+#         if not fs.exists(lib)
+#             error(f'''
+#             File "@lib@" does not exist.
+#             Please try to delete "prebuilt_downloads/", "prebuilt-x64/" and "prebuilt-x86/" directories, and retry the installation.
+#             ''')
+#         endif
+#     endforeach
 
-else
-    bases = ['/usr/local', '/usr', '/opt/homebrew', '/opt/local']
-    foreach inc_dir : bases
-        foreach sub_inc : [
-            '',
-            '/@0@'.format(sdl),
-            '/freetype2',
-        ]
-            full_inc = inc_dir / 'include' + sub_inc
-            if fs.exists(full_inc)
-                pg_inc_dirs += full_inc
-            endif
-        endforeach
-    endforeach
+#     # put dlls in root of install
+#     install_data(dlls, install_dir: pg_dir, install_tag: 'pg-tag')
 
-    foreach lib_dir : bases
-        foreach sub_lib : ['lib', 'lib64']
-            full_lib = lib_dir / sub_lib
-            if fs.exists(full_lib)
-                pg_lib_dirs += full_lib
-            endif
-        endforeach
-    endforeach
-endif
+# else
+#     bases = ['/usr/local', '/usr', '/opt/homebrew', '/opt/local']
+#     foreach inc_dir : bases
+#         foreach sub_inc : [
+#             '',
+#             '/@0@'.format(sdl),
+#             '/freetype2',
+#         ]
+#             full_inc = inc_dir / 'include' + sub_inc
+#             if fs.exists(full_inc)
+#                 pg_inc_dirs += full_inc
+#             endif
+#         endforeach
+#     endforeach
 
-# TODO: add version constraints?
-sdl_dep = dependency(sdl, required: false)
-if not sdl_dep.found()
-    sdl_dep = declare_dependency(
-        include_directories: pg_inc_dirs,
-        dependencies: cc.find_library(sdl, dirs: pg_lib_dirs),
-    )
-endif
+#     foreach lib_dir : bases
+#         foreach sub_lib : ['lib', 'lib64']
+#             full_lib = lib_dir / sub_lib
+#             if fs.exists(full_lib)
+#                 pg_lib_dirs += full_lib
+#             endif
+#         endforeach
+#     endforeach
+# endif
 
-# optional
-sdl_image_dep = dependency(sdl_image, required: false)
-if not sdl_image_dep.found()
-    sdl_image_dep = declare_dependency(
-        include_directories: pg_inc_dirs,
-        dependencies: cc.find_library(
-            sdl_image,
-            dirs: pg_lib_dirs,
-            required: get_option('image'),
-        ),
-    )
-endif
+# SDL deps need to be pointed to a specific path instead of the system
+sdl_dep = declare_dependency(
+    include_directories: ['/Users/luke/Downloads/SDL-release-2.32.8/include'],
+    link_args: ['-F/Users/luke/dev/python/sdl-libs', '-framework', 'SDL2'] # only works on iOS!
+)
 
-sdl_mixer_dep = dependency(sdl_mixer, required: false)
-if not sdl_mixer_dep.found()
-    sdl_mixer_dep = declare_dependency(
-        include_directories: pg_inc_dirs,
-        dependencies: cc.find_library(
-            sdl_mixer,
-            dirs: pg_lib_dirs,
-            required: get_option('mixer'),
-        ),
-    )
-endif
+sdl_image_dep = declare_dependency(
+    include_directories: ['/Users/luke/Downloads/SDL_image-release-2.8.8/include'],
+    link_args: ['-F/Users/luke/dev/python/sdl-libs', '-framework', 'SDL2_image'] # only works on iOS!
+)
 
-sdl_ttf_dep = dependency(sdl_ttf, required: false)
-if not sdl_ttf_dep.found()
-    sdl_ttf_dep = declare_dependency(
-        include_directories: pg_inc_dirs,
-        dependencies: cc.find_library(
-            sdl_ttf,
-            dirs: pg_lib_dirs,
-            required: get_option('font'),
-        ),
-    )
-endif
+sdl_mixer_dep = declare_dependency(
+    include_directories: ['/Users/luke/Downloads/SDL_mixer-release-2.8.1/include'],
+    link_args: ['-F/Users/luke/dev/python/sdl-libs', '-framework', 'SDL2_mixer'] # only works on iOS!
+)
 
-freetype_dep = dependency('freetype2', required: false)
-if not freetype_dep.found()
-    freetype_dep = declare_dependency(
-        include_directories: pg_inc_dirs,
-        dependencies: cc.find_library(
-            'freetype',
-            dirs: pg_lib_dirs,
-            required: get_option('freetype'),
-        ),
-    )
-endif
+sdl_ttf_dep = declare_dependency(
+    include_directories: ['/Users/luke/Downloads/SDL_ttf-release-2.24.0'],
+    link_args: ['-F/Users/luke/dev/python/sdl-libs', '-framework', 'SDL2_ttf'] # only works on iOS!
+)
 
-portmidi_dep = dependency('portmidi', required: false)
-if not portmidi_dep.found()
-    portmidi_dep = declare_dependency(
-        include_directories: pg_inc_dirs,
-        dependencies: cc.find_library(
-            'portmidi',
-            dirs: pg_lib_dirs,
-            required: get_option('midi'),
-        ),
-    )
-endif
+# SDL_ttf includes freetype, this is not needed
+# freetype_dep = dependency('freetype2', required: false)
+# if not freetype_dep.found()
+#     freetype_dep = declare_dependency(
+#         include_directories: pg_inc_dirs,
+#         dependencies: cc.find_library(
+#             'freetype',
+#             dirs: pg_lib_dirs,
+#             required: get_option('freetype'),
+#         ),
+#     )
+# endif
 
-portmidi_deps = [portmidi_dep]
+# portmidi and porttime are not available yet
+# TODO: fix dependency summary below when these get added
+# portmidi_dep = dependency('portmidi', required: false)
+# if not portmidi_dep.found()
+#     portmidi_dep = declare_dependency(
+#         include_directories: pg_inc_dirs,
+#         dependencies: cc.find_library(
+#             'portmidi',
+#             dirs: pg_lib_dirs,
+#             required: get_option('midi'),
+#         ),
+#     )
+# endif
 
-if portmidi_dep.found()
-    # porttime can be a separate library, or be inbuilt in portmidi.
-    # So if it is available as a separate library, include it as a dependency
-    porttime_dep = dependency('porttime', required: false)
-    if not porttime_dep.found()
-        porttime_dep = cc.find_library(
-            'porttime',
-            dirs: pg_lib_dirs,
-            required: false,
-        )
-    endif
+# portmidi_deps = [portmidi_dep]
 
-    if porttime_dep.found()
-        portmidi_deps += porttime_dep
-    endif
-endif
+# if portmidi_dep.found()
+#     # porttime can be a separate library, or be inbuilt in portmidi.
+#     # So if it is available as a separate library, include it as a dependency
+#     porttime_dep = dependency('porttime', required: false)
+#     if not porttime_dep.found()
+#         porttime_dep = cc.find_library(
+#             'porttime',
+#             dirs: pg_lib_dirs,
+#             required: false,
+#         )
+#     endif
+
+#     if porttime_dep.found()
+#         portmidi_deps += porttime_dep
+#     endif
+# endif
 
 pg_base_deps = [sdl_dep, py_dep]
 
@@ -334,9 +322,10 @@ summary(
         sdl_image: sdl_image_dep.found(),
         sdl_mixer: sdl_mixer_dep.found(),
         sdl_ttf: sdl_ttf_dep.found(),
-        'freetype2': freetype_dep.found(),
-        'portmidi': portmidi_dep.found(),
-        'porttime': portmidi_dep.found() ? porttime_dep.found() : false,
+        # all below are technically not being linked here, freetype is being linked to SDL_ttf
+        'freetype2': false,
+        'portmidi': false,
+        'porttime': false,
     },
     section: 'Dependencies',
 )
@@ -418,22 +407,26 @@ else
 endif
 
 subdir('src_c')
-subdir('src_py')
 
-if not get_option('stripped')
-    # run make_docs and make docs
-    if not fs.is_dir('docs/generated')
-        make_docs = files('buildconfig/make_docs.py')
-        res = run_command(
-            [find_program('python3', 'python'), make_docs],
-            check: false,
-        )
-        message(res.stdout().strip())
-        message(res.stderr().strip())
-    endif
-    subdir('docs')
-    subdir('test')
-    subdir('buildconfig/stubs')
-    install_subdir('examples', install_dir: pg_dir, install_tag: 'pg-tag')
-    # TODO: install headers? not really important though
-endif
+# the python source is copied directly into the Xcode project
+# subdir('src_py')
+
+# tries to use meson-python to install extra stuff that isn't needed
+# unit tests can be run on iOS separately
+# if not get_option('stripped')
+#     # run make_docs and make docs
+#     if not fs.is_dir('docs/generated')
+#         make_docs = files('buildconfig/make_docs.py')
+#         res = run_command(
+#             [find_program('python3', 'python'), make_docs],
+#             check: false,
+#         )
+#         message(res.stdout().strip())
+#         message(res.stderr().strip())
+#     endif
+#     subdir('docs')
+#     subdir('test')
+#     subdir('buildconfig/stubs')
+#     install_subdir('examples', install_dir: pg_dir, install_tag: 'pg-tag')
+#     # TODO: install headers? not really important though
+# endif

--- a/src_c/_sdl2/meson.build
+++ b/src_c/_sdl2/meson.build
@@ -1,67 +1,60 @@
 cython_base = '../cython/pygame/_sdl2'
 
-_sdl2_audio = py.extension_module(
+_sdl2_audio = shared_module(
     'audio',
     fs.is_file('audio.c') ? 'audio.c' : cython_base / 'audio.pyx',
     dependencies: pg_base_deps,
-    include_directories: '..',
-    install: true,
-    subdir: pg / '_sdl2',
+    include_directories: ['..'],
+    install_dir: pg / '_sdl2',
 )
 
-_sdl2_video = py.extension_module(
+_sdl2_video = shared_module(
     'video',
     fs.is_file('video.c') ? 'video.c' : cython_base / 'video.pyx',
     dependencies: pg_base_deps,
-    include_directories: '..',
-    install: true,
-    subdir: pg / '_sdl2',
+    include_directories: ['..'],
+    install_dir: pg / '_sdl2',
 )
 
-_sdl2_controller_old = py.extension_module(
+_sdl2_controller_old = shared_module(
     'controller_old',
     fs.is_file('controller_old.c') ? 'controller_old.c' : cython_base / 'controller_old.pyx',
     dependencies: pg_base_deps,
-    include_directories: '..',
-    install: true,
-    subdir: pg / '_sdl2',
+    include_directories: ['..'],
+    install_dir: pg / '_sdl2',
 )
 
 if sdl_mixer_dep.found()
-    _sdl2_mixer = py.extension_module(
+    _sdl2_mixer = shared_module(
         'mixer',
         fs.is_file('mixer.c') ? 'mixer.c' : cython_base / 'mixer.pyx',
         dependencies: pg_base_deps + sdl_mixer_dep,
-        include_directories: '..',
-        install: true,
-        subdir: pg / '_sdl2',
+        include_directories: ['..'],
+        install_dir: pg / '_sdl2',
     )
 endif
 
-_sdl2_sdl2 = py.extension_module(
+_sdl2_sdl2 = shared_module(
     'sdl2',
     fs.is_file('sdl2.c') ? 'sdl2.c' : cython_base / 'sdl2.pyx',
     dependencies: pg_base_deps,
-    include_directories: '..',
-    install: true,
-    subdir: pg / '_sdl2',
+    include_directories: ['..'],
+    install_dir: pg / '_sdl2',
 )
 
 # This is not a cython file
-_sdl2_touch = py.extension_module(
+_sdl2_touch = shared_module(
     'touch',
     'touch.c',
     dependencies: pg_base_deps,
-    include_directories: '..',
-    install: true,
-    subdir: pg / '_sdl2',
+    include_directories: ['..'],
+    install_dir: pg / '_sdl2',
 )
 
-_sdl2_controller = py.extension_module(
+_sdl2_controller = shared_module(
     'controller',
     'controller.c',
     dependencies: pg_base_deps,
-    include_directories: '..',
-    install: true,
-    subdir: pg / '_sdl2',
+    include_directories: ['..'],
+    install_dir: pg / '_sdl2',
 )

--- a/src_c/meson.build
+++ b/src_c/meson.build
@@ -1,87 +1,80 @@
 # first the "required" modules
 
-base = py.extension_module(
+# replace all instances of py.extension_module with shared_module
+
+base = shared_module(
     'base',
     'base.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-color = py.extension_module(
+color = shared_module(
     'color',
     'color.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-constants = py.extension_module(
+constants = shared_module(
     'constants',
     'constants.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
 # TODO: support SDL3
 if sdl_api != 3
-display = py.extension_module(
+display = shared_module(
     'display',
     'display.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 endif
 
-event = py.extension_module(
+event = shared_module(
     'event',
     'event.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-key = py.extension_module(
+key = shared_module(
     'key',
     'key.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-mouse = py.extension_module(
+mouse = shared_module(
     'mouse',
     'mouse.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-rect = py.extension_module(
+rect = shared_module(
     'rect',
     ['rect.c', 'pgcompat_rect.c'],
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-rwobject = py.extension_module(
+rwobject = shared_module(
     'rwobject',
     'rwobject.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
 # TODO: support SDL3
@@ -114,7 +107,7 @@ simd_surface_fill_sse2 = static_library(
     c_args: simd_sse2_neon_flags + warnings_error,
 )
 
-surface = py.extension_module(
+surface = shared_module(
     'surface',
     [
         'surface.c',
@@ -129,54 +122,48 @@ surface = py.extension_module(
         simd_surface_fill_sse2,
     ],
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 endif
 
-surflock = py.extension_module(
+surflock = shared_module(
     'surflock',
     'surflock.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-time = py.extension_module(
+time = shared_module(
     'time',
     'time.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-joystick = py.extension_module(
+joystick = shared_module(
     'joystick',
     'joystick.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-draw = py.extension_module(
+draw = shared_module(
     'draw',
     'draw.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-image = py.extension_module(
+image = shared_module(
     'image',
     'image.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
 simd_transform_avx2 = static_library(
@@ -209,120 +196,108 @@ else
     transform_sources += 'scale_mmx.c'
 endif
 
-transform = py.extension_module(
+transform = shared_module(
     'transform',
     transform_sources,
     c_args: warnings_error,
     link_with: [simd_transform_avx2, simd_transform_sse2],
     objects: transform_objs,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-mask = py.extension_module(
+mask = shared_module(
     'mask',
     ['mask.c', 'bitmask.c'],
     c_args: warnings_error + warnings_temp_mask,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-bufferproxy = py.extension_module(
+bufferproxy = shared_module(
     'bufferproxy',
     'bufferproxy.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-pixelarray = py.extension_module(
+pixelarray = shared_module(
     'pixelarray',
     'pixelarray.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-math = py.extension_module(
+math = shared_module(
     'math',
     'math.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-pixelcopy = py.extension_module(
+pixelcopy = shared_module(
     'pixelcopy',
     'pixelcopy.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-newbuffer = py.extension_module(
+newbuffer = shared_module(
     'newbuffer',
     'newbuffer.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
 # new/experimental/uncommon stuff, but built by default
-system = py.extension_module(
+system = shared_module(
     'system',
     'system.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-geometry = py.extension_module(
+geometry = shared_module(
     'geometry',
     'geometry.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
-window = py.extension_module(
+window = shared_module(
     'window',
     'window.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
 # TODO: support SDL3
 if sdl_api != 3
-_render = py.extension_module(
+_render = shared_module(
     '_render',
     'render.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 endif
 
 # TODO: support SDL3
 if sdl_api != 3
-gfxdraw = py.extension_module(
+gfxdraw = shared_module(
     'gfxdraw',
     ['gfxdraw.c', 'SDL_gfx/SDL_gfxPrimitives.c'],
     # c_args: warnings_error,
     dependencies: pg_base_deps,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 endif
 
@@ -354,14 +329,13 @@ elif plat == 'linux'
     pg_camera_sources += 'camera_v4l2.c'
 endif
 
-_camera = py.extension_module(
+_camera = shared_module(
     '_camera',
     pg_camera_sources,
     c_args: warnings_error,
     dependencies: pg_base_deps,
     link_args: pg_camera_link,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
 # pygame.scrap
@@ -370,37 +344,34 @@ if plat == 'win'
     pg_scrap_link += ['-luser32', '-lgdi32']
 endif
 
-scrap = py.extension_module(
+scrap = shared_module(
     'scrap',
     'scrap.c',
     c_args: warnings_error,
     dependencies: pg_base_deps,
     link_args: pg_scrap_link,
-    install: true,
-    subdir: pg,
+    install_dir: pg,
 )
 
 # optional modules
 
 if sdl_image_dep.found()
-    imageext = py.extension_module(
+    imageext = shared_module(
         'imageext',
         'imageext.c',
         c_args: warnings_error,
         dependencies: pg_base_deps + sdl_image_dep,
-        install: true,
-        subdir: pg,
+        install_dir: pg,
     )
 endif
 
 if sdl_ttf_dep.found()
-    font = py.extension_module(
+    font = shared_module(
         'font',
         'font.c',
         c_args: warnings_error,
         dependencies: pg_base_deps + sdl_ttf_dep,
-        install: true,
-        subdir: pg,
+        install_dir: pg,
     )
 endif
 
@@ -408,53 +379,49 @@ endif
 if sdl_api != 3
 
 if sdl_mixer_dep.found()
-    mixer = py.extension_module(
+    mixer = shared_module(
         'mixer',
         'mixer.c',
         c_args: warnings_error,
         dependencies: pg_base_deps + sdl_mixer_dep,
-        install: true,
-        subdir: pg,
+        install_dir: pg,
     )
 
-    mixer_music = py.extension_module(
+    mixer_music = shared_module(
         'mixer_music',
         'music.c',
         c_args: warnings_error,
         dependencies: pg_base_deps + sdl_mixer_dep,
-        install: true,
-        subdir: pg,
+        install_dir: pg,
     )
 endif
 
-if freetype_dep.found()
-    _freetype = py.extension_module(
-        '_freetype',
-        [
-            'freetype/ft_cache.c',
-            'freetype/ft_wrap.c',
-            'freetype/ft_render.c',
-            'freetype/ft_render_cb.c',
-            'freetype/ft_layout.c',
-            'freetype/ft_unicode.c',
-            '_freetype.c',
-        ],
-        c_args: warnings_error + warnings_temp_freetype,
-        dependencies: pg_base_deps + freetype_dep,
-        install: true,
-        subdir: pg,
-    )
-endif
+# if freetype_dep.found()
+#     _freetype = shared_module(
+#         '_freetype',
+#         [
+#             'freetype/ft_cache.c',
+#             'freetype/ft_wrap.c',
+#             'freetype/ft_render.c',
+#             'freetype/ft_render_cb.c',
+#             'freetype/ft_layout.c',
+#             'freetype/ft_unicode.c',
+#             '_freetype.c',
+#         ],
+#         c_args: warnings_error + warnings_temp_freetype,
+#         dependencies: pg_base_deps + freetype_dep,
+#         install_dir: pg,
+#     )
+# endif
 
 endif
 
-if portmidi_dep.found()
-    pypm = py.extension_module(
-        'pypm',
-        fs.is_file('pypm.c') ? 'pypm.c' : 'cython/pygame/pypm.pyx',
-        # c_args: warnings_error,
-        dependencies: pg_base_deps + portmidi_deps,
-        install: true,
-        subdir: pg,
-    )
-endif
+# if portmidi_dep.found()
+#     pypm = shared_module(
+#         'pypm',
+#         fs.is_file('pypm.c') ? 'pypm.c' : 'cython/pygame/pypm.pyx',
+#         # c_args: warnings_error,
+#         dependencies: pg_base_deps + portmidi_deps,
+#         install_dir: pg,
+#     )
+# endif


### PR DESCRIPTION
For context, I posted a video on Discord showing pygame-ce working as a native iOS app through Briefcase. This has detailed instructions about how it was done, and what iOS support looks like going forward.

## How to build for iOS (no wheel)
While working on this build, I made a lot of super hacky changes to `meson.build` to create a proof of concept, and those files are part of this PR, as well as an `ios-crossbuild.txt` file which is passed into the `--cross-file` argument. Lots of paths here are local paths on my machine (sorry), so you need to modify them to work for you. But basically:
- A `Python.framework` is linked instead of using `py.dependency` to get a dependency to Python itself. This framework can be found in a generated Briefcase iOS project, more on that below.
- SDL2 and its auxillary libs (image, ttf, mixer) need to be downloaded and built with CMake to get iOS frameworks to link with. Be sure to download and link the dependencies that come with SDL_ttf and SDL_mixer. I used the latest stable for each, but I don't think it matters.
- portmidi and porttime are disabled for this build. freetype2 is not needed as it was linked with SDL_ttf.
- All references to `py.extension_module` are replaced with `shared_module`, and all references to `py` are removed.

The build I made for the Discord video works by building the pygame-ce modules with `meson` directly using `--cross-file` to create iOS artifacts, instead of using meson-python to generate a wheel. I used the following commands:
```
meson setup build-ios --cross-file ios-crossbuild.txt --buildtype=release
meson compile -C build-ios
```

Once you have those built, you can create a fresh Briefcase app, specifying no framework (no Toga, etc) so there's no extra Python code in the way. You then create an Xcode project with `briefcase create iOS`. At this point you can attach your downloaded SDL, SDL_image, SDL_ttf, and SDL_mixer Xcode projects to the generated Xcode project through their respective iOS instructions.

Inside that Xcode project are two `app-packages` folders, one for `iphoneos` and one for `iphonesimulator`. You can copy `src_py` into both of these folders, then rename them `pygame` to make them `import`able from your game's code. You can then copy your built C modules from Meson into this folder so the `pygame` module can see them on import (make sure they are named `base.so` instead of `libbase.dylib` or whatever Meson calls them on build, they need to be `.so` for the custom xcode build phases).

Finally, you need to change `main.m` to get rid of the call to `UIApplicationMain`, since SDL calls this internally on init.

Add your game code to your Briefcase app code in `__main__.py`. Run the app on your device and it should work, I'm having issues with simulator builds but maybe you're smarter than me.

## What's probably needed for an iOS wheel
1. cibuildwheel 3.0, this is the only known stable way to build iOS wheels as far as I know.
2. A dev build of meson-python (unless it's stable by the time you read this).
3. Some way to link SDL2 and friends to the wheel, maybe they have to be wheels themselves.
4. Changes to `meson.build` to support the "ios" plat.
5. PyPI support for iOS wheels for releases, which is apparently ready.