### PR TITLE
Port more SDL functions (SDL3)

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -133,6 +133,7 @@ PG_GetSurfaceFormat(SDL_Surface *surf)
 
 #define PG_GetSurfacePalette SDL_GetSurfacePalette
 #define PG_SetPaletteColors SDL_SetPaletteColors
+#define PG_SetSurfacePalette SDL_SetSurfacePalette
 #define PG_SetSurfaceColorKey SDL_SetSurfaceColorKey
 #define PG_SetSurfaceBlendMode SDL_SetSurfaceBlendMode
 #define PG_GetSurfaceBlendMode SDL_GetSurfaceBlendMode
@@ -248,6 +249,12 @@ PG_SetPaletteColors(SDL_Palette *palette, const SDL_Color *colors,
                     int firstcolor, int ncolors)
 {
     return SDL_SetPaletteColors(palette, colors, firstcolor, ncolors) == 0;
+}
+
+static inline bool
+PG_SetSurfacePalette(SDL_Surface *surface, SDL_Palette *palette)
+{
+    return SDL_SetSurfacePalette(surface, palette) == 0;
 }
 
 static inline bool

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -82,6 +82,7 @@
 #define PG_PixelFormatEnum SDL_PixelFormat
 
 #define PG_SurfaceHasRLE SDL_SurfaceHasRLE
+#define PG_SetSurfaceRLE SDL_SetSurfaceRLE
 
 #define PG_SoftStretchNearest(src, srcrect, dst, dstrect) \
     SDL_StretchSurface(src, srcrect, dst, dstrect, SDL_SCALEMODE_NEAREST)
@@ -349,6 +350,12 @@ PG_InitSubSystem(Uint32 flags)
 #define PG_INIT_TIMER SDL_INIT_TIMER
 
 #define PG_SurfaceHasRLE SDL_HasSurfaceRLE
+
+static inline bool
+PG_SetSurfaceRLE(SDL_Surface *surface, bool enabled)
+{
+    return SDL_SetSurfaceRLE(surface, enabled) == 0;
+}
 
 static inline bool
 PG_GetSurfaceClipRect(SDL_Surface *surface, SDL_Rect *rect)

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -132,6 +132,7 @@ PG_GetSurfaceFormat(SDL_Surface *surf)
 
 #define PG_GetSurfacePalette SDL_GetSurfacePalette
 #define PG_SetPaletteColors SDL_SetPaletteColors
+#define PG_SetSurfaceColorKey SDL_SetSurfaceColorKey
 #define PG_SetSurfaceBlendMode SDL_SetSurfaceBlendMode
 #define PG_GetSurfaceBlendMode SDL_GetSurfaceBlendMode
 #define PG_GetSurfaceAlphaMod SDL_GetSurfaceAlphaMod
@@ -246,6 +247,12 @@ PG_SetPaletteColors(SDL_Palette *palette, const SDL_Color *colors,
                     int firstcolor, int ncolors)
 {
     return SDL_SetPaletteColors(palette, colors, firstcolor, ncolors) == 0;
+}
+
+static inline bool
+PG_SetSurfaceColorKey(SDL_Surface *surface, bool enabled, Uint32 key)
+{
+    return SDL_SetColorKey(surface, enabled, key) == 0;
 }
 
 static inline bool

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1795,12 +1795,9 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
     }
 
     if (h.has_cmap) {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-        if (!SDL_SetSurfacePalette(linebuf, surf_palette))
-#else
-        if (SDL_SetSurfacePalette(linebuf, surf_palette) < 0)
-#endif
+        if (!PG_SetSurfacePalette(linebuf, surf_palette)) {
             goto error; /* SDL error already set. */
+        }
     }
 
     if (rle) {

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -589,7 +589,7 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
             PG_CreateSurface(dstwidth, dstheight, PG_SURF_FORMATENUM(rz_src));
         if (SDL_HasColorKey(src)) {
             SDL_GetColorKey(src, &colorkey);
-            if (SDL_SetColorKey(rz_dst, SDL_TRUE, colorkey) != 0) {
+            if (!PG_SetSurfaceColorKey(rz_dst, SDL_TRUE, colorkey)) {
                 SDL_FreeSurface(rz_dst);
                 return NULL;
             }
@@ -649,7 +649,7 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
             PG_CreateSurface(dstwidth, dstheight, PG_SURF_FORMATENUM(rz_src));
         if (SDL_HasColorKey(src)) {
             SDL_GetColorKey(src, &colorkey);
-            if (SDL_SetColorKey(rz_dst, SDL_TRUE, colorkey) != 0) {
+            if (!PG_SetSurfaceColorKey(rz_dst, SDL_TRUE, colorkey)) {
                 SDL_FreeSurface(rz_dst);
                 return NULL;
             }

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -593,8 +593,7 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
                 SDL_FreeSurface(rz_dst);
                 return NULL;
             }
-            if (PG_SurfaceHasRLE(src) &&
-                SDL_SetSurfaceRLE(rz_dst, SDL_TRUE) != 0) {
+            if (PG_SurfaceHasRLE(src) && !PG_SetSurfaceRLE(rz_dst, SDL_TRUE)) {
                 SDL_FreeSurface(rz_dst);
                 return NULL;
             }
@@ -653,8 +652,7 @@ rotozoomSurface(SDL_Surface *src, double angle, double zoom, int smooth)
                 SDL_FreeSurface(rz_dst);
                 return NULL;
             }
-            if (PG_SurfaceHasRLE(src) &&
-                SDL_SetSurfaceRLE(rz_dst, SDL_TRUE) != 0) {
+            if (PG_SurfaceHasRLE(src) && !PG_SetSurfaceRLE(rz_dst, SDL_TRUE)) {
                 SDL_FreeSurface(rz_dst);
                 return NULL;
             }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1442,9 +1442,8 @@ surf_set_colorkey(pgSurfaceObject *self, PyObject *args)
         success = PG_SetSurfaceColorKey(surf, SDL_FALSE, color);
     }
     if (success && hascolor) {
-        success =
-            SDL_SetSurfaceRLE(
-                surf, (flags & PGS_RLEACCEL) ? SDL_TRUE : SDL_FALSE) == 0;
+        success = PG_SetSurfaceRLE(
+            surf, (flags & PGS_RLEACCEL) ? SDL_TRUE : SDL_FALSE);
     }
     if (success) {
         success = PG_SetSurfaceColorKey(surf, hascolor, color);
@@ -1496,7 +1495,7 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
     Uint32 flags = 0;
     PyObject *alpha_obj = NULL, *intobj = NULL;
     Uint8 alpha;
-    int result, alphaval = 255;
+    int alphaval = 255;
     SDL_Rect sdlrect;
     SDL_Surface *surface;
 
@@ -1544,8 +1543,8 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
         }
     }
     pgSurface_Prep(self);
-    result =
-        SDL_SetSurfaceRLE(surf, (flags & PGS_RLEACCEL) ? SDL_TRUE : SDL_FALSE);
+    bool success =
+        PG_SetSurfaceRLE(surf, (flags & PGS_RLEACCEL) ? SDL_TRUE : SDL_FALSE);
     /* HACK HACK HACK */
     if ((surf->flags & SDL_RLEACCEL) && (!(flags & PGS_RLEACCEL))) {
         /* hack to strip SDL_RLEACCEL flag off surface immediately when
@@ -1561,12 +1560,12 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
         SDL_FreeSurface(surface);
     }
     /* HACK HACK HACK */
-    if (result == 0) {
-        result = !PG_SetSurfaceAlphaMod(surf, alpha);
+    if (success) {
+        success = PG_SetSurfaceAlphaMod(surf, alpha);
     }
     pgSurface_Unprep(self);
 
-    if (result != 0) {
+    if (!success) {
         return RAISE(pgExc_SDLError, SDL_GetError());
     }
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3236,7 +3236,7 @@ surf_subsurface(PyObject *self, PyObject *args)
             SDL_FreeSurface(sub);
             return NULL;
         }
-        if (SDL_SetSurfacePalette(sub, pal) != 0) {
+        if (!PG_SetSurfacePalette(sub, pal)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreePalette(pal);
             SDL_FreeSurface(sub);

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -202,8 +202,7 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
             SDL_FreeSurface(newsurf);
             return NULL;
         }
-        if (PG_SurfaceHasRLE(surf) &&
-            SDL_SetSurfaceRLE(newsurf, SDL_TRUE) != 0) {
+        if (PG_SurfaceHasRLE(surf) && !PG_SetSurfaceRLE(newsurf, SDL_TRUE)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
             return NULL;

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -197,7 +197,7 @@ newsurf_fromsurf(SDL_Surface *surf, int width, int height)
 
     if (SDL_HasColorKey(surf)) {
         SDL_GetColorKey(surf, &colorkey);
-        if (SDL_SetColorKey(newsurf, SDL_TRUE, colorkey) != 0) {
+        if (!PG_SetSurfaceColorKey(newsurf, SDL_TRUE, colorkey)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             SDL_FreeSurface(newsurf);
             return NULL;

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -1251,13 +1251,8 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
         return -1;
     }
     if (icon_colorkey != -1) {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-        if (!SDL_SetColorKey(pgSurface_AsSurface(icon), SDL_TRUE,
-                             icon_colorkey)) {
-#else
-        if (SDL_SetColorKey(pgSurface_AsSurface(icon), SDL_TRUE,
-                            icon_colorkey) < 0) {
-#endif
+        if (!PG_SetSurfaceColorKey(pgSurface_AsSurface(icon), SDL_TRUE,
+                                   icon_colorkey)) {
             PyErr_SetString(pgExc_SDLError, SDL_GetError());
             return -1;
         }


### PR DESCRIPTION
While https://github.com/pygame-community/pygame-ce/pull/3435 does get Surface compiling, it's actual functionality is quite limited due to the prevalence of SDL int return code -> bool return code issues.

When combined with #3435 and built on SDL3, this brings the surface test suite from
`FAILED (failures=8, errors=198, skipped=2)` to `FAILED (failures=5, errors=130, skipped=2)`, a significant improvement. A lot of the remaining fails after this are about the lack of display.
