### PR TITLE
docs: logical_size might be (0, 0)

### DIFF
--- a/docs/reST/ref/sdl2_video.rst
+++ b/docs/reST/ref/sdl2_video.rst
@@ -378,6 +378,10 @@
       | :sl:`Get or set the logical Renderer size (a device independent resolution for rendering)`
       | :sg:`logical_size -> (int width, int height)`
 
+      Note: When the rendering target is the main window, and ``logical_size``
+      has not been set before, it will contain ``(0, 0)`` and not the size of
+      the window.
+
    .. attribute:: scale
 
       | :sl:`Get the drawing scale for the current rendering target`


### PR DESCRIPTION
When Renderer.logical_size hasn't been changed before, it will contain (0, 0) and not the size of the window as one might expect.

This bit me, and I only by chance found a remark pointing that out in the SDL2 docs.

This adds a similar remark to the pygame-ce docs.