### PR TITLE
Fix math.lerp docs, improve code

### DIFF
--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -119,7 +119,7 @@ Conversion can be combined with swizzling or slicing to create a new order
 
    The formula is:
 
-   ``a * value + (1 - value) * b``.
+   ``a + (b - a) * value``.
 
    .. versionadded:: 2.4.0
 

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -4494,12 +4494,12 @@ math_lerp(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *max = args[1];
     PyObject *value = args[2];
 
-    if (PyNumber_Check(args[2]) != 1) {
-        return RAISE(PyExc_TypeError,
-                     "lerp requires the interpolation amount to be number");
-    }
-
+    double a = PyFloat_AsDouble(min);
+    RAISE_ARG_TYPE_ERROR("min")
+    double b = PyFloat_AsDouble(max);
+    RAISE_ARG_TYPE_ERROR("max")
     double t = PyFloat_AsDouble(value);
+    RAISE_ARG_TYPE_ERROR("value")
 
     if (nargs == 4 && !PyObject_IsTrue(args[3])) {
         ;  // pass if do_clamp is false
@@ -4513,16 +4513,7 @@ math_lerp(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
         }
     }
 
-    if (PyNumber_Check(min) && PyNumber_Check(max)) {
-        return PyFloat_FromDouble(PyFloat_AsDouble(min) * (1 - t) +
-                                  PyFloat_AsDouble(max) * t);
-    }
-    else {
-        return RAISE(
-            PyExc_TypeError,
-            "math.lerp requires all the arguments to be numbers. To lerp "
-            "between two vectors, please use the Vector class methods.");
-    }
+    return PyFloat_FromDouble(lerp(a, b, t));
 }
 
 static PyObject *


### PR DESCRIPTION
This PR fixes #3521 by using the correct formula in the docs.

While I was looking at the code I decided to also improve it to not do `PyNumber_Check` because the subsequent `PyFloat_AsDouble` can still fail. The more robust way to do this is to check for errors after the call.