### PR TITLE
`dev.py`: alias build with install and add argument to only test specific modules with `all`

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -203,6 +203,7 @@ class Dev:
         self.deps["all"] = set()
         for k in self.deps.values():
             self.deps["all"] |= k
+        self.deps["install"] = self.deps["build"]
 
     def cmd_build(self):
         wheel_dir = self.args.get("wheel", DIST_DIR)
@@ -274,6 +275,8 @@ class Dev:
         else:
             pprint(f"Installing in editable mode ({info_str})")
             pip_install(self.py, install_args)
+
+    cmd_install = cmd_build
 
     def cmd_docs(self):
         full = self.args.get("full", False)
@@ -355,7 +358,9 @@ class Dev:
         )
 
         # Build command
-        build_parser = subparsers.add_parser("build", help="Build the project")
+        build_parser = subparsers.add_parser(
+            "build", help="Build the project", aliases=["install"]
+        )
         build_parser.add_argument(
             "--wheel",
             nargs="?",
@@ -445,11 +450,18 @@ class Dev:
         subparsers.add_parser("format", help="Format code")
 
         # All command
-        subparsers.add_parser(
+        all_parser = subparsers.add_parser(
             "all",
             help=(
                 "Run all the subcommands. This is handy for checking that your work is "
                 "ready to be submitted"
+            ),
+        )
+        all_parser.add_argument(
+            "mod",
+            nargs="*",
+            help=(
+                "Name(s) of sub-module(s) to test. If no args are given all are tested"
             ),
         )
 


### PR DESCRIPTION
Reasoning:
- usually building stops at compiling. new contributors might not choose it thinking it won't install pygame - but it will. I have one "documented" case of this happening.
- when adding some features you usually don't need to test all modules. it would not be a problem if display tests didn't run fullscreen operations, that completely fuck up every other window state because it sucks for some reason. that annoying behavior might discourage the usage of all, and it should not be the case.