### PR TITLE
Fix FRect contains error message

### DIFF
--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -1999,6 +1999,16 @@ RectExport_containsSeq(RectObject *self, PyObject *arg)
         PyErr_SetString(PyExc_TypeError, "'in <" ObjectName
                                          ">' requires rect style object"
                                          " or int as left operand");
+        if (strcmp(ObjectName, "pygame.rect.FRect") == 0) {
+            PyErr_SetString(PyExc_TypeError, "'in <" ObjectName
+                                             ">' requires rect style object"
+                                             " or float as left operand");
+        }
+        else {
+            PyErr_SetString(PyExc_TypeError, "'in <" ObjectName
+                                             ">' requires rect style object"
+                                             " or int as left operand");
+        }
     }
     return ret;
 }

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -1994,21 +1994,16 @@ RectExport_containsSeq(RectObject *self, PyObject *arg)
         return coord == self->r.x || coord == self->r.y ||
                coord == self->r.w || coord == self->r.h;
     }
+
     int ret = RectExport_contains_internal(self, (PyObject *const *)&arg, 1);
     if (ret < 0) {
-        PyErr_SetString(PyExc_TypeError, "'in <" ObjectName
-                                         ">' requires rect style object"
-                                         " or int as left operand");
-        if (strcmp(ObjectName, "pygame.rect.FRect") == 0) {
-            PyErr_SetString(PyExc_TypeError, "'in <" ObjectName
-                                             ">' requires rect style object"
-                                             " or float as left operand");
-        }
-        else {
-            PyErr_SetString(PyExc_TypeError, "'in <" ObjectName
-                                             ">' requires rect style object"
-                                             " or int as left operand");
-        }
+        const char *operand_type =
+            strcmp(ObjectName, "pygame.rect.FRect") == 0 ? "float" : "int";
+
+        PyErr_Format(
+            PyExc_TypeError,
+            "'in %s' requires rect style object or %s as left operand",
+            ObjectName, operand_type);
     }
     return ret;
 }


### PR DESCRIPTION
FRect requires a float as the left operand but the error message says it requires an int.

Before this PR:
```
>>> fr = pygame.FRect(10,20,30,40)
>>> 10 in fr
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'in <pygame.rect.FRect>' requires rect style object or int as left operand
```

After:
```
>>> fr = pygame.FRect(10,20,30,40)
>>> 10 in fr
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'in <pygame.rect.FRect>' requires rect style object or float as left operand
```


Resolves #3533 