### PR TITLE
2.5.5 + pypy311

### DIFF
--- a/.github/workflows/build-debian-multiarch.yml
+++ b/.github/workflows/build-debian-multiarch.yml
@@ -20,7 +20,9 @@ on:
       - '!.github/workflows/build-debian-multiarch.yml'
 
   pull_request:
-    branches: main
+    branches:
+      - main
+      - 2.5.5-branch
     paths-ignore:
       - 'docs/**'
       - 'examples/**'

--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -16,7 +16,9 @@ on:
       - '!.github/workflows/build-emsdk.yml'
 
   pull_request:
-    branches: main
+    branches:
+      - main
+      - 2.5.5-branch
     paths-ignore:
       - 'docs/**'
       - 'examples/**'

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -7,7 +7,9 @@ on:
     branches: main
 
   pull_request:
-    branches: main
+    branches:
+      - main
+      - 2.5.5-branch
 
   # the github release drafter can call this workflow
   workflow_call:

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -7,7 +7,9 @@ on:
     branches: main
 
   pull_request:
-    branches: main
+    branches:
+      - main
+      - 2.5.5-branch
 
   # the github release drafter can call this workflow
   workflow_call:

--- a/.github/workflows/build-on-msys2.yml
+++ b/.github/workflows/build-on-msys2.yml
@@ -17,7 +17,9 @@ on:
       - '!.github/workflows/build-on-msys2.yml'
 
   pull_request:
-    branches: main
+    branches:
+      - main
+      - 2.5.5-branch
     paths-ignore:
       - 'docs/**'
       - 'examples/**'

--- a/.github/workflows/build-sdl3.yml
+++ b/.github/workflows/build-sdl3.yml
@@ -18,7 +18,9 @@ on:
       - '!.github/workflows/build-sdl3.yml'
 
   pull_request:
-    branches: main
+    branches:
+      - main
+      - 2.5.5-branch
     paths-ignore:
       - 'docs/**'
       - 'examples/**'

--- a/.github/workflows/build-ubuntu-coverage.yml
+++ b/.github/workflows/build-ubuntu-coverage.yml
@@ -25,7 +25,9 @@ on:
       - '!.github/workflows/build-ubuntu-coverage.yml'
 
   pull_request:
-    branches: main
+    branches:
+      - main
+      - 2.5.5-branch
     paths-ignore:
       - 'docs/**'
       - 'examples/**'

--- a/.github/workflows/build-ubuntu-debug-python.yml
+++ b/.github/workflows/build-ubuntu-debug-python.yml
@@ -26,7 +26,9 @@ on:
       - '!.github/workflows/build-ubuntu-debug-python.yml'
 
   pull_request:
-    branches: main
+    branches:
+      - main
+      - 2.5.5-branch
     paths-ignore:
       - 'docs/**'
       - 'examples/**'

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -14,7 +14,9 @@ on:
     branches: main
 
   pull_request:
-    branches: main
+    branches:
+      - main
+      - 2.5.5-branch
 
   # the github release drafter can call this workflow
   workflow_call:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -7,7 +7,9 @@ on:
     branches: main
 
   pull_request:
-    branches: main
+    branches:
+      - main
+      - 2.5.5-branch
 
   # the github release drafter can call this workflow
   workflow_call:

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -8,7 +8,9 @@ on:
       - 'src_c/**'
 
   pull_request:
-    branches: main
+    branches:
+      - main
+      - 2.5.5-branch
     paths:
       - 'src_c/**'
 

--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -8,7 +8,9 @@ on:
     branches: main
 
   pull_request:
-    branches: main
+    branches:
+      - main
+      - 2.5.5-branch
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-dev-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ requires = [
   "meson-python<=0.17.1",
   "meson<=1.7.0",
   "ninja<=1.12.1",
-  "cython<=3.0.11",
+  "cython<=3.1.2",
   "sphinx<=8.1.3",
   "sphinx-autoapi<=3.3.2",
   "pyproject-metadata!=0.9.1",
@@ -75,7 +75,7 @@ install = ['--tags=runtime,python-runtime,pg-tag']
 # dependencies. Here is where uv comes into the picture. It is an "installer" like pip,
 # but faster. It has been observed to save a couple of minutes of CI time.
 build-frontend = "build[uv]"
-build = "cp3{9,10,11,12,13}-* pp3{9,10}-*"
+build = "cp3{9,10,11,12,13}-* pp3{10,11}-*"
 skip = "*-musllinux_*"
 # build[uv] is verbose by default, so below flag is not needed here
 # build-verbosity = 3
@@ -118,5 +118,5 @@ only-binary = ["numpy"]
 # 1. skip all 32-bit manylinux (i686)
 # 2. skip all pypy+arm combinations
 [[tool.cibuildwheel.overrides]]
-select = "{*-manylinux_i686,pp*-*{arm64,aarch64}}"
+select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64}"
 test-requires = []


### PR DESCRIPTION
Backport Pypy 3.11 support to 2.5.5.

Plan:
- See if CI still works fine
- Take pypy 3.11 wheel, manually add to GitHub release and Pypi release
- Put notice in GitHub release notes with date added
- Ping the people who asked for this on discord

This is a new operation for us but could be a good test for doing the same thing for Python 3.14 support once RC1 comes out? I guess one issue with that is that it would need up to date cibuildwheel.