### PR TITLE
Fix rwops and some image stuff on SDL3

### DIFF
--- a/src_c/image.c
+++ b/src_c/image.c
@@ -197,10 +197,14 @@ image_save(PyObject *self, PyObject *arg, PyObject *kwarg)
             SDL_RWops *rw = pgRWops_FromFileObject(obj);
             if (rw != NULL) {
                 if (!strcasecmp(ext, "bmp")) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+                    result = (SDL_SaveBMP_IO(surf, rw, 0) ? 0 : -1);
+#else
                     /* The SDL documentation didn't specify which negative
                      * number is returned upon error. We want to be sure that
                      * result is either 0 or -1: */
                     result = (SDL_SaveBMP_RW(surf, rw, 0) == 0 ? 0 : -1);
+#endif
                 }
                 else {
                     result = SaveTGA_RW(surf, rw, 1);
@@ -213,10 +217,14 @@ image_save(PyObject *self, PyObject *arg, PyObject *kwarg)
         else {
             if (!strcasecmp(ext, "bmp")) {
                 Py_BEGIN_ALLOW_THREADS;
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+                result = (SDL_SaveBMP(surf, name) ? 0 : -1);
+#else
                 /* The SDL documentation didn't specify which negative number
                  * is returned upon error. We want to be sure that result is
                  * either 0 or -1: */
                 result = (SDL_SaveBMP(surf, name) == 0 ? 0 : -1);
+#endif
                 Py_END_ALLOW_THREADS;
             }
             else {

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -333,26 +333,34 @@ image_save_ext(PyObject *self, PyObject *arg, PyObject *kwarg)
         if (!strcasecmp(ext, "jpeg") || !strcasecmp(ext, "jpg")) {
             if (rw != NULL) {
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-                result = IMG_SaveJPG_IO(surf, rw, 0, JPEG_QUALITY);
+                result = IMG_SaveJPG_IO(surf, rw, 0, JPEG_QUALITY) ? 0 : -1;
 #else
                 result = IMG_SaveJPG_RW(surf, rw, 0, JPEG_QUALITY);
 #endif
             }
             else {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+                result = IMG_SaveJPG(surf, name, JPEG_QUALITY) ? 0 : -1;
+#else
                 result = IMG_SaveJPG(surf, name, JPEG_QUALITY);
+#endif
             }
         }
         else if (!strcasecmp(ext, "png")) {
             /*Py_BEGIN_ALLOW_THREADS; */
             if (rw != NULL) {
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-                result = IMG_SavePNG_IO(surf, rw, 0);
+                result = IMG_SavePNG_IO(surf, rw, 0) ? 0 : -1;
 #else
                 result = IMG_SavePNG_RW(surf, rw, 0);
 #endif
             }
             else {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+                result = IMG_SavePNG(surf, name) ? 0 : -1;
+#else
                 result = IMG_SavePNG(surf, name);
+#endif
             }
             /*Py_END_ALLOW_THREADS; */
         }


### PR DESCRIPTION
- Fixes image saving return code handling.
- `SDL_INIT_INTERFACE` needs to be used on a `SDL_IOStreamInterface` interface.
- As a result of the above issue we were going into the error handling path where `_pg_rw_close` already does `PyMem_Free(helper);`, resulting in a double free.

With these changes all `imageext` tests pass and some failing `image` tests are also passing now.