### PR TITLE
fix: typo in sndarray docs calling it surfarray #3567

### DIFF
--- a/docs/reST/ref/sndarray.rst
+++ b/docs/reST/ref/sndarray.rst
@@ -10,7 +10,7 @@
 
 Functions to convert between NumPy arrays and Sound objects. This
 module will only be functional when pygame can use the external NumPy
-package. If NumPy can't be imported, ``surfarray`` becomes a ``MissingModule``
+package. If NumPy can't be imported, ``sndarray`` becomes a ``MissingModule``
 object.
 
 Sound data is made of thousands of samples per second, and each sample is the


### PR DESCRIPTION
Issue #3567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Corrected the MissingModule note in the sound array documentation to reference sndarray (not surfarray) when NumPy is unavailable.
  - Improves accuracy and reduces confusion for users troubleshooting NumPy-related issues.
  - No changes to functionality, behavior, or public API.
  - Affects documentation renders only (local docs and online reference).
  - Estimated review effort: low.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->