### PR TITLE
Add wayland specific skips

### DIFF
--- a/buildconfig/stubs/pygame/display.pyi
+++ b/buildconfig/stubs/pygame/display.pyi
@@ -745,6 +745,9 @@ def set_window_position(position: Point) -> None:
     still be able to move the window after this call. See also
     :func:`pygame.display.get_window_position()`.
 
+    .. note:: This function is not supported on some video drivers (like wayland)
+        and a :exc:`pygame.error` exception may be raised in such cases.
+
     .. versionadded:: 2.5.0
     """
 

--- a/buildconfig/stubs/pygame/window.pyi
+++ b/buildconfig/stubs/pygame/window.pyi
@@ -222,6 +222,9 @@ class Window:
 
     Setting the always-on-top mode requires SDL 2.0.16+.
 
+    .. note:: Setting this property is not supported on some video drivers (like wayland)
+        and a :exc:`pygame.error` exception may be raised in such cases.
+
     .. versionadded:: 2.3.1
     """
 
@@ -296,12 +299,19 @@ class Window:
 
         The position may be a tuple of (x, y) coordinates or ``WINDOWPOS_CENTERED`` or
         ``WINDOWPOS_UNDEFINED``. The origin is the topleft of the main display.
+
+        .. note:: Setting this property is not supported on some video drivers (like wayland)
+            and a :exc:`pygame.error` exception may be raised in such cases.
         """
 
     @position.setter
     def position(self, value: Union[int, Point]) -> None: ...
     opacity: float
-    """Get or set the window opacity, between 0.0 (fully transparent) and 1.0 (fully opaque)."""
+    """Get or set the window opacity, between 0.0 (fully transparent) and 1.0 (fully opaque).
+
+    .. note:: Setting this property is not supported on some video drivers (like wayland)
+        and a :exc:`pygame.error` exception may be raised in such cases.
+    """
 
     @property
     def opengl(self) -> bool:

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -8,6 +8,10 @@ import pygame.transform
 from pygame import display
 from pygame.tests.test_utils import question
 
+pygame.display.init()
+is_wayland = pygame.display.get_driver() == "wayland"
+pygame.display.quit()
+
 
 class DisplayModuleTest(unittest.TestCase):
     default_caption = "pygame window"
@@ -71,6 +75,7 @@ class DisplayModuleTest(unittest.TestCase):
         os.environ.get("SDL_VIDEODRIVER") == pygame.NULL_VIDEODRIVER,
         "requires the SDL_VIDEODRIVER to be a non-null value",
     )
+    @unittest.skipIf(is_wayland, "broken on wayland")
     def test_get_active_iconify(self):
         """Test the get_active function after an iconify"""
 
@@ -411,6 +416,7 @@ class DisplayModuleTest(unittest.TestCase):
         os.environ.get("SDL_VIDEODRIVER") in [pygame.NULL_VIDEODRIVER, "android"],
         "iconify is only supported on some video drivers/platforms",
     )
+    @unittest.skipIf(is_wayland, "broken on wayland")
     def test_iconify(self):
         pygame.display.set_mode((640, 480))
 
@@ -519,6 +525,7 @@ class DisplayModuleTest(unittest.TestCase):
         pygame.version.SDL >= (2, 32, 50),
         "set_gamma is removed in SDL3, does not work in sdl2-compat either",
     )
+    @unittest.skipIf(is_wayland, "not supported on wayland")
     def test_set_gamma(self):
         pygame.display.set_mode((1, 1))
 
@@ -537,6 +544,7 @@ class DisplayModuleTest(unittest.TestCase):
         pygame.version.SDL >= (2, 32, 50),
         "set_gamma is removed in SDL3, does not work in sdl2-compat either",
     )
+    @unittest.skipIf(is_wayland, "not supported on wayland")
     def test_set_gamma__tuple(self):
         pygame.display.set_mode((1, 1))
 
@@ -690,6 +698,7 @@ class DisplayModuleTest(unittest.TestCase):
                     (test_surf.get_width(), test_surf.get_height()), width_height
                 )
 
+    @unittest.skipIf(is_wayland, "not supported on wayland")
     def test_get_set_window_position(self):
         pygame.display.set_mode((500, 500))
         pygame.display.set_window_position((420, 360))

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -5,6 +5,10 @@ import unittest
 
 import pygame
 
+pygame.display.init()
+is_wayland = pygame.display.get_driver() == "wayland"
+pygame.display.quit()
+
 EVENT_TYPES = (
     #   pygame.NOEVENT,
     #   pygame.ACTIVEEVENT,
@@ -837,8 +841,9 @@ class EventModuleTest(unittest.TestCase):
 
     @unittest.skipIf(
         os.environ.get("SDL_VIDEODRIVER") == pygame.NULL_VIDEODRIVER,
-        'requires the SDL_VIDEODRIVER to be a non-null value',
+        "requires the SDL_VIDEODRIVER to be a non-null value",
     )
+    @unittest.skipIf(is_wayland, "broken on wayland")
     def test_set_grab__and_get_symmetric(self):
         """Ensure event grabbing can be enabled and disabled.
 
@@ -905,8 +910,9 @@ class EventModuleTest(unittest.TestCase):
 
     @unittest.skipIf(
         os.environ.get("SDL_VIDEODRIVER") == pygame.NULL_VIDEODRIVER,
-        'requires the SDL_VIDEODRIVER to be a non-null value',
+        "requires the SDL_VIDEODRIVER to be a non-null value",
     )
+    @unittest.skipIf(is_wayland, "broken on wayland")
     def test_get_grab(self):
         """Ensure get_grab() works as expected"""
         surf = pygame.display.set_mode((10, 10))

--- a/test/window_test.py
+++ b/test/window_test.py
@@ -11,6 +11,10 @@ pygame.init()
 
 IS_PYPY = "PyPy" == platform.python_implementation()
 
+pygame.display.init()
+is_wayland = pygame.display.get_driver() == "wayland"
+pygame.display.quit()
+
 
 class WindowTypeTest(unittest.TestCase):
     DEFAULT_TITLE = "pygame window"
@@ -102,6 +106,7 @@ class WindowTypeTest(unittest.TestCase):
         SDL < (2, 0, 16),
         "requires SDL 2.0.16+",
     )
+    @unittest.skipIf(is_wayland, "not supported on wayland")
     def test_always_on_top_set(self):
         self.win.always_on_top = True
         self.assertTrue(self.win.always_on_top)
@@ -149,6 +154,7 @@ class WindowTypeTest(unittest.TestCase):
 
         self.win.size = (640, 480)
 
+    @unittest.skipIf(is_wayland, "not supported on wayland")
     def test_position(self):
         new_pos = (self.win.position[0] + 20, self.win.position[1] + 10)
         self.win.position = new_pos
@@ -160,8 +166,8 @@ class WindowTypeTest(unittest.TestCase):
         self.assertRaises(TypeError, lambda: setattr(self.win, "position", 123))
 
         # test set position when init
-        win = Window(position=(20, 48))
-        self.assertTupleEqual((20, 48), win.position)
+        win = Window(position=new_pos)
+        self.assertTupleEqual(new_pos, win.position)
         win.destroy()
 
         self.assertRaises(TypeError, lambda: Window(position=123))
@@ -255,6 +261,7 @@ class WindowTypeTest(unittest.TestCase):
         os.environ.get("SDL_VIDEODRIVER") == pygame.NULL_VIDEODRIVER,
         "requires the SDL_VIDEODRIVER to be a non-null value",
     )
+    @unittest.skipIf(is_wayland, "not supported on wayland")
     def test_opacity_set(self):
         self.win.opacity = 0.5
         self.assertEqual(self.win.opacity, 0.5)


### PR DESCRIPTION
Add skips to tests that fail on wayland. With this PR, we now have all tests passing on wayland on both sdl2 and sdl2-compat.

Also adds documentation to the API that is known to not work with wayland.