### PR TITLE
[Part 3] SDL3: surface+pixelarray+font+draw: runtime fixes

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1334,7 +1334,7 @@ flood_fill(PyObject *self, PyObject *arg, PyObject *kwargs)
     if (pgSurface_Check(colorobj)) {
         pat_surfobj = ((pgSurfaceObject *)colorobj);
 
-        pattern = PG_ConvertSurface(pat_surfobj->surf, surf->format);
+        pattern = PG_ConvertSurface(pat_surfobj->surf, surf);
 
         if (pattern == NULL) {
             return RAISE(PyExc_RuntimeError, "error converting pattern surf");

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -137,7 +137,7 @@ _make_surface(pgPixelArrayObject *array, PyObject *args)
     }
 
     /* Ensure the new surface has the same format as the original */
-    new_surf = PG_ConvertSurface(temp_surf, surf->format);
+    new_surf = PG_ConvertSurface(temp_surf, surf);
     if (temp_surf != surf) {
         SDL_FreeSurface(temp_surf);
     }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1620,7 +1620,7 @@ surf_copy(pgSurfaceObject *self, PyObject *_null)
     SURF_INIT_CHECK(surf)
 
     pgSurface_Prep(self);
-    newsurf = PG_ConvertSurface(surf, surf->format);
+    newsurf = PG_ConvertSurface(surf, surf);
     pgSurface_Unprep(self);
 
     final = surf_subtype_new(Py_TYPE(self), newsurf, 1);
@@ -1680,7 +1680,7 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
     if (argobject) {
         if (pgSurface_Check(argobject)) {
             src = pgSurface_AsSurface(argobject);
-            newsurf = PG_ConvertSurface(surf, src->format);
+            newsurf = PG_ConvertSurface(surf, src);
         }
         else {
             /* will be updated later, initialize to make static analyzer happy
@@ -1834,7 +1834,7 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
     if (argobject) {
         if (pgSurface_Check(argobject)) {
             src = pgSurface_AsSurface(argobject);
-            newsurf = PG_ConvertSurface(surf, src->format);
+            newsurf = PG_ConvertSurface(surf, src);
         }
         else {
             /* will be updated later, initialize to make static analyzer happy
@@ -1951,7 +1951,7 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
                     SDL_SetPixelFormatPalette(format, palette);
                 }
             }
-            newsurf = PG_ConvertSurface(surf, format);
+            newsurf = SDL_ConvertSurface(surf, format, 0);
             SDL_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_NONE);
             SDL_FreeFormat(format);
             SDL_FreePalette(palette);
@@ -3753,7 +3753,7 @@ surf_premul_alpha(pgSurfaceObject *self, PyObject *_null)
 
     pgSurface_Prep(self);
     // Make a copy of the surface first
-    newsurf = PG_ConvertSurface(surf, surf->format);
+    newsurf = PG_ConvertSurface(surf, surf);
 
     if ((surf->w > 0 && surf->h > 0)) {
         // If the surface has no pixels we don't need to premul


### PR DESCRIPTION
- A few abstractions were improved. `PG_ConvertSurface` now takes a surface as its second argument so it can copy the palette from it, to compat for the SDL2 path already doing it because there palette was part of the format. `PG_GetSurfacePalette` now creates a palette when the surface is indexed, SDL2 did it implicitly.
-  Added compat code for `PG_BlitSurface` because SDL3 doesn't modify dstrect anymore.