### PR TITLE
Add weak reference support to Texture

### DIFF
--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -556,6 +556,7 @@ struct pgTextureObject {
     pgRendererObject *renderer;
     int width;
     int height;
+    PyObject *weakreflist;
 };
 
 typedef struct {

--- a/src_c/render.c
+++ b/src_c/render.c
@@ -682,6 +682,7 @@ texture_from_surface(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_XINCREF(new_texture->renderer);
     new_texture->width = surf->w;
     new_texture->height = surf->h;
+    new_texture->weakreflist = NULL;
     return (PyObject *)new_texture;
 }
 
@@ -1169,6 +1170,9 @@ texture_dealloc(pgTextureObject *self, PyObject *_null)
     if (self->texture) {
         SDL_DestroyTexture(self->texture);
     }
+    if (self->weakreflist) {
+        PyObject_ClearWeakRefs((PyObject *)self);
+    }
     Py_TYPE(self)->tp_free(self);
 }
 
@@ -1289,6 +1293,7 @@ static PyTypeObject pgTexture_Type = {
     .tp_basicsize = sizeof(pgTextureObject),
     .tp_dealloc = (destructor)texture_dealloc,
     .tp_doc = DOC_SDL2_VIDEO_TEXTURE,
+    .tp_weaklistoffset = offsetof(pgTextureObject, weakreflist),
     .tp_methods = texture_methods,
     .tp_init = (initproc)texture_init,
     .tp_new = PyType_GenericNew,

--- a/test/render_test.py
+++ b/test/render_test.py
@@ -1,4 +1,6 @@
+import gc
 import unittest
+import weakref
 
 import pygame
 import pygame._render as _render
@@ -464,6 +466,13 @@ class TextureTest(unittest.TestCase):
         result = self.renderer.to_surface()
         for x in range(64, 82):
             self.assertEqual(pygame.Color(80, 120, 160, 255), result.get_at((x, 50)))
+
+    def test_garbage_collection(self):
+        reference = weakref.ref(self.texture)
+        self.assertTrue(reference() is self.texture)
+        del self.texture
+        gc.collect()
+        self.assertIsNone(reference())
 
     def test_update(self):
         surface = pygame.Surface((100, 100))


### PR DESCRIPTION
Per #3585, pygame-ce is kind of inconsistent in that some of its types support weak references, while others do not. As weak references have value in some cases such as asset caching, I believe it is worthwhile to support them.

This PR aims to bring `_render.Texture` to parity with `Surface` with regard to this feature.