### PR TITLE
Add weak reference support to freetype.Font

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -632,6 +632,7 @@ PyTypeObject pgFont_Type = {
     .tp_repr = (reprfunc)_ftfont_repr,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     .tp_doc = DOC_FREETYPE_FONT,
+    .tp_weaklistoffset = offsetof(pgFontObject, weakreflist),
     .tp_methods = _ftfont_methods,
     .tp_getset = _ftfont_getsets,
     .tp_init = (initproc)_ftfont_init,
@@ -674,6 +675,7 @@ _ftfont_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
         obj->bgcolor[2] = 0;
         obj->bgcolor[3] = 0;
         obj->init_generation = current_freetype_generation;
+        obj->weakreflist = NULL;
     }
     return (PyObject *)obj;
 }
@@ -689,6 +691,9 @@ _ftfont_dealloc(pgFontObject *self)
     _PGFT_Quit(self->freetype);
 
     Py_XDECREF(self->path);
+    if (self->weakreflist) {
+        PyObject_ClearWeakRefs((PyObject *)self);
+    }
     ((PyObject *)self)->ob_type->tp_free((PyObject *)self);
 }
 

--- a/src_c/freetype.h
+++ b/src_c/freetype.h
@@ -103,6 +103,7 @@ typedef struct {
     struct freetypeinstance_ *freetype; /* Personal reference */
     struct fontinternals_ *_internals;
     unsigned int init_generation;
+    PyObject *weakreflist;
 } pgFontObject;
 
 #define pgFont_IS_ALIVE(o) (((pgFontObject *)(o))->_internals != 0)

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1605,6 +1605,13 @@ class FreeTypeFontTest(unittest.TestCase):
         for i in range(n):
             self.assertIsNone(refs[i](), "ref %d not collected" % i)
 
+        font2 = ft.Font(self._fixed_path)
+        ref = weakref.ref(font2)
+        del font2
+        for i in range(2):
+            gc.collect()
+        self.assertIsNone(ref(), "ref not collected")
+
         try:
             from sys import getrefcount
         except ImportError:


### PR DESCRIPTION
Following the template of #3590, adding weak reference support to freetype.Font.

This aims to bring freetype.Font to parity with pygame.Font with respect to weak references.