### PR TITLE
Pin astroid version below 4.0.0 to fix docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ requires = [
   "ninja<=1.12.1",
   "cython<=3.1.2",
   "sphinx<=8.2.3",
+  "astroid<4.0.0",
   "sphinx-autoapi<=3.6.0",
   "pyproject-metadata!=0.9.1",
 ]


### PR DESCRIPTION
Docs currently broken due to astroid 4.0.0 installed by sphinx. Pinning below that to fix the docs generation for now