### PR TITLE
Fix premul alpha tutorial link

### DIFF
--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -1003,7 +1003,7 @@ class Surface:
         another surface with alpha - assuming both surfaces contain pre-multiplied
         alpha colors.
 
-        There is a `tutorial on premultiplied alpha blending here. <tutorials/en/premultiplied-alpha>`_
+        There is a `tutorial on premultiplied alpha blending here. <../tutorials/en/premultiplied-alpha.html>`_
 
         .. versionadded:: 2.1.4
         """


### PR DESCRIPTION
I noticed this on the deployed site, when I went to click on the link.