### PR TITLE
Fix typo in mixer docs

### DIFF
--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -354,7 +354,7 @@ The following file formats are supported
    a new buffer interface (The object is checked for a buffer interface first.)
 
    The Sound object represents actual sound sample data. Methods that change
-   the state of the Sound object will the all instances of the Sound playback.
+   the state of the Sound object will impact all instances of the Sound playback.
    A Sound object also exports a new buffer interface.
 
    The Sound can be loaded from an ``OGG`` audio file or from an uncompressed


### PR DESCRIPTION
Makes no sense before.

Closes #3180 

If you're curious, I actually did verify this is true with stop() and set_volume(), btw.

```py
import pygame

pygame.init()

s = pygame.mixer.Sound("xm_test/surfonasinewave.xm")

print("start 1")
s.play()

pygame.time.wait(1500)

print("start 2")
s.play()

pygame.time.wait(7000)

#print("STOP")
#s.stop()

print("QUIET")
s.set_volume(0.3)

while True:
    pygame.time.wait(1)
```