### PR TITLE
Fix Rect contains error message

### DIFF
--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -138,6 +138,7 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
 #define RectExport_getsize pg_rect_getsize
 #define RectExport_setsize pg_rect_setsize
 #define RectImport_primitiveType int
+#define RectImport_PrimitiveTypeName "int"
 #define RectImport_RectCheck pgRect_Check
 #define RectImport_OtherRectCheck pgFRect_Check
 #define RectImport_OtherRectCheckExact pgFRect_CheckExact
@@ -257,6 +258,7 @@ four_floats_from_obj(PyObject *obj, float *val1, float *val2, float *val3,
 #define RectExport_getsize pg_frect_getsize
 #define RectExport_setsize pg_frect_setsize
 #define RectImport_primitiveType float
+#define RectImport_PrimitiveTypeName "float"
 #define RectImport_RectCheck pgFRect_Check
 #define RectImport_OtherRectCheck pgRect_Check
 #define RectImport_OtherRectCheckExact pgRect_CheckExact

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -324,13 +324,16 @@
 #error RectImport_OtherRectCheck needs to be defined
 #endif
 #ifndef RectImport_RectCheckExact
-#error RectImport_RectCheckExact needs to be Defined
+#error RectImport_RectCheckExact needs to be defined
 #endif
 #ifndef RectImport_OtherRectCheckExact
 #error RectImport_OtherRectCheckExact needs to be Defined
 #endif
 #ifndef RectImport_primitiveType
 #error RectImport_primitiveType needs to be defined
+#endif
+#ifndef RectImport_PrimitiveTypeName
+#error RectImport_PrimitiveTypeName needs to be defined
 #endif
 #ifndef RectImport_innerRectStruct
 #error RectImport_innerRectStruct needs to be defined
@@ -2010,7 +2013,8 @@ RectExport_containsSeq(RectObject *self, PyObject *arg)
     if (ret < 0) {
         PyErr_SetString(PyExc_TypeError, "'in <" ObjectName
                                          ">' requires rect style object"
-                                         " or int as left operand");
+                                         " or " RectImport_PrimitiveTypeName
+                                         " as left operand");
     }
     return ret;
 }
@@ -3027,6 +3031,7 @@ RectExport_iterator(RectObject *self)
 #undef RectImport_PythonNumberAsPrimitiveType
 #undef RectImport_PrimitiveTypeAsPythonNumber
 #undef RectImport_primitiveType
+#undef RectImport_PrimitiveTypeName
 #undef RectImport_RectCheck
 #undef RectImport_OtherRectCheck
 #undef RectImport_RectCheckExact

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -808,6 +808,7 @@ class RectTypeTest(unittest.TestCase):
         self.assertTrue(2 in Rect(0, 0, 1, 2), "r does not contain 2")
         self.assertFalse(3 in Rect(0, 0, 1, 2), "r contains 3")
 
+        self.assertRaises(TypeError, lambda: 1.0 in Rect(0, 0, 1, 2))
         self.assertRaises(TypeError, lambda: "string" in Rect(0, 0, 1, 2))
         self.assertRaises(TypeError, lambda: 4 + 3j in Rect(0, 0, 1, 2))
 
@@ -3104,6 +3105,7 @@ class FRectTypeTest(RectTypeTest):
         # self.assertTrue(2 in FRect(0, 0, 1, 2), "r does not contain 2")
         # self.assertFalse(3 in FRect(0, 0, 1, 2), "r contains 3")
 
+        self.assertRaises(TypeError, lambda: 1 in FRect(0, 0, 1, 2))
         self.assertRaises(TypeError, lambda: "string" in FRect(0, 0, 1, 2))
         self.assertRaises(TypeError, lambda: 4 + 3j in FRect(0, 0, 1, 2))
 


### PR DESCRIPTION
Fixes #3533 

This error shouldn't exist at all imo, but for backwards compatibility lets keep it for now. And the error should at least be accurate, so this commit fixes that. Put an idea to change it in the pygame-ce 3 ideas discussion: https://github.com/pygame-community/pygame-ce/issues/2760#issuecomment-3477499295

Previously it would say "int" even on FRects, where it meant float.

I also added explicit tests for the "mixed number type" type error behavior.

IDK if this counts as a bugfix, or if it's more like docs.