### PR TITLE
docs: `math.Vector2|3` zero vector normalisation raises ValueError

### DIFF
--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -281,7 +281,7 @@ Conversion can be combined with swizzling or slicing to create a new order
       | :sg:`normalize() -> Vector2`
 
       Returns a new vector that has ``length`` equal to ``1`` and the same
-      direction as self.  If the vector is the zero vector (i.e. has length
+      direction as self. If the vector is the zero vector (i.e. has length
       ``0`` thus no direction) a ``ValueError`` is raised.
 
       .. ## Vector2.normalize ##
@@ -292,7 +292,7 @@ Conversion can be combined with swizzling or slicing to create a new order
       | :sg:`normalize_ip() -> None`
 
       Normalizes the vector so that it has ``length`` equal to ``1``.
-      The direction of the vector is not changed.  If the vector is the zero
+      The direction of the vector is not changed. If the vector is the zero
       vector (i.e. has length ``0`` thus no direction) a ``ValueError`` is
       raised.
 


### PR DESCRIPTION
This PR documents that `ValueError` is raised when attempting to normalize a zero vector with `Vector2|3.normalize()`, `Vector2|3.normalize_ip()`.

Wording is copied from existing text for `Vector2|3.scale_to_length()`.

