### PR TITLE
Add more system info

### DIFF
--- a/buildconfig/stubs/pygame/system.pyi
+++ b/buildconfig/stubs/pygame/system.pyi
@@ -86,6 +86,25 @@ def get_total_ram() -> int:
     .. versionadded:: 2.3.1
     """
 
+def get_platform() -> str:
+    """Get the name of the running system platform.
+
+    Returns a string with the name of the running system platform.
+
+    Examples of supported platforms include:
+    ``Windows``, ``Linux``, ``Mac OS X``, ``iOS``, ``Android``.
+
+    .. note::
+        If the correct platform name is not available,
+        returns a string beginning with the text "Unknown".
+
+    .. note::
+        The ``platform`` library has similar functionality for this use case,
+        but has more detailed platform information.
+
+    .. versionadded:: 2.5.7
+    """
+
 def get_pref_path(org: str, app: str) -> str:
     """Get a writeable folder for your app.
 

--- a/src_c/doc/system_doc.h
+++ b/src_c/doc/system_doc.h
@@ -3,6 +3,7 @@
 #define DOC_SYSTEM_GETCPUCORES "get_cpu_cores() -> int\nGet the number of CPU cores available in the system."
 #define DOC_SYSTEM_GETCPUINSTRUCTIONSETS "get_cpu_instruction_sets() -> _InstructionSets\nGet the information of CPU instruction sets."
 #define DOC_SYSTEM_GETTOTALRAM "get_total_ram() -> int\nGet the amount of RAM configured in the system."
+#define DOC_SYSTEM_GETPLATFORM "get_platform() -> str\nGet the name of the running system platform."
 #define DOC_SYSTEM_GETPREFPATH "get_pref_path(org, app) -> str\nGet a writeable folder for your app."
 #define DOC_SYSTEM_GETPREFLOCALES "get_pref_locales() -> list[_Locale]\nGet preferred locales set on the system."
 #define DOC_SYSTEM_GETPOWERSTATE "get_power_state() -> PowerState | None\nGet the current power supply state."

--- a/src_c/system.c
+++ b/src_c/system.c
@@ -70,6 +70,12 @@ pg_system_get_total_ram(PyObject *self, PyObject *_null)
 }
 
 static PyObject *
+pg_system_get_platform(PyObject *self, PyObject *_null)
+{
+    return PyUnicode_FromString(SDL_GetPlatform());
+}
+
+static PyObject *
 pg_system_get_pref_path(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     char *org, *project;
@@ -264,6 +270,8 @@ static PyMethodDef _system_methods[] = {
      METH_NOARGS, DOC_SYSTEM_GETCPUINSTRUCTIONSETS},
     {"get_total_ram", pg_system_get_total_ram, METH_NOARGS,
      DOC_SYSTEM_GETTOTALRAM},
+    {"get_platform", pg_system_get_platform, METH_NOARGS,
+     DOC_SYSTEM_GETPLATFORM},
     {"get_pref_path", (PyCFunction)pg_system_get_pref_path,
      METH_VARARGS | METH_KEYWORDS, DOC_SYSTEM_GETPREFPATH},
     {"get_pref_locales", pg_system_get_pref_locales, METH_NOARGS,

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -22,6 +22,11 @@ class SystemModuleTest(unittest.TestCase):
 
         self.assertIsInstance(ram, int)
 
+    def test_get_platform(self):
+        platform = pygame.system.get_platform()
+
+        self.assertIsInstance(platform, str)
+
     def test_get_pref_path(self):
         get_pref_path = pygame.system.get_pref_path
 


### PR DESCRIPTION
This PR adds **get_cpu_cores** and **get_platform** functions to the system module, providing basic system information to reduce the need for external libraries.