### PR TITLE
Turn off SDL3 signal handlers

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -217,6 +217,15 @@ pg_init(PyObject *self, PyObject *_null)
         /* IMPPREFIX "_sdl2.controller", Is this required? Comment for now*/
         NULL};
 
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    // In SDL3, specify that signal handlers should not be enabled.
+    // By default, unlike SDL2, these signal handlers convert into QUIT
+    // events. However, if QUIT events / events aren't being handled,
+    // this leaves people unable to quit their script. Plus it's different
+    // than SDL2 behavior.
+    SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
+#endif
+
     /*nice to initialize timer, so startup time will reflec pg_init() time*/
 #if defined(WITH_THREAD) && !defined(MS_WIN32) && defined(SDL_INIT_EVENTTHREAD)
     pg_sdl_was_init = PG_InitSubSystem(SDL_INIT_EVENTTHREAD | PG_INIT_TIMER |


### PR DESCRIPTION
So that CTRL-C KeyboardExits behave the same way as SDL2, instead of being converted into QUIT events.

I spent a while trying to debug this behavior when working on the SDL3 audio system. I thought I had messed up something in implementation on our end, and then I boiled it down to a C reproducer, and then slouken told me it's intended behavior (https://github.com/libsdl-org/SDL/issues/14614)

```py
import pygame

# pygame setup
pygame.init()
clock = pygame.time.Clock()
running = True

while running:
    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            print("RECEIVED QUIT EVENT OMG")
            running = False

    clock.tick(60)

pygame.quit()
```

SDL2
```
pygame-ce 2.5.6 (SDL 2.32.10, Python 3.11.9)
Traceback (most recent call last):
  File "C:\Users\charl\Desktop\pygame-ce-stuff\pygame_files\test_ctrl_c.py", line 14, in <module>
    clock.tick(60)
KeyboardInterrupt
```

SDL3 before this PR or with `SDL_NO_SIGNAL_HANDLERS=0` in env
```
pygame-ce 2.5.7.dev1 (SDL 3.2.22, Python 3.11.9)
RECEIVED QUIT EVENT OMG
```

SDL3 after this PR or with `SDL_NO_SIGNAL_HANDLERS=1` in env
```
pygame-ce 2.5.7.dev1 (SDL 3.2.22, Python 3.11.9)
Traceback (most recent call last):
  File "C:\Users\charl\Desktop\pygame-ce-stuff\pygame_files\test_ctrl_c.py", line 14, in <module>
    clock.tick(60)
KeyboardInterrupt
```