### PR TITLE
Move SDL hint so it always triggers on import

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -217,15 +217,6 @@ pg_init(PyObject *self, PyObject *_null)
         /* IMPPREFIX "_sdl2.controller", Is this required? Comment for now*/
         NULL};
 
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-    // In SDL3, specify that signal handlers should not be enabled.
-    // By default, unlike SDL2, these signal handlers convert into QUIT
-    // events. However, if QUIT events / events aren't being handled,
-    // this leaves people unable to quit their script. Plus it's different
-    // than SDL2 behavior.
-    SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
-#endif
-
     /*nice to initialize timer, so startup time will reflec pg_init() time*/
 #if defined(WITH_THREAD) && !defined(MS_WIN32) && defined(SDL_INIT_EVENTTHREAD)
     pg_sdl_was_init = PG_InitSubSystem(SDL_INIT_EVENTTHREAD | PG_INIT_TIMER |
@@ -2129,6 +2120,15 @@ MODINIT_DEFINE(base)
                                          NULL};
 
     PyObject *module, *apiobj;
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    // In SDL3, specify that signal handlers should not be enabled.
+    // By default, unlike SDL2, these signal handlers convert into QUIT
+    // events. However, if QUIT events / events aren't being handled,
+    // this leaves people unable to quit their script. Plus it's different
+    // than SDL2 behavior.
+    SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
+#endif
 
     /* import need modules. Do this first so if there is an error
         the module is not loaded.


### PR DESCRIPTION
Rather than relying on pygame.init() being called, since not all workflows would do that.

This just moves where the code added in https://github.com/pygame-community/pygame-ce/pull/3654 triggers. Thanks to reviewers on that for reviewing it so quickly, I'm sort of embarrassed to already want to change it.

But I was thinking about what Ankith said in his review, that we wouldn't want SDL to ever override signal handlers from Python. And my previous PR didn't do that. It just turned it off if one happened to call pygame.init(). Like in my audio example script in my other recent PR I don't call pygame.init(), I just call audio.init().

