### PR TITLE
Use TemporaryDirectory in unit tests for temp dirs

### DIFF
--- a/test/font_test.py
+++ b/test/font_test.py
@@ -5,6 +5,7 @@ import pathlib
 import platform
 import sys
 import unittest
+from tempfile import TemporaryDirectory
 
 import pygame
 from pygame import font as pygame_font  # So font can be replaced with ftfont
@@ -815,19 +816,12 @@ class FontTypeTest(unittest.TestCase):
     def _load_unicode(self, path):
         import shutil
 
-        fdir = str(FONTDIR)
-        temp = os.path.join(fdir, path)
-        pgfont = os.path.join(fdir, "test_sans.ttf")
-        shutil.copy(pgfont, temp)
-        try:
-            with open(temp, "rb") as f:
-                pass
-        except FileNotFoundError:
-            raise unittest.SkipTest("the path cannot be opened")
-        try:
+        with TemporaryDirectory() as tmpdir:
+            fdir = str(FONTDIR)
+            temp = os.path.join(tmpdir, path)
+            pgfont = os.path.join(fdir, "test_sans.ttf")
+            shutil.copy(pgfont, temp)
             pygame_font.Font(temp, 20)
-        finally:
-            os.remove(temp)
 
     def test_load_from_file_unicode_0(self):
         """ASCII string as a unicode object"""

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -539,38 +539,22 @@ class ImageModuleTest(unittest.TestCase):
     def test_load_unicode_path(self):
         import shutil
 
-        orig = example_path("data/asprite.bmp")
-        temp = os.path.join(example_path("data"), "你好.bmp")
-        shutil.copy(orig, temp)
-        try:
-            im = pygame.image.load(temp)
-        finally:
-            os.remove(temp)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            orig = example_path("data/asprite.bmp")
+            temp = os.path.join(tmpdir, "你好.bmp")
+            shutil.copy(orig, temp)
+            pygame.image.load(temp)
 
     def _unicode_save(self, temp_file):
         im = pygame.Surface((10, 10), 0, 32)
-        try:
-            with open(temp_file, "w") as f:
-                pass
-            os.remove(temp_file)
-        except OSError:
-            raise unittest.SkipTest("the path cannot be opened")
-
         self.assertFalse(os.path.exists(temp_file))
-
-        try:
-            pygame.image.save(im, temp_file)
-
-            self.assertGreater(os.path.getsize(temp_file), 10)
-        finally:
-            try:
-                os.remove(temp_file)
-            except OSError:
-                pass
+        pygame.image.save(im, temp_file)
+        self.assertGreater(os.path.getsize(temp_file), 10)
 
     def test_save_unicode_path(self):
         """save unicode object with non-ASCII chars"""
-        self._unicode_save("你好.bmp")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._unicode_save(os.path.join(tmpdir, "你好.bmp"))
 
     def assertPremultipliedAreEqual(self, string1, string2, source_string):
         self.assertEqual(len(string1), len(string2))

--- a/test/imageext_test.py
+++ b/test/imageext_test.py
@@ -2,6 +2,7 @@ import os
 import os.path
 import sys
 import unittest
+from tempfile import TemporaryDirectory
 
 import pygame
 import pygame.image
@@ -53,41 +54,26 @@ class ImageextModuleTest(unittest.TestCase):
         """non-ASCII unicode"""
         import shutil
 
-        orig = example_path("data/alien1.png")
-        temp = os.path.join(example_path("data"), "你好.png")
-        shutil.copy(orig, temp)
-        try:
-            im = imageext.load_extended(temp)
-        finally:
-            os.remove(temp)
+        with TemporaryDirectory() as tmpdir:
+            orig = example_path("data/alien1.png")
+            temp = os.path.join(tmpdir, "你好.png")
+            shutil.copy(orig, temp)
+            imageext.load_extended(temp)
 
     def _unicode_save(self, temp_file):
         im = pygame.Surface((10, 10), 0, 32)
-        try:
-            with open(temp_file, "w") as f:
-                pass
-            os.remove(temp_file)
-        except OSError:
-            raise unittest.SkipTest("the path cannot be opened")
-
         self.assertFalse(os.path.exists(temp_file))
-
-        try:
-            imageext.save_extended(im, temp_file)
-
-            self.assertGreater(os.path.getsize(temp_file), 10)
-        finally:
-            try:
-                os.remove(temp_file)
-            except OSError:
-                pass
+        imageext.save_extended(im, temp_file)
+        self.assertGreater(os.path.getsize(temp_file), 10)
 
     def test_save_unicode_path_0(self):
         """unicode object with ASCII chars"""
-        self._unicode_save("temp_file.png")
+        with TemporaryDirectory() as tmpdir:
+            self._unicode_save(os.path.join(tmpdir, "temp_file.png"))
 
     def test_save_unicode_path_1(self):
-        self._unicode_save("你好.png")
+        with TemporaryDirectory() as tmpdir:
+            self._unicode_save(os.path.join(tmpdir, "你好.png"))
 
 
 if __name__ == "__main__":

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -3,6 +3,7 @@ import platform
 import sys
 import time
 import unittest
+from tempfile import TemporaryDirectory
 
 import pygame
 from pygame.tests.test_utils import example_path
@@ -154,20 +155,13 @@ class MixerMusicModuleTest(unittest.TestCase):
         import shutil
 
         ep = example_path("data")
-        temp_file = os.path.join(ep, "你好.wav")
-        org_file = os.path.join(ep, "house_lo.wav")
-        try:
-            with open(temp_file, "w") as f:
-                pass
-            os.remove(temp_file)
-        except OSError:
-            raise unittest.SkipTest("the path cannot be opened")
-        shutil.copy(org_file, temp_file)
-        try:
+
+        with TemporaryDirectory() as tmpdir:
+            temp_file = os.path.join(tmpdir, "你好.wav")
+            org_file = os.path.join(ep, "house_lo.wav")
+            shutil.copy(org_file, temp_file)
             pygame.mixer.music.load(temp_file)
             pygame.mixer.music.load(org_file)  # unload
-        finally:
-            os.remove(temp_file)
 
     def test_unload(self):
         import shutil

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -5,6 +5,7 @@ import platform
 import sys
 import time
 import unittest
+from tempfile import TemporaryDirectory
 
 import pygame
 from pygame import mixer
@@ -278,20 +279,12 @@ class MixerModuleTest(unittest.TestCase):
         import shutil
 
         ep = example_path("data")
-        temp_file = os.path.join(ep, "你好.wav")
-        org_file = os.path.join(ep, "house_lo.wav")
-        shutil.copy(org_file, temp_file)
-        try:
-            with open(temp_file, "rb") as f:
-                pass
-        except OSError:
-            raise unittest.SkipTest("the path cannot be opened")
-
-        try:
+        with TemporaryDirectory() as tmpdir:
+            temp_file = os.path.join(tmpdir, "你好.wav")
+            org_file = os.path.join(ep, "house_lo.wav")
+            shutil.copy(org_file, temp_file)
             sound = mixer.Sound(temp_file)
             del sound
-        finally:
-            os.remove(temp_file)
 
     @unittest.skipIf(
         os.environ.get("SDL_AUDIODRIVER") == "disk",


### PR DESCRIPTION
When I was testing out the [pygame-ce AUR package](https://aur.archlinux.org/packages/python-pygame-ce) I found out that some test fails arise because our test code assumes directories like `examples/data` and `tests/fixtures/fonts` are writeable. In a package manager managed install we cannot assume this, and in general writing to our install location is a bad idea.

I replaced all instances where we were using these directories with `tempfile.TemporaryDirectory` API.

As a nice bonus, the context manager API of `TemporaryDirectory` ensures the directory is cleaned up at exit so we need not do it explicitly