### PR TITLE
Update meson, cython, fix meson warning

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,15 +24,15 @@ option('midi', type: 'feature', value: 'enabled')
 # Controls whether to make a "stripped" pygame install. Enabling this disables
 # the bundling of docs/examples/tests/stubs in the wheels.
 # The default behaviour is to bundle all of these.
-option('stripped', type: 'boolean', value: 'false')
+option('stripped', type: 'boolean', value: false)
 
 # Controls whether to compile with -Werror (or its msvc equivalent). The default
 # behaviour is to not do this by default
-option('error_on_warns', type: 'boolean', value: 'false')
+option('error_on_warns', type: 'boolean', value: false)
 
 # Controls whether to error on build if generated docs are missing. Defaults to
 # false.
-option('error_docs_missing', type: 'boolean', value: 'false')
+option('error_docs_missing', type: 'boolean', value: false)
 
 # Controls whether to do a coverage build.
 # This argument must be used together with the editable install.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ pygame_ce = 'pygame.__briefcase.pygame_ce:PygameCEGuiBootstrap'
 [build-system]
 requires = [
   "meson-python<=0.18.0",
-  "meson<=1.9.1",
+  "meson<=1.10.0",
   "ninja<=1.13.0",
-  "cython<=3.1.4",
+  "cython<=3.2.4",
   "sphinx<=8.2.3",
   "astroid<4.0.0",
   "sphinx-autoapi<=3.6.0",


### PR DESCRIPTION
I ran the test suite locally and everything checked out.

The warning:
```
  ..\meson_options.txt:27: WARNING: Project does not target a minimum version but uses feature deprecated since '1.1.0': "boolean option" keyword argument "value" of type str. use a boolean, not a string
  ..\meson_options.txt:31: WARNING: Project does not target a minimum version but uses feature deprecated since '1.1.0': "boolean option" keyword argument "value" of type str. use a boolean, not a string
  ..\meson_options.txt:35: WARNING: Project does not target a minimum version but uses feature deprecated since '1.1.0': "boolean option" keyword argument "value" of type str. use a boolean, not a string
```

There are also 2 other mesons warnings, one about using fs.relative_to (a relatively recent feature) without declaring a minimum version, and the other about using the built in warning compilation options, but I have not touched those in this PR.