### PR TITLE
Small simplification of type initializations

### DIFF
--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -1979,24 +1979,13 @@ MODINIT_DEFINE(_camera)
         return NULL;
     }
 
-    /* type preparation */
-    pgCamera_Type.tp_new = PyType_GenericNew;
-    if (PyType_Ready(&pgCamera_Type) < 0) {
-        return NULL;
-    }
-
     /* create the module */
     module = PyModule_Create(&_module);
     if (!module) {
         return NULL;
     }
 
-    if (PyModule_AddObjectRef(module, "CameraType",
-                              (PyObject *)&pgCamera_Type)) {
-        Py_DECREF(module);
-        return NULL;
-    }
-    if (PyModule_AddObjectRef(module, "Camera", (PyObject *)&pgCamera_Type)) {
+    if (PyModule_AddType(module, &pgCamera_Type)) {
         Py_DECREF(module);
         return NULL;
     }

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -1393,6 +1393,7 @@ static PyTypeObject PyFont_Type = {
     .tp_methods = font_methods,
     .tp_getset = font_getsets,
     .tp_init = (initproc)font_init,
+    .tp_new = PyType_GenericNew,
 };
 
 /*font module methods*/
@@ -1499,7 +1500,6 @@ MODINIT_DEFINE(font)
     if (PyType_Ready(&PyFont_Type) < 0) {
         return NULL;
     }
-    PyFont_Type.tp_new = PyType_GenericNew;
 
     module = PyModule_Create(&_module);
     if (module == NULL) {

--- a/src_c/key.c
+++ b/src_c/key.c
@@ -68,9 +68,7 @@ key_get_repeat(PyObject *self, PyObject *_null)
  *     https://github.com/pygame-community/pygame-ce/issues/519
  * so that they work with SDL_GetKeyboardState().
  */
-#define _PG_SCANCODEWRAPPER_TYPE_NAME "ScancodeWrapper"
-#define _PG_SCANCODEWRAPPER_TYPE_FULLNAME \
-    "pygame.key." _PG_SCANCODEWRAPPER_TYPE_NAME
+#define _PG_SCANCODEWRAPPER_TYPE_FULLNAME "pygame.key.ScancodeWrapper"
 
 typedef struct {
     PyTupleObject tuple;
@@ -155,7 +153,7 @@ pg_scancodewrapper_repr(pgScancodeWrapper *self)
 }
 
 static PyTypeObject pgScancodeWrapper_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "pygame.key.ScancodeWrapper",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = _PG_SCANCODEWRAPPER_TYPE_FULLNAME,
     .tp_repr = (reprfunc)pg_scancodewrapper_repr,
     .tp_as_mapping = &pg_scancodewrapper_mapping,
     .tp_iter = (getiterfunc)pg_iter_raise,
@@ -655,11 +653,6 @@ MODINIT_DEFINE(key)
     if (PyErr_Occurred()) {
         return NULL;
     }
-    /* type preparation */
-    pgScancodeWrapper_Type.tp_base = &PyTuple_Type;
-    if (PyType_Ready(&pgScancodeWrapper_Type) < 0) {
-        return NULL;
-    }
 
     /* create the module */
     module = PyModule_Create(&_module);
@@ -667,8 +660,11 @@ MODINIT_DEFINE(key)
         return NULL;
     }
 
-    if (PyModule_AddObjectRef(module, _PG_SCANCODEWRAPPER_TYPE_NAME,
-                              (PyObject *)&pgScancodeWrapper_Type)) {
+    // has to be set in init function rather than statically per note on
+    // https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_base
+    pgScancodeWrapper_Type.tp_base = &PyTuple_Type;
+
+    if (PyModule_AddType(module, &pgScancodeWrapper_Type)) {
         Py_DECREF(module);
         return NULL;
     }


### PR DESCRIPTION
Camera: _camera is an internal module, CameraType is not exposed in a public module. So we can remove CameraType and switch to Pymodule_AddType.*
Font: tp_new should be on the type, not added after.
Key: Use PyModule_AddType, add comment on why tp_base needs to be in init function unlike everything else.

*You can technically get to it with pygame.camera._camera.CameraType, but I don't see that as something that we need to be worried about.