### PR TITLE
Disable mouse rect test on null backend

### DIFF
--- a/test/window_test.py
+++ b/test/window_test.py
@@ -114,8 +114,9 @@ class WindowTypeTest(unittest.TestCase):
         self.assertFalse(self.win.always_on_top)
 
     @unittest.skipIf(
-        SDL < (2, 0, 18),
-        "requires SDL 2.0.18+",
+        SDL < (2, 0, 18)
+        or os.environ.get("SDL_VIDEODRIVER") == pygame.NULL_VIDEODRIVER,
+        "requires SDL 2.0.18+ and SDL_VIDEODRIVER to be a non-null value",
     )
     def test_mouse_rect(self):
         self.win.mouse_rect = None


### PR DESCRIPTION
The SDL_SetWindowMouseRect function returns false on unsupported backends since <https://github.com/libsdl-org/SDL/commit/2a873be9cdb35972dc8bacd12653aafc02e835de>.