### PR TITLE
Fixed an error in `test/display_test.py`

### DIFF
--- a/test/display_test.py
+++ b/test/display_test.py
@@ -695,7 +695,7 @@ class DisplayModuleTest(unittest.TestCase):
             # if not original width/height should be preserved
             else:
                 self.assertEqual(
-                    (test_surf.get_width(), test_surf.get_height()), width_height
+                    (test_surf.width, test_surf.height), width_height
                 )
 
     @unittest.skipIf(is_wayland, "not supported on wayland")


### PR DESCRIPTION
Updated line 698 to use `test_surf.width` and `test_surf.height` instead of `test_surf.get_width()` and `test_surf.get_height()`, respectively.

When built, this works but the same file creates another error, ~300 lines later.

Fixes issue #3693