### PR TITLE
exposed the mouse button event "clicks" property

### DIFF
--- a/docs/reST/ref/event.rst
+++ b/docs/reST/ref/event.rst
@@ -72,8 +72,8 @@ specific attributes.
     KEYDOWN           key, mod, unicode, scancode
     KEYUP             key, mod, unicode, scancode
     MOUSEMOTION       pos, rel, buttons, touch
-    MOUSEBUTTONUP     pos, button, touch
-    MOUSEBUTTONDOWN   pos, button, touch
+    MOUSEBUTTONUP     pos, button, touch, clicks
+    MOUSEBUTTONDOWN   pos, button, touch, clicks
     JOYAXISMOTION     joy (deprecated), instance_id, axis, value
     JOYBALLMOTION     joy (deprecated), instance_id, ball, rel
     JOYHATMOTION      joy (deprecated), instance_id, hat, value
@@ -86,6 +86,12 @@ specific attributes.
 .. versionchangedold:: 2.0.0 The ``joy`` attribute was deprecated, ``instance_id`` was added.
 
 .. versionchangedold:: 2.0.1 The ``unicode`` attribute was added to ``KEYUP`` event.
+
+.. versionchangedold:: 2.5.7 The ``clicks`` attribute was added to ``MOUSEBUTTONDOWN`` and ``MOUSEBUTTONUP`` events.
+
+The ``clicks`` attribute of the ``MOUSEBUTTONDOWN`` and ``MOUSEBUTTONUP`` events indicate the number of clicks occurring
+in rapid succession, e.g. ``1`` for single-click, ``2`` for double-click, etc. Note that double, triple, or more clicks
+will still fire mouse events for each individual click, with a progressively increasing ``clicks`` attribute.
 
 Note that ``ACTIVEEVENT``, ``VIDEORESIZE`` and ``VIDEOEXPOSE`` are considered
 as "legacy" events, the use of pygame2 ``WINDOWEVENT`` API is recommended over

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1211,6 +1211,7 @@ dict_from_event(SDL_Event *event)
                                                   (int)event->button.y);
             _pg_insobj(dict, "pos", obj);
             _pg_insobj(dict, "button", PyLong_FromLong(event->button.button));
+            _pg_insobj(dict, "clicks", PyLong_FromLong(event->button.clicks));
             _pg_insobj(
                 dict, "touch",
                 PyBool_FromLong((event->button.which == SDL_TOUCH_MOUSEID)));


### PR DESCRIPTION
**Why?**
I am adding this because I wanted a simple mechanism to detect double-clicks inside my game. I found that the `SDL_MouseButtonEvent` actually has a property called `clicks` that counts the amount of rapid clicks in a row based on the system-defined double click timing. Pygame-CE just didn't expose this functionality. This PR amends this by simply exposing the `clicks` property of the SDL_MouseButtonEvent to the Pygame mouse button events. It is my belief that Pygame should expose this as it is an existing functionality of SDL that Pygame seems to have forgotten to implement, and it offers an easy solution to a commonly tackled problem of how to add double-click detection to Pygame (or any n-clicks detection for that matter).

**Test program**
Below is a simple test program that opens a window that can detect mouse clicks. It prints the button ID and the `clicks` property whenever a mouse button is clicked. Additionally pressing `q` exits the program.
```py
import pygame
pygame.init()

screen = pygame.display.set_mode((500, 500))

clock = pygame.time.Clock()
running = True

while running:
    clock.tick(60)

    for event in pygame.event.get():
        if event.type == pygame.MOUSEBUTTONDOWN:
            print(event.button, event.clicks)
        if event.type == pygame.KEYDOWN and event.key == pygame.K_q:
            running = False
```
As can be seen when running the program, if you rapidly click on the window then the `clicks` value (the second number) increases, showing the number of rapid, consecutive clicks. Pausing for a short second and then clicking shows that the `clicks` value has gone back to `1`, meaning the pause was enough for the clicks to no longer be considered rapid and consecutive.

**Tests**
No test has been added, as Pygame-CE's tests don't seem to cover testing the individual properties of events. If it should be put in a test, let me know and I'll get on it.

**Documentation**
The `clicks` property has been added to the list of properties for both the MOUSEBUTTONUP and MOUSEBUTTONDOWN events. No additional documentation has been added as no individual properties are discussed in depth elsewhere either.