### PR TITLE
Remove legacy credits from the Italian README

### DIFF
--- a/docs/readmes/README.it.rst
+++ b/docs/readmes/README.it.rst
@@ -69,62 +69,6 @@ configurare automaticamente, compilare e installare pygame-ce.
 Più informazioni riguardo all'installazione e alla compilazione sono
 disponibili sulla `Compilation wiki page`_.
 
-Crediti
--------
-
-Grazie a tutti coloro che hanno aiutato a contribuire per questa libraria.
-In ordine sono riportati i ringraziamenti speciali.
-
-* Marcus Von Appen: many changes, and fixes, 1.7.1+ freebsd maintainer
-* Lenard Lindstrom: the 1.8+ windows maintainer, many changes, and fixes
-* Brian Fisher for svn auto builder, bug tracker and many contributions
-* Rene Dudfield: many changes, and fixes, 1.7+ release manager/maintainer
-* Phil Hassey for his work on the pygame.org website
-* DR0ID for his work on the sprite module
-* Richard Goedeken for his smoothscale function
-* Ulf Ekström for his pixel perfect collision detection code
-* Pete Shinners: original author
-* David Clark for filling the right-hand-man position
-* Ed Boraas and Francis Irving: Debian packages
-* Maxim Sobolev: FreeBSD packaging
-* Bob Ippolito: macOS and OS X porting (much work!)
-* Jan Ekhol, Ray Kelm, and Peter Nicolai: putting up with early design ideas
-* Nat Pryce for starting our unit tests
-* Dan Richter for documentation work
-* TheCorruptor for his incredible logos and graphics
-* Nicholas Dudfield: many test improvements
-* Alex Folkner for pygame-ctypes
-
-Grazie a coloro che inviano patches e correzioni: Niki Spahiev, Gordon
-Tyler, Nathaniel Pryce, Dave Wallace, John Popplewell, Michael Urman,
-Andrew Straw, Michael Hudson, Ole Martin Bjoerndalen, Herve Cauwelier,
-James Mazer, Lalo Martins, Timothy Stranex, Chad Lester, Matthias
-Spiller, Bo Jangeborg, Dmitry Borisov, Campbell Barton, Diego Essaya,
-Eyal Lotem, Regis Desgroppes, Emmanuel Hainry, Randy Kaelber,
-Matthew L Daniel, Nirav Patel, Forrest Voight, Charlie Nolan,
-Frankie Robertson, John Krukoff, Lorenz Quack, Nick Irvine,
-Michael George, Saul Spatz, Thomas Ibbotson, Tom Rothamel, Evan Kroske,
-Cambell Barton.
-
-E ai nostri incredibili cacciatori di bug: Angus, Guillaume Proux, Frank
-Raiser, Austin Henry, Kaweh Kazemi, Arturo Aldama, Mike Mulcheck,
-Michael Benfield, David Lau.
-
-Ci sono molte altre persone là fuori che hanno condiviso utili idee, che
-hanno mantenuto il progetto in vita e che ci hanno essenzialmente reso la
-vita più facile. Grazie!
-
-Molte grazie alle persone che pubblicano commenti sulla documentazione e che
-contribuiscono alla `pygame documentation`_ e alla `pygame-ce documentation`_.
-
-Altrettanti ringraziamenti alle persone che creano giochi e che li pubblicano
-sul sito pygame.org per rendere possibile agli altri di imparare da essi e di divertirsi.
-
-Molte grazie a James Paige per aver ospitato il bugzilla di pygame.
-
-Un altro grande ringraziamento a Roger Dingledine e al team di SEUL.ORG
-per un hosting eccellente.
-
 Requisiti
 ---------
 
@@ -203,8 +147,6 @@ Controlla docs/licenses per le licenze dei requisiti.
     :target: https://github.com/psf/black
 
 .. _Pygame: https://pyga.me
-.. _pygame-ce documentation: https://pyga.me/docs/
-.. _pygame documentation: https://www.pygame.org/docs/
 .. _Simple DirectMedia Layer library: https://www.libsdl.org
 .. _Compilation wiki page: https://github.com/pygame-community/pygame-ce/wiki#compiling
 .. _docs page: https://pyga.me/docs


### PR DESCRIPTION
Following https://github.com/pygame-community/pygame-ce/pull/3709 footsteps, I went and updated the Italian README. Since those were legacy credits, it's not an issue for them to only be available in English (besides, it's mainly just names).