### PR TITLE
Move non deprecated scrap function docs to stubs

### DIFF
--- a/buildconfig/stubs/pygame/scrap.pyi
+++ b/buildconfig/stubs/pygame/scrap.pyi
@@ -3,6 +3,41 @@ from typing_extensions import (
     deprecated,  # added in 3.13
 )
 
+def put_text(text: str, /) -> None:
+    """
+    Places text into the clipboard.
+
+    Places the input text into the clipboard. The data should be a string.
+    This is the same clipboard as the legacy scrap API when using ``SCRAP_TEXT``.
+
+    :raises pygame.error: if video mode has not been set_mode
+
+    .. note:: ``pygame.display.set_mode()`` should be called before using the ``scrap`` module
+
+    .. versionadded:: 2.2.0
+    """
+
+def get_text() -> str:
+    """
+    Gets text from the clipboard.
+
+    Gets text from the clipboard and returns it. If the clipboard is empty,
+    returns an empty string. This is the same clipboard as the legacy scrap
+    API when using ``SCRAP_TEXT``.
+
+    .. versionadded:: 2.2.0
+    """
+
+def has_text() -> bool:
+    """
+    Checks if text is in the clipboard.
+
+    Returns ``True`` if the clipboard has a string, otherwise returns ``False``.
+    This is the same clipboard as the legacy scrap API when using ``SCRAP_TEXT``.
+
+    .. versionadded:: 2.2.0
+    """
+
 @deprecated("since 2.2.0. Use the new API instead, which only requires display init")
 def init() -> None: ...
 @deprecated("since 2.2.0. Use the new API instead, which doesn't require scrap init")
@@ -19,6 +54,3 @@ def contains(data_type: str, /) -> bool: ...
 def lost() -> bool: ...
 @deprecated("since 2.2.0. Use the new API instead, which only supports strings")
 def set_mode(mode: int, /) -> None: ...
-def put_text(text: str, /) -> None: ...
-def get_text() -> str: ...
-def has_text() -> bool: ...

--- a/docs/reST/ref/scrap.rst
+++ b/docs/reST/ref/scrap.rst
@@ -21,53 +21,11 @@ in a future release of pygame.
    clipboard as the rest of the current API, but only strings are compatible with the
    new API as of right now.
 
-.. function:: put_text
+.. autopgfunction:: put_text
 
-   | :sl:`Places text into the clipboard.`
-   | :sg:`put_text(text, /) -> None`
+.. autopgfunction:: get_text
 
-   Places the input text into the clipboard. The data should be a string.
-   This is the same clipboard as the legacy scrap API when using ``SCRAP_TEXT``.
-
-   :param string text: String to be placed into the clipboard
-   :rtype: None
-
-   :raises pygame.error: if video mode has not been set_mode
-
-   .. note:: ``pygame.display.set_mode()`` should be called before using the ``scrap`` module
-
-   .. versionadded:: 2.2.0
-
-   .. ## pygame.scrap.put_text
-
-.. function:: get_text
-
-   | :sl:`Gets text from the clipboard.`
-   | :sg:`get_text() -> str`
-
-   Gets text from the clipboard and returns it. If the clipboard is empty,
-   returns an empty string. This is the same clipboard as the legacy scrap
-   API when using ``SCRAP_TEXT``.
-
-   :rtype: str
-
-   .. versionadded:: 2.2.0
-
-   .. ## pygame.scrap.get_text
-
-.. function:: has_text
-
-   | :sl:`Checks if text is in the clipboard.`
-   | :sg:`has_text() -> bool`
-
-   Returns ``True`` if the clipboard has a string, otherwise returns ``False``.
-   This is the same clipboard as the legacy scrap API when using ``SCRAP_TEXT``.
-
-   :rtype: bool
-
-   .. versionadded:: 2.2.0
-
-   .. ## pygame.scrap.has_text
+.. autopgfunction:: has_text
 
 **THE BELOW INFORMATION IS DEPRECATED IN PYGAME 2.2.0 AND WILL BE REMOVED IN THE FUTURE.**
 


### PR DESCRIPTION
For https://github.com/pygame-community/pygame-ce/issues/2757

Removes the "rtype" and explicit parameter typings b/c that is redundant to the other visible content in the stub.

<img width="1091" height="192" alt="image" src="https://github.com/user-attachments/assets/c2400125-ad91-410c-b046-1f5fa89b0a46" />
