### PR TITLE
docs: copy scrap module docstring into stubs and use autopgmodule

### DIFF
--- a/buildconfig/stubs/pygame/scrap.pyi
+++ b/buildconfig/stubs/pygame/scrap.pyi
@@ -1,3 +1,16 @@
+"""pygame module for clipboard support.
+
+The scrap module is for transferring data to/from the clipboard. This allows for
+transferring of strings between pygame and other applications. Currently, only strings
+are supported with the ``scrap.put_text``, ``scrap.get_text``, and ``scrap.has_text``
+functions. All other functions are deprecated as of pygame 2.2.0 and will be removed
+in a future release of pygame.
+
+.. note:: ``scrap.put_text``, ``scrap.get_text``, and ``scrap.has_text`` use the same
+   clipboard as the rest of the current API, but only strings are compatible with the
+   new API as of right now.
+"""
+
 from typing_extensions import (
     Buffer,  # added in 3.12,
     deprecated,  # added in 3.13

--- a/buildconfig/stubs/pygame/scrap.pyi
+++ b/buildconfig/stubs/pygame/scrap.pyi
@@ -1,5 +1,8 @@
 """pygame module for clipboard support.
 
+**EXPERIMENTAL!**: This API may change or disappear in later pygame releases. If
+you use this, your code may break with the next pygame release.
+
 The scrap module is for transferring data to/from the clipboard. This allows for
 transferring of strings between pygame and other applications. Currently, only strings
 are supported with the ``scrap.put_text``, ``scrap.get_text``, and ``scrap.has_text``

--- a/docs/reST/ref/scrap.rst
+++ b/docs/reST/ref/scrap.rst
@@ -6,9 +6,6 @@
 .. autopgmodule:: pygame.scrap
    :members:
 
-**EXPERIMENTAL!**: This API may change or disappear in later pygame releases. If
-you use this, your code may break with the next pygame release.
-
 **THE BELOW INFORMATION IS DEPRECATED IN PYGAME 2.2.0 AND WILL BE REMOVED IN THE FUTURE.**
 
 The scrap module is for transferring data to/from the clipboard. This allows

--- a/docs/reST/ref/scrap.rst
+++ b/docs/reST/ref/scrap.rst
@@ -6,6 +6,9 @@
 .. autopgmodule:: pygame.scrap
    :members:
 
+**EXPERIMENTAL!**: This API may change or disappear in later pygame releases. If
+you use this, your code may break with the next pygame release.
+
 **THE BELOW INFORMATION IS DEPRECATED IN PYGAME 2.2.0 AND WILL BE REMOVED IN THE FUTURE.**
 
 The scrap module is for transferring data to/from the clipboard. This allows

--- a/docs/reST/ref/scrap.rst
+++ b/docs/reST/ref/scrap.rst
@@ -3,6 +3,14 @@
 :mod:`pygame.scrap`
 ===================
 
+.. module:: pygame.scrap
+   :synopsis: pygame module for clipboard support.
+
+| :sl:`pygame module for clipboard support.`
+
+**EXPERIMENTAL!**: This API may change or disappear in later pygame releases. If
+you use this, your code may break with the next pygame release.
+
 .. autopgmodule:: pygame.scrap
    :members:
 

--- a/docs/reST/ref/scrap.rst
+++ b/docs/reST/ref/scrap.rst
@@ -3,14 +3,6 @@
 :mod:`pygame.scrap`
 ===================
 
-.. module:: pygame.scrap
-   :synopsis: pygame module for clipboard support.
-
-| :sl:`pygame module for clipboard support.`
-
-**EXPERIMENTAL!**: This API may change or disappear in later pygame releases. If
-you use this, your code may break with the next pygame release.
-
 .. autopgmodule:: pygame.scrap
    :members:
 

--- a/docs/reST/ref/scrap.rst
+++ b/docs/reST/ref/scrap.rst
@@ -3,29 +3,8 @@
 :mod:`pygame.scrap`
 ===================
 
-.. module:: pygame.scrap
-   :synopsis: pygame module for clipboard support.
-
-| :sl:`pygame module for clipboard support.`
-
-**EXPERIMENTAL!**: This API may change or disappear in later pygame releases. If
-you use this, your code may break with the next pygame release.
-
-The scrap module is for transferring data to/from the clipboard. This allows for
-transferring of strings between pygame and other applications. Currently, only strings
-are supported with the ``scrap.put_text``, ``scrap.get_text``, and ``scrap.has_text``
-functions. All other functions are deprecated as of pygame 2.2.0 and will be removed
-in a future release of pygame.
-
-.. note:: ``scrap.put_text``, ``scrap.get_text``, and ``scrap.has_text`` use the same
-   clipboard as the rest of the current API, but only strings are compatible with the
-   new API as of right now.
-
-.. autopgfunction:: put_text
-
-.. autopgfunction:: get_text
-
-.. autopgfunction:: has_text
+.. autopgmodule:: pygame.scrap
+   :members:
 
 **THE BELOW INFORMATION IS DEPRECATED IN PYGAME 2.2.0 AND WILL BE REMOVED IN THE FUTURE.**
 


### PR DESCRIPTION
## Summary

Adds a module-level docstring to `buildconfig/stubs/pygame/scrap.pyi` and updates `docs/reST/ref/scrap.rst` to use `autopgmodule` with `:members:`.

## Why this matters

Follow-up from [PR #3730 review](https://github.com/pygame-community/pygame-ce/pull/3730#pullrequestreview-3909594560) where @zoldalma999 suggested copying the non-deprecated module docstrings into the stubs so the RST can pull them via `autopgmodule`.

## Changes

- `buildconfig/stubs/pygame/scrap.pyi`: Added module-level docstring with the non-deprecated module description and usage note
- `docs/reST/ref/scrap.rst`: Replaced the manual module description and individual `autopgfunction` directives with a single `autopgmodule:: pygame.scrap` + `:members:` block, matching the pattern used by `cursors.rst` and other modules

The deprecated function section below remains unchanged with its manual RST documentation.

Fixes #3744

This contribution was developed with AI assistance (Claude Code).