### PR TITLE
Added force option for mouse.set_pos

### DIFF
--- a/buildconfig/stubs/pygame/mouse.pyi
+++ b/buildconfig/stubs/pygame/mouse.pyi
@@ -188,15 +188,18 @@ def get_rel() -> tuple[int, int]:
     """
 
 @overload
-def set_pos(pos: Point, /) -> None: ...
+def set_pos(pos: Point, force: bool = False) -> None: ...
 @overload
-def set_pos(x: float, y: float, /) -> None: ...
+def set_pos(x: float, y: float, force: bool = False) -> None: ...
 def set_pos(*args) -> None:  # type: ignore
     """Set the mouse cursor position.
 
     Set the current mouse position to arguments given. If the mouse cursor is
     visible it will jump to the new coordinates. Moving the mouse will generate
     a new ``pygame.MOUSEMOTION`` event.
+
+    If the ``force`` argument is ``True``, the mouse position will change even
+    if mouse cursor is outside window.
     """
 
 def set_visible(value: bool, /) -> int:

--- a/src_c/doc/mouse_doc.h
+++ b/src_c/doc/mouse_doc.h
@@ -5,7 +5,7 @@
 #define DOC_MOUSE_GETJUSTRELEASED "get_just_released() -> tuple\nGet the most recently released buttons."
 #define DOC_MOUSE_GETPOS "get_pos(desktop=False) -> tuple[int, int]\nGet the mouse cursor position."
 #define DOC_MOUSE_GETREL "get_rel() -> tuple[int, int]\nGet the amount of mouse movement."
-#define DOC_MOUSE_SETPOS "set_pos(pos, /) -> None\nset_pos(x, y, /) -> None\nSet the mouse cursor position."
+#define DOC_MOUSE_SETPOS "set_pos(pos, force=False) -> None\nset_pos(x, y, force=False) -> None\nSet the mouse cursor position."
 #define DOC_MOUSE_SETVISIBLE "set_visible(value, /) -> int\nHide or show the mouse cursor."
 #define DOC_MOUSE_GETVISIBLE "get_visible() -> bool\nGet the current visibility state of the mouse cursor."
 #define DOC_MOUSE_GETFOCUSED "get_focused() -> bool\nCheck if the display is receiving mouse input."

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -31,9 +31,29 @@
 
 /* mouse module functions */
 static PyObject *
-mouse_set_pos(PyObject *self, PyObject *args)
+mouse_set_pos(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     int x, y;
+    int force = 0;
+
+    Py_ssize_t nargs = PyTuple_Size(args);
+
+    if (nargs == 1) {
+        static char *kwids[] = {"pos", "force", NULL};
+        PyObject* pos = NULL;
+
+        if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|i", kwids, &pos, &force)) {
+            return NULL;
+        }
+
+    } else {
+        static char *kwids[] = {"x", "y", "force", NULL};
+        PyObject *_x, *_y = NULL;
+
+        if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|i", kwids, &_x, &_y, &force)) {
+            return NULL;
+        }
+    }
 
     if (!pg_TwoIntsFromObj(args, &x, &y)) {
         return RAISE(PyExc_TypeError, "invalid position argument for set_pos");
@@ -41,25 +61,28 @@ mouse_set_pos(PyObject *self, PyObject *args)
 
     VIDEO_INIT_CHECK();
 
-    {
-        SDL_Window *sdlWindow = pg_GetDefaultWindow();
-        SDL_Renderer *sdlRenderer = SDL_GetRenderer(sdlWindow);
-        if (sdlRenderer != NULL) {
-            SDL_Rect vprect;
-            float scalex, scaley;
+    SDL_Window *sdlWindow = pg_GetDefaultWindow();
+    SDL_Renderer *sdlRenderer = SDL_GetRenderer(sdlWindow);
+    if (sdlRenderer != NULL) {
+        SDL_Rect vprect;
+        float scalex, scaley;
 
-            SDL_RenderGetScale(sdlRenderer, &scalex, &scaley);
-            SDL_RenderGetViewport(sdlRenderer, &vprect);
+        SDL_RenderGetScale(sdlRenderer, &scalex, &scaley);
+        SDL_RenderGetViewport(sdlRenderer, &vprect);
 
-            x += vprect.x;
-            y += vprect.y;
+        x += vprect.x;
+        y += vprect.y;
 
-            x = (int)(x * scalex);
-            y = (int)(y * scaley);
-        }
+        x = (int)(x * scalex);
+        y = (int)(y * scaley);
     }
 
-    SDL_WarpMouseInWindow(NULL, (Uint16)x, (Uint16)y);
+    if (force) {
+        SDL_WarpMouseInWindow(sdlWindow, (Uint16)x, (Uint16)y);
+    } else {
+        SDL_WarpMouseInWindow(NULL, (Uint16)x, (Uint16)y);
+    }
+
     Py_RETURN_NONE;
 }
 
@@ -646,7 +669,8 @@ mouse_set_relative_mode(PyObject *self, PyObject *arg)
 }
 
 static PyMethodDef _mouse_methods[] = {
-    {"set_pos", mouse_set_pos, METH_VARARGS, DOC_MOUSE_SETPOS},
+    {"set_pos", (PyCFunction)mouse_set_pos, METH_VARARGS | METH_KEYWORDS,
+     DOC_MOUSE_SETPOS},
     {"get_pos", (PyCFunction)mouse_get_pos, METH_VARARGS | METH_KEYWORDS,
      DOC_MOUSE_GETPOS},
     {"get_rel", (PyCFunction)mouse_get_rel, METH_NOARGS, DOC_MOUSE_GETREL},

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -40,17 +40,19 @@ mouse_set_pos(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (nargs == 1) {
         static char *kwids[] = {"pos", "force", NULL};
-        PyObject* pos = NULL;
+        PyObject *pos = NULL;
 
-        if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|i", kwids, &pos, &force)) {
+        if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|i", kwids, &pos,
+                                         &force)) {
             return NULL;
         }
-
-    } else {
+    }
+    else {
         static char *kwids[] = {"x", "y", "force", NULL};
         PyObject *_x, *_y = NULL;
 
-        if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|i", kwids, &_x, &_y, &force)) {
+        if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|i", kwids, &_x, &_y,
+                                         &force)) {
             return NULL;
         }
     }
@@ -79,7 +81,8 @@ mouse_set_pos(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (force) {
         SDL_WarpMouseInWindow(sdlWindow, (Uint16)x, (Uint16)y);
-    } else {
+    }
+    else {
         SDL_WarpMouseInWindow(NULL, (Uint16)x, (Uint16)y);
     }
 

--- a/test/mouse_test.py
+++ b/test/mouse_test.py
@@ -69,6 +69,7 @@ class MouseModuleInteractiveTest(MouseTests):
         pygame.mouse.set_pos([9.9, 9.9])
         pygame.mouse.set_pos([9.9, 9.9], force=True)
 
+
 class MouseModuleTest(MouseTests):
     @unittest.skipIf(
         os.environ.get("SDL_VIDEODRIVER", "") == pygame.NULL_VIDEODRIVER,

--- a/test/mouse_test.py
+++ b/test/mouse_test.py
@@ -53,6 +53,21 @@ class MouseModuleInteractiveTest(MouseTests):
 
             self.assertEqual(found_pos, (x, y))
 
+    def test_set_pos_api(self):
+        pygame.mouse.set_pos(10, 10)
+        pygame.mouse.set_pos(10, 10, force=True)
+        pygame.mouse.set_pos(9.9, 9.9)
+        pygame.mouse.set_pos(9.9, 9.9, force=True)
+
+        pygame.mouse.set_pos((10, 10))
+        pygame.mouse.set_pos((10, 10), force=True)
+        pygame.mouse.set_pos((9.9, 9.9))
+        pygame.mouse.set_pos((9.9, 9.9), force=True)
+
+        pygame.mouse.set_pos([10, 10])
+        pygame.mouse.set_pos([10, 10], force=True)
+        pygame.mouse.set_pos([9.9, 9.9])
+        pygame.mouse.set_pos([9.9, 9.9], force=True)
 
 class MouseModuleTest(MouseTests):
     @unittest.skipIf(


### PR DESCRIPTION
Adds `force` argument to `mouse.set_pos` method that will force mouse position change even if the cursor is outside window's bounds.

### Rationale

If the mouse cursor is outside window, currently there is no way to force it back other than manually hovering it over the window again. This is especially apparent when a game implements cursor control with multiple devices e.g. mouse + joystick. When mouse is outside the window, I'd like to be able to force the cursor back using e.g. controller's analog stick - which I'm currently unable to do. This change addresses the issue.