### PR TITLE
Harden gh actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build-debian-multiarch.yml
+++ b/.github/workflows/build-debian-multiarch.yml
@@ -35,6 +35,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-debian-multiarch
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+
 # this command is called in two places, so save it in an env first
 env:
   INSTALL_CMD: |
@@ -65,10 +69,12 @@ jobs:
           - { arch: armv7, base_image: 'balenalib/raspberrypi3-debian:bookworm' }
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Build sources and run tests
-      uses: uraimo/run-on-arch-action@v3.0.1
+      uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
       id: build
       with:
         arch: ${{ matrix.base_image && 'none' || matrix.arch }}
@@ -108,7 +114,7 @@ jobs:
 
     # Upload the generated files under github actions assets section
     - name: Upload dist
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: pygame-multiarch-${{ matrix.arch }}-dist
         path: ~/artifacts/*.whl
@@ -121,7 +127,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Download all multiarch artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: pygame-multiarch-armv7-dist
         path: ~/artifacts
@@ -134,7 +140,7 @@ jobs:
         done
 
     - name: Test armv7 wheel on armv6
-      uses: uraimo/run-on-arch-action@v3.0.1
+      uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
       with:
         arch: armv6
         distro: bookworm

--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -31,6 +31,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-emsdk
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-pygbag:
     runs-on: ubuntu-22.04
@@ -42,7 +45,9 @@ jobs:
       PYBUILD: 3.13
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Install python-wasm-sdk
       run: |
@@ -55,7 +60,7 @@ jobs:
 
     # Upload the generated files under github actions assets section
     - name: Upload dist
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: pygame-wasm-dist
         path: ./dist/*
@@ -64,13 +69,15 @@ jobs:
     name: Pyodide build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
-    - uses: pypa/cibuildwheel@v3.4.0
+    - uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
       env:
         CIBW_PLATFORM: pyodide
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: pyodide-wheels
         path: wheelhouse/*.whl

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-macos
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   deps:
     name: ${{ matrix.macarch }} deps
@@ -28,11 +31,13 @@ jobs:
           - { macarch: x86_64, os: macos-15 }
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Test for Mac Deps cache hit
         id: macdep-cache
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ github.workspace }}/pygame_mac_deps_${{ matrix.macarch }}
           # The hash of all files in buildconfig manylinux-build and macdependencies is
@@ -51,7 +56,7 @@ jobs:
 
       # Uncomment when you want to manually verify the deps by downloading them
       # - name: Upload Mac deps
-      #   uses: actions/upload-artifact@v7
+      #   uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       #   with:
       #     name: pygame-mac-deps-${{ matrix.macarch }}
       #     path: ${{ github.workspace }}/pygame_mac_deps_${{ matrix.macarch }}
@@ -88,28 +93,30 @@ jobs:
       CIBW_BEFORE_TEST: rm -rf ${{ github.workspace }}/pygame_mac_deps
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: pip cache
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/Library/Caches/pip  # This cache path is only right on mac
           key: pip-cache-${{ matrix.macarch }}-${{ matrix.os }}
 
       - name: Fetch Mac deps
         id: macdep-cache
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ github.workspace }}/pygame_mac_deps_${{ matrix.macarch }}
           key: macdep-${{ hashFiles('buildconfig/manylinux-build/**') }}-${{ hashFiles('buildconfig/macdependencies/*.sh') }}-${{ matrix.macarch }}
           fail-on-cache-miss: true
 
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@v3.4.0
+        uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
         with:
           extras: uv
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: macos-partial-${{ matrix.macarch }}
           path: ./wheelhouse/*.whl
@@ -120,7 +127,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
 
@@ -165,7 +172,7 @@ jobs:
           python3 -m pip install --no-index --find-links wheelhouse pygame-ce
           python3 -m pygame.tests -v --exclude opengl,music,timing --time_out 300
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pygame-wheels-macos
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -33,7 +33,9 @@ jobs:
       CIBW_ARCHS: ${{ matrix.arch }}
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Log in to the Container registry
       uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
@@ -74,11 +76,11 @@ jobs:
         CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/${{ github.repository }}_aarch64:${{ steps.meta.outputs.version }}
         CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: ghcr.io/${{ github.repository }}_aarch64:${{ steps.meta.outputs.version }}
 
-      uses: pypa/cibuildwheel@v3.4.0
+      uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
 
     # We upload the generated files under github actions assets
     - name: Upload dist
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: pygame-wheels-manylinux-${{ matrix.arch }}
         path: ./wheelhouse/*.whl

--- a/.github/workflows/build-sdl3.yml
+++ b/.github/workflows/build-sdl3.yml
@@ -33,8 +33,11 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-ubuntu-sdist
+  group: ${{ github.workflow }}-${{ github.ref }}-build-sdl3
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -52,8 +55,10 @@ jobs:
       PG_DEPS_FROM_SYSTEM: 1
 
     steps:
-    - uses: actions/checkout@v6.0.2
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
 

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-ubuntu-sdist
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -39,7 +42,9 @@ jobs:
       PG_DEPS_FROM_SYSTEM: 1
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Install deps
       # install numpy from pip and not apt because the one from pip is newer,
@@ -69,7 +74,7 @@ jobs:
 
     # We upload the generated files under github actions assets
     - name: Upload sdist
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: pygame-wheels-sdist
         path: dist/*.tar.gz

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-windows
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # windows build with legacy prebuilts
   # this job is to be removed when we generalize the Windows ARM job
@@ -33,18 +36,21 @@ jobs:
       CIBW_ARCHS: ${{ matrix.winarch }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: TheMrMilchmann/setup-msvc-dev@v4  # this lets us use the developer command prompt on windows
+      # this lets us use the developer command prompt on windows
+      - uses: TheMrMilchmann/setup-msvc-dev@79dac248aac9d0059f86eae9d8b5bfab4e95e97c # v4.0.0
         with:
           arch: ${{ matrix.msvc-dev-arch }}
 
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@v3.4.0
+        uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
         with:
           extras: uv
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pygame-wheels-windows-${{ matrix.winarch }}
           path: ./wheelhouse/*.whl
@@ -65,11 +71,13 @@ jobs:
 
     steps:
       - run: git config --global core.autocrlf input  # do not introduce carriage returns
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Test for Win Deps cache hit
         id: windep-cache
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ github.workspace }}/pygame_win_deps_${{ matrix.winarch }}
           # The hash of all files in buildconfig manylinux-build and windependencies is
@@ -77,7 +85,7 @@ jobs:
           key: windep-${{ hashFiles('buildconfig/manylinux-build/**') }}-${{ hashFiles('buildconfig/windependencies/*') }}-${{ matrix.winarch }}
 
       # Setup msys environment
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
         if: steps.windep-cache.outputs.cache-hit != 'true'
         with:
           update: true
@@ -105,7 +113,7 @@ jobs:
           bash ./build_win_deps.sh
 
       - name: Upload win deps
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pygame_win_deps_${{ matrix.winarch }}
           path: ${{ github.workspace }}/pygame_win_deps_${{ matrix.winarch }}
@@ -128,26 +136,28 @@ jobs:
 
     steps:
       - run: git config --global core.autocrlf input  # do not introduce carriage returns
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Force 32-bit MSVC
         if: matrix.winarch == 'x86'
-        uses: egor-tensin/vs-shell@v2
+        uses: egor-tensin/vs-shell@9a932a62d05192eae18ca370155cf877eecc2202 # v2.1
         with:
           arch: x86
 
       - name: Download Windows deps artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pygame_win_deps_${{ matrix.winarch }}
           path: ${{ github.workspace }}/pygame_win_deps_${{ matrix.winarch }}
 
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@v3.4.0
+        uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
         with:
           extras: uv
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pygame-wheels-windows-${{ matrix.winarch }}
           path: ./wheelhouse/*.whl
@@ -170,8 +180,10 @@ jobs:
 
     steps:
       - run: git config --global core.autocrlf input  # do not introduce carriage returns
-      - uses: actions/checkout@v6.0.2
-      - uses: msys2/setup-msys2@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
         with:
           msystem: ${{ matrix.sys }}
           update: true
@@ -185,7 +197,7 @@ jobs:
             mingw-w64-${{ matrix.env }}-cython
 
       - name: Download Windows deps artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pygame_win_deps_${{ matrix.winarch }}
           path: ${{ github.workspace }}/pygame_win_deps_${{ matrix.winarch }}

--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-dev-check
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   dev-check:
     runs-on: ubuntu-24.04
@@ -31,7 +34,9 @@ jobs:
       SDL_AUDIODRIVER: "disk"
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install deps
         run: |

--- a/.github/workflows/release-gh-draft.yml
+++ b/.github/workflows/release-gh-draft.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: 'release/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-gh-draft
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   manylinux:
     uses: ./.github/workflows/build-manylinux.yml
@@ -26,10 +33,8 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6.0.2
-
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: pygame-wheels
           pattern: pygame-wheels-*
@@ -42,12 +47,12 @@ jobs:
         run: echo "VER=${GITHUB_REF_NAME#'release/'}" >> $GITHUB_OUTPUT
 
       - name: Generate release attestation
-        uses: actions/attest-build-provenance@v4.1.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: "pygame-wheels/*"
 
       - name: Draft a release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           draft: true
           prerelease: ${{ contains(steps.ver.outputs.VER, 'dev') }}

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-release-pypi
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -12,10 +16,8 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/checkout@v6.0.2
-
       - name: Pull all release assets
-        uses: robinraju/release-downloader@v1.12
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
           releaseId: ${{ github.event.release.id }}
           fileName: "*"
@@ -42,4 +44,4 @@ jobs:
           done
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1

--- a/.github/workflows/run-ubuntu-checks.yml
+++ b/.github/workflows/run-ubuntu-checks.yml
@@ -44,6 +44,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-ubuntu-checks
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   debug_coverage:
     runs-on: ${{ matrix.os }}
@@ -65,7 +68,9 @@ jobs:
       PG_DEPS_FROM_SYSTEM: 1
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Install pygame-ce deps
       # https://github.com/actions/runner-images/issues/7192
@@ -87,7 +92,7 @@ jobs:
 
     - name: Cache debug python build
       id: cache-python
-      uses: actions/cache@v5.0.4
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         key: ${{ matrix.python }}
         path: ~/.pyenv/versions/${{ matrix.python }}-debug/**
@@ -123,7 +128,7 @@ jobs:
     - name: Upload coverage html
       # want to continue only if the coverage generation was successful
       if: ${{ steps.gen-coverage.conclusion == 'success' && !cancelled() }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: pygame-coverage-${{ matrix.os }}-${{ matrix.python }}
         path: ./out
@@ -134,16 +139,17 @@ jobs:
     needs: debug_coverage
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0  # fetch full history
+        persist-credentials: false
 
     - name: Check if any src_c files changed
       id: check-changes
       continue-on-error: true
       run: |
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          CHANGED_FILES=$(git diff --name-only origin/${GITHUB_BASE_REF}...HEAD)
         else
           CHANGED_FILES=$(git diff --name-only HEAD^1...HEAD)
         fi


### PR DESCRIPTION
After learning about the recent [litellm security incident](https://docs.litellm.ai/blog/security-update-march-2026) (TL;DR: supply chain attack via github actions, the PyPI token of a popular library was leaked to attackers who released bad releases that then compromised user creds and so on) I was prompted into further scrutinizing our own actions for security.

The good news is that we are already pretty secure in terms of PyPI publishing. We don't use a static PyPI token and instead use the recommended [Trusted PyPI Publisher](https://docs.pypi.org/trusted-publishers/) approach for managing our releases. So an attack like the above mentioned case wouldn't be possible with us.

But still, to be cautious (using [zizmor](https://docs.zizmor.sh/) for github actions static analysis) this PR identifies and fixes a couple of security gotchas, mainly under three categories:
- Pins all actions to hashes instead of versions (this secures us against potential malicious upstream releases that re-use old tags). Dependabot is capable of keeping these hashes updated as hashes.
- Explicit content read-only permissions for all actions (this secures us against actions making writes to the repo)
- Checkout without persisting git credentials

