### PR TITLE
Ignore docs changes more on workflows ignoring docs

### DIFF
--- a/.github/workflows/build-debian-multiarch.yml
+++ b/.github/workflows/build-debian-multiarch.yml
@@ -11,6 +11,8 @@ on:
     branches: main
     paths-ignore:
       - 'docs/**'
+      - 'src_c/doc/**'
+      - 'buildconfig/stubs/**'
       - 'examples/**'
       - '.gitignore'
       - '*.rst'
@@ -23,6 +25,8 @@ on:
     branches: main
     paths-ignore:
       - 'docs/**'
+      - 'src_c/doc/**'
+      - 'buildconfig/stubs/**'
       - 'examples/**'
       - '.gitignore'
       - '*.rst'

--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -7,6 +7,8 @@ on:
     branches: main
     paths-ignore:
       - 'docs/**'
+      - 'src_c/doc/**'
+      - 'buildconfig/stubs/**'
       - 'examples/**'
       - '.gitignore'
       - '*.rst'
@@ -19,6 +21,8 @@ on:
     branches: main
     paths-ignore:
       - 'docs/**'
+      - 'src_c/doc/**'
+      - 'buildconfig/stubs/**'
       - 'examples/**'
       - '.gitignore'
       - '*.rst'

--- a/.github/workflows/build-sdl3.yml
+++ b/.github/workflows/build-sdl3.yml
@@ -9,6 +9,8 @@ on:
     branches: main
     paths-ignore:
       - 'docs/**'
+      - 'src_c/doc/**'
+      - 'buildconfig/stubs/**'
       - 'examples/**'
       - '.gitignore'
       - '*.rst'
@@ -21,6 +23,8 @@ on:
     branches: main
     paths-ignore:
       - 'docs/**'
+      - 'src_c/doc/**'
+      - 'buildconfig/stubs/**'
       - 'examples/**'
       - '.gitignore'
       - '*.rst'

--- a/.github/workflows/run-ubuntu-checks.yml
+++ b/.github/workflows/run-ubuntu-checks.yml
@@ -20,6 +20,8 @@ on:
     branches: main
     paths-ignore:
       - 'docs/**'
+      - 'src_c/doc/**'
+      - 'buildconfig/stubs/**'
       - 'examples/**'
       - '.gitignore'
       - '*.rst'
@@ -32,6 +34,8 @@ on:
     branches: main
     paths-ignore:
       - 'docs/**'
+      - 'src_c/doc/**'
+      - 'buildconfig/stubs/**'
       - 'examples/**'
       - '.gitignore'
       - '*.rst'


### PR DESCRIPTION
I think other builds could probably ignore docs changes as well, but they aren't right now.

This PR makes it so that docs changes like I just put up a few PRs for should be ignored by at least a few workflows.