### PR TITLE
Use noexcept in cython recording_cb to fix warning

### DIFF
--- a/src_c/cython/pygame/_sdl2/audio.pxd
+++ b/src_c/cython/pygame/_sdl2/audio.pxd
@@ -11,7 +11,7 @@ cdef extern from "SDL.h" nogil:
 
     ctypedef Uint32 SDL_AudioDeviceID
     ctypedef Uint16 SDL_AudioFormat
-    ctypedef void (*SDL_AudioCallback)(void *userdata, Uint8 *stream, int len)
+    ctypedef void (*SDL_AudioCallback)(void *userdata, Uint8 *stream, int len) noexcept nogil
 
     ctypedef struct SDL_AudioSpec:
         int freq

--- a/src_c/cython/pygame/_sdl2/audio.pyx
+++ b/src_c/cython/pygame/_sdl2/audio.pyx
@@ -68,7 +68,7 @@ def get_audio_device_names(iscapture = False):
     return names
 
 import traceback
-cdef void recording_cb(void* userdata, Uint8* stream, int len) nogil:
+cdef void recording_cb(void* userdata, Uint8* stream, int len) noexcept nogil:
     """ This is called in a thread made by SDL.
         So we need the python GIL to do python stuff.
     """
@@ -81,7 +81,6 @@ cdef void recording_cb(void* userdata, Uint8* stream, int len) nogil:
             (<object>userdata).callback(<object>userdata, a_memoryview)
         except:
             traceback.print_exc()
-            raise
 
 
 # disable auto_pickle since it causes stubcheck error

--- a/src_c/cython/pygame/_sdl2/mixer.pyx
+++ b/src_c/cython/pygame/_sdl2/mixer.pyx
@@ -14,7 +14,7 @@ import traceback
 # Mix_SetPostMix(noEffect, NULL);
 
 
-cdef void recording_cb(void* userdata, Uint8* stream, int len) nogil:
+cdef void recording_cb(void* userdata, Uint8* stream, int len) noexcept nogil:
     """ This is called in a thread made by SDL.
         So we need the python GIL to do python stuff.
     """
@@ -27,7 +27,6 @@ cdef void recording_cb(void* userdata, Uint8* stream, int len) nogil:
             (<object>userdata).callback(<object>userdata, a_memoryview)
         except:
             traceback.print_exc()
-            raise
 
 # ctypedef void (*cfptr)(int)
 # cdef cfptr myfunctionptr = &myfunc


### PR DESCRIPTION
This PR fixes cython compiler warnings that pop up during build time. These functions shouldn't raise exceptions (handling is done by printing the exception) so they must be marked with `noexcept`