### PR TITLE
Remove mask/freetype warning supressions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -544,15 +544,9 @@ summary(
 # stores werror
 warnings_error = []
 
-# module specific warnings (TODO remove these by fixing code)
-warnings_temp_freetype = []
-warnings_temp_mask = []
-
 if cc.get_argument_syntax() == 'msvc'
     # base warnings on msvc
     add_global_arguments(['/W3', '/wd4142', '/wd4996'], language: 'c')
-
-    warnings_temp_mask += ['/wd6385', '/wd6386']
 
     if get_option('error_on_warns') and not is_pypy
         warnings_error += '/WX'
@@ -561,19 +555,6 @@ if cc.get_argument_syntax() == 'msvc'
 else
     # base warnings on gcc/clang
     add_global_arguments(['-Wall', '-Wno-error=unknown-pragmas'], language: 'c')
-
-    # check for exact gcc (flags not needed on clang)
-    if cc.get_id() == 'gcc'
-        warnings_temp_freetype += [
-            '-Wno-error=unused-but-set-variable',
-            '-Wno-error=array-bounds',
-        ]
-        warnings_temp_mask += '-Wno-error=array-bounds'
-    endif
-
-    if cc.sizeof('long') != 8
-        warnings_temp_mask += '-Wno-error=shift-count-overflow'
-    endif
 
     if get_option('error_on_warns') and not is_pypy
         warnings_error += '-Werror'

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -774,7 +774,7 @@ _pg_new_capsuleinterface(Py_buffer *view_p)
     int i;
 
     cinter_size =
-        (sizeof(pgCapsuleInterface) + sizeof(Py_intptr_t) * (2 * ndim - 1));
+        (sizeof(pgCapsuleInterface) + sizeof(Py_intptr_t) * (2 * ndim));
     cinter_p = (pgCapsuleInterface *)PyMem_Malloc(cinter_size);
     if (!cinter_p) {
         PyErr_NoMemory();
@@ -1265,7 +1265,7 @@ _pg_arraystruct_as_buffer(Py_buffer *view_p, PyObject *cobj,
 {
     pgViewInternals *internal_p;
     Py_ssize_t sz =
-        (sizeof(pgViewInternals) + (2 * inter_p->nd - 1) * sizeof(Py_ssize_t));
+        (sizeof(pgViewInternals) + (2 * inter_p->nd) * sizeof(Py_ssize_t));
     int readonly = (inter_p->flags & PAI_WRITEABLE) ? 0 : 1;
     Py_ssize_t i;
 
@@ -1646,7 +1646,7 @@ _pg_values_as_buffer(Py_buffer *view_p, int flags, PyObject *typestr,
                         "require writable buffer, but it is read-only");
         return -1;
     }
-    sz = sizeof(pgViewInternals) + (2 * ndim - 1) * sizeof(Py_ssize_t);
+    sz = sizeof(pgViewInternals) + (2 * ndim) * sizeof(Py_ssize_t);
     internal_p = (pgViewInternals *)PyMem_Malloc(sz);
     if (!internal_p) {
         PyErr_NoMemory();

--- a/src_c/base.h
+++ b/src_c/base.h
@@ -45,13 +45,13 @@ QDGlobals pg_qd;
 /* Extended array struct */
 typedef struct pg_capsule_interface_s {
     PyArrayInterface inter;
-    Py_intptr_t imem[1];
+    Py_intptr_t imem[];
 } pgCapsuleInterface;
 
 /* Py_buffer internal data for an array interface/struct */
 typedef struct pg_view_internals_s {
     char format[4]; /* make 4 byte word sized */
-    Py_ssize_t imem[1];
+    Py_ssize_t imem[];
 } pgViewInternals;
 
 extern PG_PixelFormatEnum pg_default_convert_format;

--- a/src_c/bitmask.c
+++ b/src_c/bitmask.c
@@ -118,7 +118,7 @@ bitmask_create(int w, int h)
         return 0;
     }
 
-    size = offsetof(bitmask_t, bits);
+    size = sizeof(bitmask_t);
 
     if (w && h) {
         size += h * ((w - 1) / BITMASK_W_LEN + 1) * sizeof(BITMASK_W);

--- a/src_c/bitmask.c
+++ b/src_c/bitmask.c
@@ -39,55 +39,46 @@
 static INLINE unsigned int
 bitcount(BITMASK_W n)
 {
-    const int bitmask_len = BITMASK_W_LEN;
-    if (bitmask_len == 32) {
+#if BITMASK_W_LEN == 32
 #ifdef GILLIES
-        /* (C) Donald W. Gillies, 1992.  All rights reserved.  You may reuse
-           this bitcount() function anywhere you please as long as you retain
-           this Copyright Notice. */
-        register unsigned long tmp;
-        return (tmp = (n) - (((n) >> 1) & 033333333333) -
-                      (((n) >> 2) & 011111111111),
-                tmp = ((tmp + (tmp >> 3)) & 030707070707),
-                tmp = (tmp + (tmp >> 6)),
-                tmp = (tmp + (tmp >> 12) + (tmp >> 24)) & 077);
+    /* (C) Donald W. Gillies, 1992.  All rights reserved.  You may reuse
+       this bitcount() function anywhere you please as long as you retain
+       this Copyright Notice. */
+    register unsigned long tmp;
+    return (
+        tmp = (n) - (((n) >> 1) & 033333333333) - (((n) >> 2) & 011111111111),
+        tmp = ((tmp + (tmp >> 3)) & 030707070707), tmp = (tmp + (tmp >> 6)),
+        tmp = (tmp + (tmp >> 12) + (tmp >> 24)) & 077);
 /* End of Donald W. Gillies bitcount code */
 #else
-        /* This piece taken from Jorg Arndt's "Algorithms for Programmers" */
-        n = ((n >> 1) & 0x55555555) + (n & 0x55555555);  // 0-2 in 2 bits
-        n = ((n >> 2) & 0x33333333) + (n & 0x33333333);  // 0-4 in 4 bits
-        n = ((n >> 4) + n) & 0x0f0f0f0f;                 // 0-8 in 4 bits
-        n += n >> 8;                                     // 0-16 in 8 bits
-        n += n >> 16;                                    // 0-32 in 8 bits
-        return n & 0xff;
+    /* This piece taken from Jorg Arndt's "Algorithms for Programmers" */
+    n = ((n >> 1) & 0x55555555) + (n & 0x55555555);  // 0-2 in 2 bits
+    n = ((n >> 2) & 0x33333333) + (n & 0x33333333);  // 0-4 in 4 bits
+    n = ((n >> 4) + n) & 0x0f0f0f0f;                 // 0-8 in 4 bits
+    n += n >> 8;                                     // 0-16 in 8 bits
+    n += n >> 16;                                    // 0-32 in 8 bits
+    return n & 0xff;
 #endif
-    }
-    else if (bitmask_len == 64) {
-        n = ((n >> 1) & 0x5555555555555555) + (n & 0x5555555555555555);
-        n = ((n >> 2) & 0x3333333333333333) + (n & 0x3333333333333333);
-        n = ((n >> 4) + n) & 0x0f0f0f0f0f0f0f0f;
-        n += n >> 8;
-        n += n >> 16;
-#ifdef _WIN32
-        /* Use explicit typecast to silence MSVC warning about large bitshift,
-         * even though this part code does not run on windows */
-        n += (long long)n >> 32;
-#else
-        n += n >> 32;
-#endif
-        return n & 0xff;
-    }
-    else {
-        /* Handle non-32 or 64 bit case the slow way */
-        unsigned int nbits = 0;
-        while (n) {
-            if (n & 1) {
-                nbits++;
-            }
-            n = n >> 1;
+#elif BITMASK_W_LEN == 64
+    n = ((n >> 1) & 0x5555555555555555) + (n & 0x5555555555555555);
+    n = ((n >> 2) & 0x3333333333333333) + (n & 0x3333333333333333);
+    n = ((n >> 4) + n) & 0x0f0f0f0f0f0f0f0f;
+    n += n >> 8;
+    n += n >> 16;
+    n += n >> 32;
+    return n & 0xff;
+#else  /* BITMASK_W_LEN */
+    /* Handle non-32 or 64 bit case the slow way. This code shouldn't really
+     * be reachable. */
+    unsigned int nbits = 0;
+    while (n) {
+        if (n & 1) {
+            nbits++;
         }
-        return nbits;
+        n = n >> 1;
     }
+    return nbits;
+#endif /* BITMASK_W_LEN */
 }
 
 /* Positive modulo of the given dividend and divisor (dividend % divisor).

--- a/src_c/freetype/ft_cache.c
+++ b/src_c/freetype/ft_cache.c
@@ -33,9 +33,11 @@ typedef struct keyfields_ {
     FT_Fixed strength;
 } KeyFields;
 
+#define NUM_DWORDS ((sizeof(KeyFields) + 3) / 4)
+
 typedef union cachenodekey_ {
     KeyFields fields;
-    FT_UInt32 dwords[(sizeof(KeyFields) + 3) / 4];
+    FT_UInt32 dwords[NUM_DWORDS];
 } NodeKey;
 
 typedef struct cachenode_ {
@@ -82,7 +84,7 @@ equal_node_keys(const NodeKey *a, const NodeKey *b)
 {
     size_t i;
 
-    for (i = 0; i < sizeof(a->dwords) / sizeof(a->dwords[0]); ++i) {
+    for (i = 0; i < NUM_DWORDS; ++i) {
         if (a->dwords[i] != b->dwords[i]) {
             return 0;
         }
@@ -103,12 +105,9 @@ get_hash(const NodeKey *key)
     FT_UInt32 c2 = 0x1B873593;
 
     FT_UInt32 k1;
-    const FT_UInt32 *blocks = key->dwords - 1;
 
-    int i;
-
-    for (i = (sizeof(key->dwords) / 4); i; --i) {
-        k1 = blocks[i];
+    for (int i = (NUM_DWORDS - 1); i >= 0; --i) {
+        k1 = key->dwords[i];
 
         k1 *= c1;
         k1 = (k1 << 15) | (k1 >> 17);

--- a/src_c/freetype/ft_unicode.c
+++ b/src_c/freetype/ft_unicode.c
@@ -30,7 +30,7 @@
 #include "ft_wrap.h"
 
 #define SIZEOF_PGFT_STRING(len) \
-    (sizeof(PGFT_String) + (Py_ssize_t)(len) * sizeof(PGFT_char))
+    (sizeof(PGFT_String) + (Py_ssize_t)((len) + 1) * sizeof(PGFT_char))
 
 static const PGFT_char UNICODE_HSA_START = 0xD800;
 static const PGFT_char UNICODE_HSA_END = 0xDBFF;

--- a/src_c/freetype/ft_wrap.h
+++ b/src_c/freetype/ft_wrap.h
@@ -216,7 +216,7 @@ typedef struct fontinternals_ {
 
 typedef struct PGFT_String_ {
     Py_ssize_t length;
-    PGFT_char data[1];
+    PGFT_char data[];
 } PGFT_String;
 
 #if defined(PGFT_DEBUG_CACHE)

--- a/src_c/include/bitmask.h
+++ b/src_c/include/bitmask.h
@@ -43,7 +43,13 @@ extern "C" {
 #endif
 
 #define BITMASK_W unsigned long int
-#define BITMASK_W_LEN (sizeof(BITMASK_W) * CHAR_BIT)
+#if ULONG_MAX == 0xFFFFFFFFUL
+#define BITMASK_W_LEN 32
+#elif ULONG_MAX == 0xFFFFFFFFFFFFFFFFUL
+#define BITMASK_W_LEN 64
+#else
+#error "Unsupported unsigned long size"
+#endif
 #define BITMASK_W_MASK (BITMASK_W_LEN - 1)
 #define BITMASK_N(n) ((BITMASK_W)1 << (n))
 

--- a/src_c/include/bitmask.h
+++ b/src_c/include/bitmask.h
@@ -49,7 +49,7 @@ extern "C" {
 
 typedef struct bitmask {
     int w, h;
-    BITMASK_W bits[1];
+    BITMASK_W bits[];
 } bitmask_t;
 
 /* Creates a bitmask of width w and height h, where

--- a/src_c/meson.build
+++ b/src_c/meson.build
@@ -239,7 +239,7 @@ transform = py.extension_module(
 mask = py.extension_module(
     'mask',
     ['mask.c', 'bitmask.c'],
-    c_args: warnings_error + warnings_temp_mask,
+    c_args: warnings_error,
     dependencies: pg_base_deps,
     install: true,
     subdir: pg,
@@ -468,7 +468,7 @@ if freetype_dep.found()
             'freetype/ft_unicode.c',
             '_freetype.c',
         ],
-        c_args: warnings_error + warnings_temp_freetype,
+        c_args: warnings_error,
         dependencies: pg_base_deps + freetype_dep,
         install: true,
         subdir: pg,


### PR DESCRIPTION
This PR:
- updates all our structs to use [FAM](https://en.wikipedia.org/wiki/Flexible_array_member) where needed. This fixes some mask warnings
- cleans up some `ft_cache` logic. The new logic is (almost) equivalent but easier to understand and does not trip the compiler into raising warnings.
- Updates the `bitcount` code to use macro checks instead of if-else checks