### PR TITLE
`pos` attribute added to `MOUSEWHEEL` event

### DIFF
--- a/docs/reST/ref/event.rst
+++ b/docs/reST/ref/event.rst
@@ -160,7 +160,7 @@ These ``TEXT*`` events are useful to implement inputs/languages that require com
 provided by the system's IME (Input Method Editor). The ``TEXTINPUT`` event is only
 fired when the text is confirmed.
 
-(``5``): Position information was added to ``MOUSEWHEEL`` events in SDL 2.0.26.  If
+(``5``): Position information was added to ``MOUSEWHEEL`` events in SDL 2.26.0  If
 pygame was build on a version lower than that, the ``pos`` attribute is ``(0, 0)``.
 
 |

--- a/docs/reST/ref/event.rst
+++ b/docs/reST/ref/event.rst
@@ -88,7 +88,7 @@ You can also find a list of constants for keyboard keys
     MOUSEBUTTONUP              pos, button, touch(2), clicks(3), window(1)
     MOUSEBUTTONDOWN            pos, button, touch(2), clicks(3), window(1)
     MOUSEWHEEL                 which, flipped, x, y, touch(2), precise_x,
-                                precise_y, window(1)
+                                precise_y, window(1), pos(5)
 
     JOYAXISMOTION              instance_id, axis, value (deprecated: joy)
     JOYBALLMOTION              instance_id, ball, rel (deprecated: joy)
@@ -160,6 +160,9 @@ These ``TEXT*`` events are useful to implement inputs/languages that require com
 provided by the system's IME (Input Method Editor). The ``TEXTINPUT`` event is only
 fired when the text is confirmed.
 
+(``5``): Position information was added to ``MOUSEWHEEL`` events in SDL 2.0.26.  If
+pygame was build on a version lower than that, the ``pos`` attribute is ``(0, 0)``.
+
 |
 
 Here is a list of the new window events.
@@ -222,6 +225,8 @@ On Android, the following events can be generated:
 
 .. versionadded:: 2.5.7 The ``clicks`` attribute was added to ``MOUSEBUTTONDOWN``
    and ``MOUSEBUTTONUP`` events.
+
+.. versionadded:: 2.5.8 The ``pos`` attribute was added to ``MOUSEWHEEL`` events.
 
 |
 

--- a/docs/reST/ref/event.rst
+++ b/docs/reST/ref/event.rst
@@ -161,7 +161,7 @@ provided by the system's IME (Input Method Editor). The ``TEXTINPUT`` event is o
 fired when the text is confirmed.
 
 (``5``): Position information was added to ``MOUSEWHEEL`` events in SDL 2.26.0  If
-pygame was build on a version lower than that, the ``pos`` attribute is ``(0, 0)``.
+pygame was build on a version lower than that, the ``pos`` attribute is ``None``.
 
 |
 

--- a/docs/reST/ref/event.rst
+++ b/docs/reST/ref/event.rst
@@ -160,8 +160,8 @@ These ``TEXT*`` events are useful to implement inputs/languages that require com
 provided by the system's IME (Input Method Editor). The ``TEXTINPUT`` event is only
 fired when the text is confirmed.
 
-(``5``): Position information was added to ``MOUSEWHEEL`` events in SDL 2.26.0  If
-pygame was build on a version lower than that, the ``pos`` attribute is ``None``.
+(``5``): Position information was added to ``MOUSEWHEEL`` events in SDL 2.26.0.  If
+pygame was built on a version lower than that, the ``pos`` attribute is ``None``.
 
 |
 

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1380,7 +1380,7 @@ dict_from_event(SDL_Event *event)
                 dict, "touch",
                 PyBool_FromLong((event->wheel.which == SDL_TOUCH_MOUSEID)));
 
-#if SDL_VERSION_ATLEAST(2, 0, 26)
+#if SDL_VERSION_ATLEAST(2, 26, 0)
             obj = pg_tuple_couple_from_values_int((int)event->wheel.mouseX,
                                                   (int)event->wheel.mouseY);
 #else

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1387,7 +1387,7 @@ dict_from_event(SDL_Event *event)
             obj = pg_tuple_couple_from_values_int((int)event->wheel.mouseX,
                                                   (int)event->wheel.mouseY);
 #else
-            obj = pg_tuple_couple_from_values_int(0, 0);
+        obj = pg_tuple_couple_from_values_int(0, 0);
 #endif /* SDL_VERSION_ATLEAST(2, 26, 0) */
             _pg_insobj(dict, "pos", obj);
 

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1387,8 +1387,7 @@ dict_from_event(SDL_Event *event)
             obj = pg_tuple_couple_from_values_int((int)event->wheel.mouseX,
                                                   (int)event->wheel.mouseY);
 #else
-        obj = Py_None;
-        Py_INCREF(obj);
+        obj = Py_NewRef(Py_None);
 
 #endif /* SDL_VERSION_ATLEAST(2, 26, 0) */
             _pg_insobj(dict, "pos", obj);

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1380,12 +1380,15 @@ dict_from_event(SDL_Event *event)
                 dict, "touch",
                 PyBool_FromLong((event->wheel.which == SDL_TOUCH_MOUSEID)));
 
-#if SDL_VERSION_ATLEAST(2, 26, 0)
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+            obj = pg_tuple_couple_from_values_int((int)event->wheel.mouse_x,
+                                                  (int)event->wheel.mouse_y);
+#elif SDL_VERSION_ATLEAST(2, 26, 0)
             obj = pg_tuple_couple_from_values_int((int)event->wheel.mouseX,
                                                   (int)event->wheel.mouseY);
 #else
             obj = pg_tuple_couple_from_values_int(0, 0);
-#endif
+#endif /* SDL_VERSION_ATLEAST(2, 26, 0) */
             _pg_insobj(dict, "pos", obj);
 
             break;

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1387,7 +1387,7 @@ dict_from_event(SDL_Event *event)
             obj = pg_tuple_couple_from_values_int((int)event->wheel.mouseX,
                                                   (int)event->wheel.mouseY);
 #else
-        obj = pg_tuple_couple_from_values_int(0, 0);
+        obj = Py_None;
 #endif /* SDL_VERSION_ATLEAST(2, 26, 0) */
             _pg_insobj(dict, "pos", obj);
 

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1380,6 +1380,14 @@ dict_from_event(SDL_Event *event)
                 dict, "touch",
                 PyBool_FromLong((event->wheel.which == SDL_TOUCH_MOUSEID)));
 
+#if SDL_VERSION_ATLEAST(2, 0, 26)
+            obj = pg_tuple_couple_from_values_int((int)event->wheel.mouseX,
+                                                  (int)event->wheel.mouseY);
+#else
+            obj = pg_tuple_couple_from_values_int(0, 0);
+#endif
+            _pg_insobj(dict, "pos", obj);
+
             break;
         case SDL_TEXTINPUT:
             /* https://wiki.libsdl.org/SDL_TextInputEvent */

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1388,6 +1388,8 @@ dict_from_event(SDL_Event *event)
                                                   (int)event->wheel.mouseY);
 #else
         obj = Py_None;
+        Py_INCREF(obj);
+
 #endif /* SDL_VERSION_ATLEAST(2, 26, 0) */
             _pg_insobj(dict, "pos", obj);
 


### PR DESCRIPTION
Up to now, if the position where a MOUSEWHEEL event happends is required, a user has to either fall back on the additionally created MOUSEBUTTON events, or poll the mouse position manually.

Position information in the MOUSEWHEEL event was added with SDL 2.0.26. In case pygame was built with an SDL version older than 2.0.26, the `pos` value will be `None`.