### PR TITLE
Fix gcc16 -Werror compile issues

### DIFF
--- a/src_c/font.h
+++ b/src_c/font.h
@@ -1,6 +1,8 @@
 #ifndef PGFONT_INTERNAL_H
 #define PGFONT_INTERNAL_H
 
+#include <Python.h>
+
 #ifdef PG_SDL3
 #include <SDL3_ttf/SDL_ttf.h>
 

--- a/src_c/include/pygame_font.h
+++ b/src_c/include/pygame_font.h
@@ -20,7 +20,6 @@
     pete@shinners.org
 */
 
-#include <Python.h>
 #include "pgplatform.h"
 
 struct TTF_Font;

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -22,6 +22,8 @@
 
 #include <stddef.h>
 
+#include "pygame.h"
+
 #include "palette.h"
 
 #include "pgcompat.h"
@@ -38,8 +40,6 @@ typedef enum {
 } _pc_view_kind_t;
 
 #if !defined(BUILD_STATIC)
-
-#include "pygame.h"
 
 static int
 _validate_view_format(const char *format)
@@ -275,6 +275,12 @@ _copy_colorplane(Py_buffer *view_p, SDL_Surface *surf,
     PG_PixelFormat *format;
     SDL_Palette *palette;
 
+    if (pixelsize > 4 || pixelsize <= 0) {
+        PyErr_Format(PyExc_ValueError, "Unsupported bytes per pixel: %d",
+                     pixelsize);
+        return -1;
+    }
+
     if (view_p->shape[0] != w || view_p->shape[1] != h) {
         PyErr_Format(PyExc_ValueError,
                      "Expected a (%d, %d) target: got (%d, %d)", w, h,
@@ -390,6 +396,12 @@ _copy_unmapped(Py_buffer *view_p, SDL_Surface *surf)
     Py_intptr_t x, y, z;
     _pc_pixel_t pixel = {0};
     Uint8 r, g, b;
+
+    if (pixelsize > 4 || pixelsize <= 0) {
+        PyErr_Format(PyExc_ValueError, "Unsupported bytes per pixel: %d",
+                     pixelsize);
+        return -1;
+    }
 
     if (view_p->shape[0] != w || view_p->shape[1] != h ||
         view_p->shape[2] != 3) {

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -20,17 +20,11 @@
 */
 
 /* Handle clipboard text and data in arbitrary formats */
-#include <limits.h>
-#include <stdio.h>
+#include "pygame.h"
 
-#ifdef PG_SDL3
-#include <SDL3/SDL.h>
-#else
-#include <SDL.h>
+#ifndef PG_SDL3
 #include "SDL_syswm.h"
 #endif
-
-#include "pygame.h"
 
 #include "pgcompat.h"
 

--- a/src_c/surface.h
+++ b/src_c/surface.h
@@ -29,12 +29,6 @@
 #undef _POSIX_C_SOURCE
 #endif
 
-#ifdef PG_SDL3
-#include <SDL3/SDL.h>
-#else
-#include <SDL.h>
-#endif
-
 #include "pygame.h"
 #if !defined(BUILD_STATIC)
 /* Blend modes */


### PR DESCRIPTION
PR to fix the Fedora 44 compile time issues initially reported by @DickerDackel on discord. Fedora 44 is the first major distro to ship with the latest GCC 16. This new GCC version now raises more warnings which become errors in `dev.py install`. 

This PR reorganizes some includes to ensure that `Python.h` is always included first. This fixes `_XOPEN_SOUCE`/`_POSIX_C_SOURCE` macro redefinition issues. It also adds extra error checking in one place for bpp to silence new size warnings.