### PR TITLE
Start using Py_NewRef in a few modules

### DIFF
--- a/src_c/color.c
+++ b/src_c/color.c
@@ -1625,8 +1625,7 @@ _color_add(PyObject *obj1, PyObject *obj2)
     pgColorObject *color1 = (pgColorObject *)obj1;
     pgColorObject *color2 = (pgColorObject *)obj2;
     if (!pgColor_Check(obj1) || !pgColor_Check(obj2)) {
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
+        return Py_NewRef(Py_NotImplemented);
     }
     rgba[0] = MIN(color1->data[0] + color2->data[0], 255);
     rgba[1] = MIN(color1->data[1] + color2->data[1], 255);
@@ -1645,8 +1644,7 @@ _color_sub(PyObject *obj1, PyObject *obj2)
     pgColorObject *color1 = (pgColorObject *)obj1;
     pgColorObject *color2 = (pgColorObject *)obj2;
     if (!pgColor_Check(obj1) || !pgColor_Check(obj2)) {
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
+        return Py_NewRef(Py_NotImplemented);
     }
     rgba[0] = MAX(color1->data[0] - color2->data[0], 0);
     rgba[1] = MAX(color1->data[1] - color2->data[1], 0);
@@ -1665,8 +1663,7 @@ _color_mul(PyObject *obj1, PyObject *obj2)
     pgColorObject *color1 = (pgColorObject *)obj1;
     pgColorObject *color2 = (pgColorObject *)obj2;
     if (!pgColor_Check(obj1) || !pgColor_Check(obj2)) {
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
+        return Py_NewRef(Py_NotImplemented);
     }
     rgba[0] = MIN(color1->data[0] * color2->data[0], 255);
     rgba[1] = MIN(color1->data[1] * color2->data[1], 255);
@@ -1685,8 +1682,7 @@ _color_div(PyObject *obj1, PyObject *obj2)
     pgColorObject *color1 = (pgColorObject *)obj1;
     pgColorObject *color2 = (pgColorObject *)obj2;
     if (!pgColor_Check(obj1) || !pgColor_Check(obj2)) {
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
+        return Py_NewRef(Py_NotImplemented);
     }
     if (color2->data[0] != 0) {
         rgba[0] = color1->data[0] / color2->data[0];
@@ -1713,8 +1709,7 @@ _color_mod(PyObject *obj1, PyObject *obj2)
     pgColorObject *color1 = (pgColorObject *)obj1;
     pgColorObject *color2 = (pgColorObject *)obj2;
     if (!pgColor_Check(obj1) || !pgColor_Check(obj2)) {
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
+        return Py_NewRef(Py_NotImplemented);
     }
     if (color2->data[0] != 0) {
         rgba[0] = color1->data[0] % color2->data[0];
@@ -2099,8 +2094,7 @@ _color_richcompare(PyObject *o1, PyObject *o2, int opid)
     }
 
 Unimplemented:
-    Py_INCREF(Py_NotImplemented);
-    return Py_NotImplemented;
+    return Py_NewRef(Py_NotImplemented);
 }
 
 static int
@@ -2138,8 +2132,7 @@ _color_getbuffer(pgColorObject *color, Py_buffer *view, int flags)
         view->strides = 0;
     }
     view->suboffsets = 0;
-    Py_INCREF(color);
-    view->obj = (PyObject *)color;
+    view->obj = Py_NewRef(color);
     return 0;
 }
 

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -807,8 +807,7 @@ vector_generic_math(PyObject *o1, PyObject *o2, int op)
             break;
         default:
             Py_XDECREF(ret);
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
+            return Py_NewRef(Py_NotImplemented);
     }
     return (PyObject *)ret;
 }
@@ -1402,8 +1401,7 @@ vector_richcompare(PyObject *o1, PyObject *o2, int op)
             Py_RETURN_TRUE;
         }
         else {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
+            return Py_NewRef(Py_NotImplemented);
         }
     }
 
@@ -3930,8 +3928,7 @@ vector_elementwiseproxy_richcompare(PyObject *o1, PyObject *o2, int op)
         }
     }
     else {
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
+        return Py_NewRef(Py_NotImplemented);
     }
 
     return PyBool_FromLong(ret);
@@ -4213,15 +4210,13 @@ vector_elementwiseproxy_pow(PyObject *baseObj, PyObject *expoObj,
             }
         }
         else if (RealNumber_Check(expoObj)) {
-            /* INCREF so that we can unify the clean up code */
+            /* NEWREF so that we can unify the clean up code */
             for (i = 0; i < dim; i++) {
-                expos[i] = expoObj;
-                Py_INCREF(expoObj);
+                expos[i] = Py_NewRef(expoObj);
             }
         }
         else {
-            Py_INCREF(Py_NotImplemented);
-            ret = Py_NotImplemented;
+            ret = Py_NewRef(Py_NotImplemented);
             goto clean_up;
         }
     }
@@ -4238,15 +4233,13 @@ vector_elementwiseproxy_pow(PyObject *baseObj, PyObject *expoObj,
             }
         }
         else if (RealNumber_Check(baseObj)) {
-            /* INCREF so that we can unify the clean up code */
+            /* NEWREF so that we can unify the clean up code */
             for (i = 0; i < dim; i++) {
-                bases[i] = baseObj;
-                Py_INCREF(baseObj);
+                bases[i] = Py_NewRef(baseObj);
             }
         }
         else {
-            Py_INCREF(Py_NotImplemented);
-            ret = Py_NotImplemented;
+            ret = Py_NewRef(Py_NotImplemented);
             goto clean_up;
         }
     }
@@ -4398,8 +4391,7 @@ math_clamp(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     // if value < min: return min
     int result = PyObject_RichCompareBool(value, min, Py_LT);
     if (result == 1) {
-        Py_INCREF(min);
-        return min;
+        return Py_NewRef(min);
     }
     else if (result == -1) {
         return NULL;
@@ -4408,15 +4400,13 @@ math_clamp(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     // if value > max: return max
     result = PyObject_RichCompareBool(value, max, Py_GT);
     if (result == 1) {
-        Py_INCREF(max);
-        return max;
+        return Py_NewRef(max);
     }
     else if (result == -1) {
         return NULL;
     }
 
-    Py_INCREF(value);
-    return value;
+    return Py_NewRef(value);
 }
 
 #define RAISE_ARG_TYPE_ERROR(var)                                     \

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1220,8 +1220,7 @@ surf_get_locks(PyObject *self, PyObject *_null)
             return NULL;
         }
         if (weakref_getref_result == 0) {
-            tmp = Py_None;
-            Py_INCREF(tmp);
+            tmp = Py_NewRef(Py_None);
         }
         PyTuple_SetItem(tuple, i, tmp);
     }
@@ -3272,8 +3271,7 @@ surf_subsurface(PyObject *self, PyObject *args)
         PyMem_Free(data);
         return NULL;
     }
-    Py_INCREF(self);
-    data->owner = self;
+    data->owner = Py_NewRef(self);
     data->offsetx = rect->x;
     data->offsety = rect->y;
     ((pgSurfaceObject *)subobj)->subsurface = data;
@@ -3338,8 +3336,7 @@ surf_get_parent(PyObject *self, PyObject *_null)
         Py_RETURN_NONE;
     }
 
-    Py_INCREF(subdata->owner);
-    return subdata->owner;
+    return Py_NewRef(subdata->owner);
 }
 
 static PyObject *
@@ -3353,8 +3350,7 @@ surf_get_abs_parent(PyObject *self, PyObject *_null)
 
     subdata = ((pgSurfaceObject *)self)->subsurface;
     if (!subdata) {
-        Py_INCREF(self);
-        return self;
+        return Py_NewRef(self);
     }
 
     subdata = ((pgSurfaceObject *)self)->subsurface;
@@ -3365,8 +3361,7 @@ surf_get_abs_parent(PyObject *self, PyObject *_null)
         owner = subdata->owner;
     }
 
-    Py_INCREF(owner);
-    return owner;
+    return Py_NewRef(owner);
 }
 
 static PyObject *
@@ -3784,8 +3779,7 @@ surf_premul_alpha_ip(pgSurfaceObject *self, PyObject *_null)
     SURF_INIT_CHECK(surf)
 
     if (!surf->w || !surf->h) {
-        Py_INCREF(self);
-        return (PyObject *)self;
+        return Py_NewRef(self);
     }
 
     pgSurface_Prep(self);
@@ -3802,8 +3796,7 @@ surf_premul_alpha_ip(pgSurfaceObject *self, PyObject *_null)
 
     pgSurface_Unprep(self);
 
-    Py_INCREF(self);
-    return (PyObject *)self;
+    return Py_NewRef(self);
 }
 
 static int
@@ -3829,8 +3822,7 @@ _get_buffer_0D(PyObject *obj, Py_buffer *view_p, int flags)
             view_p->strides[0] = view_p->itemsize;
         }
     }
-    Py_INCREF(obj);
-    view_p->obj = obj;
+    view_p->obj = Py_NewRef(obj);
     return 0;
 }
 
@@ -3887,8 +3879,7 @@ _get_buffer_1D(PyObject *obj, Py_buffer *view_p, int flags)
         }
     }
     view_p->suboffsets = 0;
-    Py_INCREF(obj);
-    view_p->obj = obj;
+    view_p->obj = Py_NewRef(obj);
     return 0;
 }
 
@@ -3973,8 +3964,7 @@ _get_buffer_2D(PyObject *obj, Py_buffer *view_p, int flags)
     view_p->strides[0] = itemsize;
     view_p->strides[1] = surface->pitch;
     view_p->suboffsets = 0;
-    Py_INCREF(obj);
-    view_p->obj = obj;
+    view_p->obj = Py_NewRef(obj);
     return 0;
 }
 
@@ -4057,8 +4047,7 @@ _get_buffer_3D(PyObject *obj, Py_buffer *view_p, int flags)
 #endif /* SDL_BYTEORDER != SDL_LIL_ENDIAN */
     }
     view_p->buf = startpixel;
-    Py_INCREF(obj);
-    view_p->obj = obj;
+    view_p->obj = Py_NewRef(obj);
     return 0;
 }
 
@@ -4196,8 +4185,7 @@ _get_buffer_colorplane(PyObject *obj, Py_buffer *view_p, int flags, char *name,
     view_p->shape[1] = surface->h;
     view_p->strides[0] = pixelsize;
     view_p->strides[1] = surface->pitch;
-    Py_INCREF(obj);
-    view_p->obj = obj;
+    view_p->obj = Py_NewRef(obj);
     return 0;
 }
 

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -130,8 +130,7 @@ get_grabbed_window(PyObject *self, PyObject *_null)
         if (!win_obj) {
             Py_RETURN_NONE;
         }
-        Py_INCREF(win_obj);
-        return win_obj;
+        return Py_NewRef(win_obj);
     }
     Py_RETURN_NONE;
 }
@@ -177,8 +176,7 @@ window_get_surface(pgWindowObject *self, PyObject *_null)
             return RAISE(pgExc_SDLError,
                          "display.set_mode has not been called yet.");
         }
-        Py_INCREF(surf);
-        return surf;
+        return Py_NewRef(surf);
     }
 
     _surf = SDL_GetWindowSurface(self->_win);
@@ -198,8 +196,7 @@ window_get_surface(pgWindowObject *self, PyObject *_null)
     }
     self->surf->surf = _surf;
 
-    Py_INCREF(self->surf);
-    return (PyObject *)self->surf;
+    return Py_NewRef(self->surf);
 }
 
 static PyObject *
@@ -1395,8 +1392,7 @@ window_from_display_module(PyTypeObject *cls, PyObject *_null)
 
     pgWindowObject *self = (pgWindowObject *)pg_get_pg_window(window);
     if (self != NULL) {
-        Py_INCREF(self);
-        return (PyObject *)self;
+        return Py_NewRef(self);
     }
 
     self = (pgWindowObject *)(cls->tp_new(cls, NULL, NULL));


### PR DESCRIPTION
When looking at ref counting https://github.com/pygame-community/pygame-ce/pull/3783, I was surprised to see we don't use Py_NewRef at all throughout our codebase.

Docs: https://docs.python.org/3/c-api/refcounting.html#c.Py_NewRef

Instead of assigning something and then incref-ing it, we can use newref inline to return a new reference to the object. Which is the same thing, just more concise. I checked the generated assembly with my `add_global_arguments('/FAcsu', language: 'c')` trick for MSVC, I did not see any meaningful change in the generated output.

It seems that this is the preferred way of doing things in CPython internally now: https://github.com/python/cpython/issues/99300