### PR TITLE
Fix typo in sndarray.py docstring

### DIFF
--- a/src_py/sndarray.py
+++ b/src_py/sndarray.py
@@ -22,7 +22,7 @@
 
 Functions to convert between NumPy arrays and Sound objects. This module
 will only be functional when pygame can use the external NumPy package.
-If NumPy can't be imported, surfarray becomes a MissingModule object.
+If NumPy can't be imported, sndarray becomes a MissingModule object.
 
 Sound data is made of thousands of samples per second, and each sample
 is the amplitude of the wave at a particular moment in time. For


### PR DESCRIPTION
Change 'surfarray' to 'sndarray' in module docstring