### PR TITLE
Fix incorrect 24bit writes

### DIFF
--- a/buildconfig/stubs/pygame/transform.pyi
+++ b/buildconfig/stubs/pygame/transform.pyi
@@ -420,6 +420,9 @@ def threshold(
     .. versionaddedold:: 1.8
     .. versionchangedold:: 1.9.4
         Fixed a lot of bugs and added keyword arguments. Test your code.
+    .. versionchanged:: 2.5.8
+        Fixed ``set_color`` writing the wrong channels on 24-bit destination
+        surfaces whose byte layout did not match the platform default.
     """
 
 def hsl(

--- a/docs/reST/ref/pixelarray.rst
+++ b/docs/reST/ref/pixelarray.rst
@@ -137,6 +137,10 @@
    .. versionaddedold: 1.9.4
       Methods :meth:`close`
 
+   .. versionchanged:: 2.5.8
+      Fixed incorrect color matching and writing on 24-bit surfaces whose
+      byte layout did not match the platform default.
+
    .. attribute:: surface
 
       | :sl:`Gets the Surface the PixelArray uses.`
@@ -223,6 +227,10 @@
       PixelArray.
 
       .. versionaddedold:: 1.8.1
+
+      .. versionchanged:: 2.5.8
+         Fixed incorrect color matching and writing on 24-bit surfaces whose
+         byte layout did not match the platform default.
 
       .. ## PixelArray.replace ##
 

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -1164,22 +1164,19 @@ _array_assign_sequence(pgPixelArrayObject *array, Py_ssize_t low,
             }
             break;
         case 3: {
-#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-            Uint32 Roffset = surf_format->Rshift >> 3;
-            Uint32 Goffset = surf_format->Gshift >> 3;
-            Uint32 Boffset = surf_format->Bshift >> 3;
-#else
-            Uint32 Roffset = 2 - (surf_format->Rshift >> 3);
-            Uint32 Goffset = 2 - (surf_format->Gshift >> 3);
-            Uint32 Boffset = 2 - (surf_format->Bshift >> 3);
-#endif
             for (y = 0; y < dim1; ++y) {
                 pixel_p = pixelrow;
                 val_color_p = val_colors;
                 for (x = 0; x < dim0; ++x) {
-                    pixel_p[Roffset] = (Uint8)(*val_color_p >> 16);
-                    pixel_p[Goffset] = (Uint8)(*val_color_p >> 8);
-                    pixel_p[Boffset] = (Uint8)*val_color_p;
+#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
+                    pixel_p[0] = (Uint8)*val_color_p;
+                    pixel_p[1] = (Uint8)(*val_color_p >> 8);
+                    pixel_p[2] = (Uint8)(*val_color_p >> 16);
+#else
+                    pixel_p[0] = (Uint8)(*val_color_p >> 16);
+                    pixel_p[1] = (Uint8)(*val_color_p >> 8);
+                    pixel_p[2] = (Uint8)*val_color_p;
+#endif
                     pixel_p += stride0;
                     ++val_color_p;
                 }
@@ -1261,25 +1258,18 @@ _array_assign_slice(pgPixelArrayObject *array, Py_ssize_t low, Py_ssize_t high,
             }
         } break;
         case 3: {
-#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-            Uint32 Roffset = surf_format->Rshift >> 3;
-            Uint32 Goffset = surf_format->Gshift >> 3;
-            Uint32 Boffset = surf_format->Bshift >> 3;
-#else
-            Uint32 Roffset = 2 - (surf_format->Rshift >> 3);
-            Uint32 Goffset = 2 - (surf_format->Gshift >> 3);
-            Uint32 Boffset = 2 - (surf_format->Bshift >> 3);
-#endif
-            Uint8 r = (Uint8)(color >> 16);
-            Uint8 g = (Uint8)(color >> 8);
-            Uint8 b = (Uint8)(color);
-
             for (y = 0; y < dim1; ++y) {
                 pixel_p = pixelrow;
                 for (x = 0; x < dim0; ++x) {
-                    pixel_p[Roffset] = r;
-                    pixel_p[Goffset] = g;
-                    pixel_p[Boffset] = b;
+#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
+                    pixel_p[0] = (Uint8)color;
+                    pixel_p[1] = (Uint8)(color >> 8);
+                    pixel_p[2] = (Uint8)(color >> 16);
+#else
+                    pixel_p[0] = (Uint8)(color >> 16);
+                    pixel_p[1] = (Uint8)(color >> 8);
+                    pixel_p[2] = (Uint8)color;
+#endif
                     pixel_p += stride0;
                 }
                 pixelrow += stride1;
@@ -1395,19 +1385,16 @@ _pxarray_ass_item(pgPixelArrayObject *array, Py_ssize_t index, PyObject *value)
             }
             break;
         case 3: {
-#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-            Uint32 Roffset = surf_format->Rshift >> 3;
-            Uint32 Goffset = surf_format->Gshift >> 3;
-            Uint32 Boffset = surf_format->Bshift >> 3;
-#else
-            Uint32 Roffset = 2 - (surf_format->Rshift >> 3);
-            Uint32 Goffset = 2 - (surf_format->Gshift >> 3);
-            Uint32 Boffset = 2 - (surf_format->Bshift >> 3);
-#endif
             for (y = 0; y < dim1; ++y) {
-                pixel_p[Roffset] = (Uint8)(color >> 16);
-                pixel_p[Goffset] = (Uint8)(color >> 8);
-                pixel_p[Boffset] = (Uint8)color;
+#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
+                pixel_p[0] = (Uint8)color;
+                pixel_p[1] = (Uint8)(color >> 8);
+                pixel_p[2] = (Uint8)(color >> 16);
+#else
+                pixel_p[0] = (Uint8)(color >> 16);
+                pixel_p[1] = (Uint8)(color >> 8);
+                pixel_p[2] = (Uint8)color;
+#endif
                 pixel_p += stride1;
             }
             break;

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -450,15 +450,6 @@ _replace_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
             }
         } break;
         case 3: {
-#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-            Uint32 Roffset = format->Rshift >> 3;
-            Uint32 Goffset = format->Gshift >> 3;
-            Uint32 Boffset = format->Bshift >> 3;
-#else
-            Uint32 Roffset = 2 - (format->Rshift >> 3);
-            Uint32 Goffset = 2 - (format->Gshift >> 3);
-            Uint32 Boffset = 2 - (format->Bshift >> 3);
-#endif
             Uint32 pxcolor;
             int ppa =
                 (SDL_ISPIXELFORMAT_ALPHA(format->format) && format->Amask);
@@ -466,23 +457,39 @@ _replace_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
             for (y = 0; y < dim1; ++y) {
                 pixel_p = pixelrow;
                 for (x = 0; x < dim0; ++x) {
-                    pxcolor = (((Uint32)pixel_p[Roffset] << 16) +
-                               ((Uint32)pixel_p[Goffset] << 8) +
-                               ((Uint32)pixel_p[Boffset]));
+#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
+                    pxcolor = pixel_p[0] | ((Uint32)pixel_p[1] << 8) |
+                              ((Uint32)pixel_p[2] << 16);
+#else
+                    pxcolor = pixel_p[2] | ((Uint32)pixel_p[1] << 8) |
+                              ((Uint32)pixel_p[0] << 16);
+#endif
                     if (distance != 0.0) {
                         GET_PIXELVALS(r2, g2, b2, a2, pxcolor, format, palette,
                                       ppa);
                         if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2,
                                            b2) <= distance) {
-                            pixel_p[Roffset] = (Uint8)(rcolor >> 16);
-                            pixel_p[Goffset] = (Uint8)(rcolor >> 8);
-                            pixel_p[Boffset] = (Uint8)rcolor;
+#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
+                            pixel_p[0] = (Uint8)rcolor;
+                            pixel_p[1] = (Uint8)(rcolor >> 8);
+                            pixel_p[2] = (Uint8)(rcolor >> 16);
+#else
+                            pixel_p[0] = (Uint8)(rcolor >> 16);
+                            pixel_p[1] = (Uint8)(rcolor >> 8);
+                            pixel_p[2] = (Uint8)rcolor;
+#endif
                         }
                     }
                     else if (pxcolor == dcolor) {
-                        pixel_p[Roffset] = (Uint8)(rcolor >> 16);
-                        pixel_p[Goffset] = (Uint8)(rcolor >> 8);
-                        pixel_p[Boffset] = (Uint8)rcolor;
+#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
+                        pixel_p[0] = (Uint8)rcolor;
+                        pixel_p[1] = (Uint8)(rcolor >> 8);
+                        pixel_p[2] = (Uint8)(rcolor >> 16);
+#else
+                        pixel_p[0] = (Uint8)(rcolor >> 16);
+                        pixel_p[1] = (Uint8)(rcolor >> 8);
+                        pixel_p[2] = (Uint8)rcolor;
+#endif
                     }
                     pixel_p += stride0;
                 }

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1819,13 +1819,13 @@ _set_at_pixels(int x, int y, Uint8 *pixels, PG_PixelFormat *format,
         case 3:
             byte_buf = (Uint8 *)(pixels + y * surf_pitch) + x * 3;
 #if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-            *(byte_buf + (format->Rshift >> 3)) = (Uint8)(the_color >> 16);
-            *(byte_buf + (format->Gshift >> 3)) = (Uint8)(the_color >> 8);
-            *(byte_buf + (format->Bshift >> 3)) = (Uint8)the_color;
+            byte_buf[0] = (Uint8)(the_color);
+            byte_buf[1] = (Uint8)(the_color >> 8);
+            byte_buf[2] = (Uint8)(the_color >> 16);
 #else
-            *(byte_buf + 2 - (format->Rshift >> 3)) = (Uint8)(the_color >> 16);
-            *(byte_buf + 2 - (format->Gshift >> 3)) = (Uint8)(the_color >> 8);
-            *(byte_buf + 2 - (format->Bshift >> 3)) = (Uint8)the_color;
+            byte_buf[0] = (Uint8)(the_color >> 16);
+            byte_buf[1] = (Uint8)(the_color >> 8);
+            byte_buf[2] = (Uint8)(the_color);
 #endif
             break;
         default: /* case 4: */

--- a/test/pixelarray_test.py
+++ b/test/pixelarray_test.py
@@ -1330,7 +1330,7 @@ class PixelArrayTypeTest(unittest.TestCase, TestMixin):
     def test_set_pixel_24bit_formats(self):
         """Pixel assignment must write the correct channels on both RGB24 and BGR24.
 
-        On little-endian SDL, RGB24 has Rmask=0xFF (R at byte 0) while the
+        On little-endian systems, RGB24 has Rmask=0xFF (R at byte 0) while the
         default pygame.Surface(..., 24) produces BGR24 (Rmask=0xFF0000, R at
         byte 2).  The old _array_assign_index code assumed the mapped color was
         always 0x00RRGGBB, which silently worked for BGR24 but swapped R and B

--- a/test/pixelarray_test.py
+++ b/test/pixelarray_test.py
@@ -1327,6 +1327,90 @@ class PixelArrayTypeTest(unittest.TestCase, TestMixin):
         with self.assertRaises(ValueError):
             test[400, 400] = [255, 255, 0]
 
+    def test_set_pixel_24bit_formats(self):
+        """Pixel assignment must write the correct channels on both RGB24 and BGR24.
+
+        On little-endian SDL, RGB24 has Rmask=0xFF (R at byte 0) while the
+        default pygame.Surface(..., 24) produces BGR24 (Rmask=0xFF0000, R at
+        byte 2).  The old _array_assign_index code assumed the mapped color was
+        always 0x00RRGGBB, which silently worked for BGR24 but swapped R and B
+        for RGB24.
+        """
+        color = (200, 100, 50)
+        masks_and_names = [
+            ((0xFF, 0xFF00, 0xFF0000, 0), "RGB24"),
+            ((0xFF0000, 0xFF00, 0xFF, 0), "BGR24"),
+        ]
+        for masks, name in masks_and_names:
+            with self.subTest(format=name):
+                sf = pygame.Surface((4, 4), depth=24, masks=masks)
+                sf.fill((0, 0, 0))
+                ar = pygame.PixelArray(sf)
+                ar[1][2] = color
+                del ar
+                self.assertEqual(sf.get_at((1, 2))[:3], color)
+
+    def test_set_slice_24bit_formats(self):
+        """Slice assignment with a single color must write correctly on RGB24 and BGR24."""
+        color = (200, 100, 50)
+        masks_and_names = [
+            ((0xFF, 0xFF00, 0xFF0000, 0), "RGB24"),
+            ((0xFF0000, 0xFF00, 0xFF, 0), "BGR24"),
+        ]
+        for masks, name in masks_and_names:
+            with self.subTest(format=name):
+                sf = pygame.Surface((4, 4), depth=24, masks=masks)
+                sf.fill((0, 0, 0))
+                ar = pygame.PixelArray(sf)
+                ar[0:2] = color
+                del ar
+                self.assertEqual(sf.get_at((0, 0))[:3], color)
+                self.assertEqual(sf.get_at((1, 3))[:3], color)
+                self.assertEqual(sf.get_at((2, 0))[:3], (0, 0, 0))
+
+    def test_set_sequence_24bit_formats(self):
+        """Slice assignment with a color list must write correctly on RGB24 and BGR24."""
+        color_a = (200, 100, 50)
+        color_b = (10, 20, 30)
+        masks_and_names = [
+            ((0xFF, 0xFF00, 0xFF0000, 0), "RGB24"),
+            ((0xFF0000, 0xFF00, 0xFF, 0), "BGR24"),
+        ]
+        for masks, name in masks_and_names:
+            with self.subTest(format=name):
+                sf = pygame.Surface((4, 4), depth=24, masks=masks)
+                sf.fill((0, 0, 0))
+                ar = pygame.PixelArray(sf)
+                ar[0:2] = [color_a, color_b]
+                del ar
+                self.assertEqual(sf.get_at((0, 0))[:3], color_a)
+                self.assertEqual(sf.get_at((1, 0))[:3], color_b)
+
+    def test_replace_24bit_formats(self):
+        """PixelArray.replace must match and write the correct channels on RGB24 and BGR24."""
+        old_color = (200, 100, 50)
+        new_color = (10, 20, 30)
+        masks_and_names = [
+            ((0xFF, 0xFF00, 0xFF0000, 0), "RGB24"),
+            ((0xFF0000, 0xFF00, 0xFF, 0), "BGR24"),
+        ]
+        for masks, name in masks_and_names:
+            with self.subTest(format=name):
+                sf = pygame.Surface((4, 4), depth=24, masks=masks)
+                sf.fill(old_color)
+                ar = pygame.PixelArray(sf)
+                ar.replace(old_color, new_color)
+                del ar
+                self.assertEqual(sf.get_at((0, 0))[:3], new_color)
+                self.assertEqual(sf.get_at((3, 3))[:3], new_color)
+
+                # distance-based variant
+                sf.fill(old_color)
+                ar = pygame.PixelArray(sf)
+                ar.replace(old_color, new_color, distance=0.1)
+                del ar
+                self.assertEqual(sf.get_at((0, 0))[:3], new_color)
+
 
 @unittest.skipIf(IS_PYPY, "pypy having issues")
 class PixelArrayArrayInterfaceTest(unittest.TestCase, TestMixin):

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -957,7 +957,7 @@ class TransformModuleTest(unittest.TestCase):
     def test_threshold_set_color_24bit(self):
         """set_color channels must round-trip correctly on both RGB24 and BGR24 surfaces.
 
-        On little-endian SDL, SDL_PIXELFORMAT_RGB24 has Rmask=0xFF (R at byte 0)
+        On little-endian systems, SDL_PIXELFORMAT_RGB24 has Rmask=0xFF (R at byte 0)
         and SDL_PIXELFORMAT_BGR24 has Rmask=0xFF0000 (R at byte 2).  The old
         _set_at_pixels code assumed the_color was always packed 0x00RRGGBB, which
         happened to be correct for BGR24 but swapped R and B for RGB24.

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -954,6 +954,35 @@ class TransformModuleTest(unittest.TestCase):
 
         self.assertEqual(result.get_at((0, 0)), diff_color)
 
+    def test_threshold_set_color_24bit(self):
+        """set_color channels must round-trip correctly on both RGB24 and BGR24 surfaces.
+
+        On little-endian SDL, SDL_PIXELFORMAT_RGB24 has Rmask=0xFF (R at byte 0)
+        and SDL_PIXELFORMAT_BGR24 has Rmask=0xFF0000 (R at byte 2).  The old
+        _set_at_pixels code assumed the_color was always packed 0x00RRGGBB, which
+        happened to be correct for BGR24 but swapped R and B for RGB24.
+        """
+        masks_and_names = [
+            ((0xFF, 0xFF00, 0xFF0000, 0), "RGB24"),
+            ((0xFF0000, 0xFF00, 0xFF, 0), "BGR24"),
+        ]
+        set_color = (255, 0, 0)
+        for masks, name in masks_and_names:
+            with self.subTest(format=name):
+                surf = pygame.Surface((4, 4), depth=24, masks=masks)
+                surf.fill((0, 0, 0))
+                result = pygame.Surface((4, 4), depth=24, masks=masks)
+                pygame.transform.threshold(
+                    dest_surface=result,
+                    surface=surf,
+                    search_color=(0, 0, 0),
+                    threshold=(1, 1, 1),
+                    set_color=set_color,
+                    set_behavior=1,
+                    inverse_set=True,
+                )
+                self.assertEqual(result.get_at((0, 0))[:3], set_color)
+
     def test_threshold__uneven_colors(self):
         (w, h) = size = (16, 16)
 


### PR DESCRIPTION
Closes #3702

Originally assigned to Matt, but it was dormant with no activity for 3 months so I took it over.

This PR fixes incorrect handling of certain 24 bit surfaces when written to by transform.threshold, PixelArray.replace, and PixelArray[...] = ...

I did research in the original issue (thanks again to Kyuchumimo for reporting), and then I used Claude to implement the code fixes and tests, along with asking it to find other instances of the problem (pixelarray stuff).

I then wrote a verification script by hand as well, to demonstrate the changes.

<details><summary>Script</summary>

```py
import pygame
pygame.init()

surfs = []

# RGB/BGR names are confusing here. I believe what we would intuitively call 
# BGR would be RGB24 in SDL pixelformat parlance

surfs.append((pygame.Surface((100,100), depth=24, masks=(0xFF, 0xFF00, 0xFF0000, 0)), "rgb24"))
surfs.append((pygame.Surface((100,100), depth=24, masks=(0xFF0000, 0xFF00, 0xFF, 0)), "bgr24"))
surfs.append((pygame.Surface((100,100), depth=32), "32bit"))

def test_pixelarray_replace():
    print("Testing replace()")

    for surf, name in surfs:
        print(name, surf, surf.get_shifts())

        surf.fill("red")

        with pygame.PixelArray(surf) as px:
            px.replace(pygame.Color("red"), (40,60,80))

        print(surf.get_at((0,0)), surf.get_at((0,0)) == (40,60,80))
    print()


def test_pixelarray_assign_sequence():
    print("Testing assign_sequence")

    for surf, name in surfs:
        print(name, surf, surf.get_shifts())

        surf.fill("red")

        with pygame.PixelArray(surf) as px:
            px[0:20] = [(40,60,80) for _ in range(20)]

        print(surf.get_at((0,0)), surf.get_at((0,0)) == (40,60,80))
    print()


def test_pixelarray_assign_slice():
    print("Testing assign_slice")

    for surf, name in surfs:
        print(name, surf, surf.get_shifts())

        surf.fill("red")

        with pygame.PixelArray(surf) as px:
            px[0:20] = (40,60,80)

        print(surf.get_at((0,0)), surf.get_at((0,0)) == (40,60,80))
    print()


def test_pixelarray_assign_item():
    print("Testing assign_item")

    for surf, name in surfs:
        print(name, surf, surf.get_shifts())

        surf.fill("red")

        with pygame.PixelArray(surf) as px:
            px[0] = (40,60,80)

        print(surf.get_at((0,0)), surf.get_at((0,0)) == (40,60,80))
    print()


def test_transform_threshold():
    print("Testing transform threshold")

    for surf, name in surfs:
        print(name, surf, surf.get_shifts())

        surf.fill("red")
        pygame.transform.threshold(surf, surf, "red", (0,0,0,0), (40,60,80), 1, None, True)
        print(surf.get_at((0,0)), surf.get_at((0,0)) == (40,60,80))
    print()

test_pixelarray_replace()
test_pixelarray_assign_sequence()
test_pixelarray_assign_slice()
test_pixelarray_assign_item()
test_transform_threshold()
```
</details>

<details><summary>Results on main</summary>

```
Testing replace()
rgb24 <Surface(100x100x24)> (0, 8, 16, 0)
Color(255, 0, 0, 255) False
bgr24 <Surface(100x100x24)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True
32bit <Surface(100x100x32)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True

Testing assign_sequence
rgb24 <Surface(100x100x24)> (0, 8, 16, 0)
Color(80, 60, 40, 255) False
bgr24 <Surface(100x100x24)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True
32bit <Surface(100x100x32)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True

Testing assign_slice
rgb24 <Surface(100x100x24)> (0, 8, 16, 0)
Color(80, 60, 40, 255) False
bgr24 <Surface(100x100x24)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True
32bit <Surface(100x100x32)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True

Testing assign_item
rgb24 <Surface(100x100x24)> (0, 8, 16, 0)
Color(80, 60, 40, 255) False
bgr24 <Surface(100x100x24)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True
32bit <Surface(100x100x32)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True

Testing transform threshold
rgb24 <Surface(100x100x24)> (0, 8, 16, 0)
Color(80, 60, 40, 255) False
bgr24 <Surface(100x100x24)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True
32bit <Surface(100x100x32)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True
```
</details>

<details><summary>Results on this branch</summary>

```
Testing replace()
rgb24 <Surface(100x100x24)> (0, 8, 16, 0)
Color(40, 60, 80, 255) True
bgr24 <Surface(100x100x24)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True
32bit <Surface(100x100x32)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True

Testing assign_sequence
rgb24 <Surface(100x100x24)> (0, 8, 16, 0)
Color(40, 60, 80, 255) True
bgr24 <Surface(100x100x24)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True
32bit <Surface(100x100x32)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True

Testing assign_slice
rgb24 <Surface(100x100x24)> (0, 8, 16, 0)
Color(40, 60, 80, 255) True
bgr24 <Surface(100x100x24)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True
32bit <Surface(100x100x32)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True

Testing assign_item
rgb24 <Surface(100x100x24)> (0, 8, 16, 0)
Color(40, 60, 80, 255) True
bgr24 <Surface(100x100x24)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True
32bit <Surface(100x100x32)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True

Testing transform threshold
rgb24 <Surface(100x100x24)> (0, 8, 16, 0)
Color(40, 60, 80, 255) True
bgr24 <Surface(100x100x24)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True
32bit <Surface(100x100x32)> (16, 8, 0, 0)
Color(40, 60, 80, 255) True
```
</details>

See how on main, when writing into a "rgb24" surface, the red and blue channels are swapped. The old code incorrectly assumes all 24 bit mapped colors are in the same format, the one that corresponds to the "bgr24" surface. But it's a mapped color, it's already laid out properly to move into the pixel buffer, no rearranging needed (expected for endianness).