### PR TITLE
Fix laplacian dst format and simplify 24bit writes

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1012,22 +1012,14 @@ surf_set_at(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
             break;
         case 3:
             byte_buf = (Uint8 *)(pixels + y * surf->pitch) + x * 3;
-            // Shouldn't this be able to happen without awareness of shifts?
-            // mapped color -> pixel and all.
 #if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-            *(byte_buf + (format->Rshift >> 3)) =
-                (Uint8)(color >> format->Rshift);
-            *(byte_buf + (format->Gshift >> 3)) =
-                (Uint8)(color >> format->Gshift);
-            *(byte_buf + (format->Bshift >> 3)) =
-                (Uint8)(color >> format->Bshift);
+            byte_buf[0] = (Uint8)(color);
+            byte_buf[1] = (Uint8)(color >> 8);
+            byte_buf[2] = (Uint8)(color >> 16);
 #else
-            *(byte_buf + 2 - (format->Rshift >> 3)) =
-                (Uint8)(color >> format->Rshift);
-            *(byte_buf + 2 - (format->Gshift >> 3)) =
-                (Uint8)(color >> format->Gshift);
-            *(byte_buf + 2 - (format->Bshift >> 3)) =
-                (Uint8)(color >> format->Bshift);
+            byte_buf[0] = (Uint8)(color >> 16);
+            byte_buf[1] = (Uint8)(color >> 8);
+            byte_buf[2] = (Uint8)(color);
 #endif
             break;
         default: /* case 4: */

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -2197,12 +2197,9 @@ clamp_4
         case 3:                                                          \
             p_byte_buf =                                                 \
                 (Uint8 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x) * 3; \
-            *(p_byte_buf + (p_format->Rshift >> 3)) =                    \
-                (Uint8)(p_color >> p_format->Rshift);                    \
-            *(p_byte_buf + (p_format->Gshift >> 3)) =                    \
-                (Uint8)(p_color >> p_format->Gshift);                    \
-            *(p_byte_buf + (p_format->Bshift >> 3)) =                    \
-                (Uint8)(p_color >> p_format->Bshift);                    \
+            p_byte_buf[0] = (Uint8)(p_color);                            \
+            p_byte_buf[1] = (Uint8)(p_color >> 8);                       \
+            p_byte_buf[2] = (Uint8)(p_color >> 16);                      \
             break;                                                       \
         default:                                                         \
             *((Uint32 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \
@@ -2226,12 +2223,9 @@ clamp_4
         case 3:                                                          \
             p_byte_buf =                                                 \
                 (Uint8 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x) * 3; \
-            *(p_byte_buf + 2 - (p_format->Rshift >> 3)) =                \
-                (Uint8)(p_color >> p_format->Rshift);                    \
-            *(p_byte_buf + 2 - (p_format->Gshift >> 3)) =                \
-                (Uint8)(p_color >> p_format->Gshift);                    \
-            *(p_byte_buf + 2 - (p_format->Bshift >> 3)) =                \
-                (Uint8)(p_color >> p_format->Bshift);                    \
+            p_byte_buf[0] = (Uint8)(p_color >> 16);                      \
+            p_byte_buf[1] = (Uint8)(p_color >> 8);                       \
+            p_byte_buf[2] = (Uint8)(p_color);                            \
             break;                                                       \
         default:                                                         \
             *((Uint32 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x)) =    \

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -2928,6 +2928,7 @@ laplacian(SDL_Surface *surf, PG_PixelFormat *format, SDL_Surface *destsurf,
     pixels = (Uint8 *)surf->pixels;
     destpixels = (Uint8 *)destsurf->pixels;
     SDL_Palette *surf_palette = PG_GetSurfacePalette(surf);
+    SDL_Palette *destsurf_palette = PG_GetSurfacePalette(destsurf);
 
     /*
         -1 -1 -1
@@ -3045,8 +3046,8 @@ laplacian(SDL_Surface *surf, PG_PixelFormat *format, SDL_Surface *destsurf,
 
             // cast on the right to Uint32, and then clamp to 255.
 
-            the_color = PG_MapRGBA(format, surf_palette, acolor[0], acolor[1],
-                                   acolor[2], acolor[3]);
+            the_color = PG_MapRGBA(destformat, destsurf_palette, acolor[0],
+                                   acolor[1], acolor[2], acolor[3]);
 
             // set_at(destsurf, color, x,y);
 
@@ -3063,19 +3064,13 @@ laplacian(SDL_Surface *surf, PG_PixelFormat *format, SDL_Surface *destsurf,
                     byte_buf =
                         (Uint8 *)(destpixels + y * destsurf->pitch) + x * 3;
 #if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-                    *(byte_buf + (destformat->Rshift >> 3)) =
-                        (Uint8)(the_color >> format->Rshift);
-                    *(byte_buf + (destformat->Gshift >> 3)) =
-                        (Uint8)(the_color >> format->Gshift);
-                    *(byte_buf + (destformat->Bshift >> 3)) =
-                        (Uint8)(the_color >> format->Bshift);
+                    byte_buf[0] = (Uint8)(the_color);
+                    byte_buf[1] = (Uint8)(the_color >> 8);
+                    byte_buf[2] = (Uint8)(the_color >> 16);
 #else
-                    *(byte_buf + 2 - (destformat->Rshift >> 3)) =
-                        (Uint8)(the_color >> format->Rshift);
-                    *(byte_buf + 2 - (destformat->Gshift >> 3)) =
-                        (Uint8)(the_color >> format->Gshift);
-                    *(byte_buf + 2 - (destformat->Bshift >> 3)) =
-                        (Uint8)(the_color >> format->Bshift);
+                    byte_buf[0] = (Uint8)(the_color >> 16);
+                    byte_buf[1] = (Uint8)(the_color >> 8);
+                    byte_buf[2] = (Uint8)(the_color);
 #endif
                     break;
                 default:

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -1269,6 +1269,39 @@ class TransformModuleTest(unittest.TestCase):
         finally:
             pygame.display.quit()
 
+    def test_laplacian__cross_format(self):
+        # Regression: laplacian used to map the filtered RGB with the source
+        # format and write the bytes directly into the destination, which
+        # swapped channels when the surfaces had the same bytes-per-pixel
+        # (so the size check passed) but different channel layouts.
+        SIZE = 32
+        # RGBA layout for the source (R at the low byte).
+        s1 = pygame.Surface(
+            (SIZE, SIZE),
+            0,
+            32,
+            masks=(0xFF, 0xFF00, 0xFF0000, 0xFF000000),
+        )
+        s1.fill((10, 10, 70))
+        pygame.draw.line(s1, (255, 0, 0), (3, 10), (20, 20))
+        pygame.draw.line(s1, (255, 0, 0), (0, 31), (31, 31))
+
+        # BGRA layout for the destination — different channel order.
+        s2 = pygame.Surface(
+            (SIZE, SIZE),
+            0,
+            32,
+            masks=(0xFF0000, 0xFF00, 0xFF, 0xFF000000),
+        )
+        pygame.transform.laplacian(s1, s2)
+
+        # Compare RGB only; the alpha channel is also laplacian-filtered
+        # and isn't relevant to the channel-order bug under test.
+        self.assertEqual(s2.get_at((0, 0))[:3], (0, 0, 0))
+        self.assertEqual(s2.get_at((3, 10))[:3], (255, 0, 0))
+        self.assertEqual(s2.get_at((0, 31))[:3], (255, 0, 0))
+        self.assertEqual(s2.get_at((31, 31))[:3], (255, 0, 0))
+
     def test_average_surfaces(self):
         """ """
 


### PR DESCRIPTION
This is a follow-up to https://github.com/pygame-community/pygame-ce/pull/3790

CodeRabbit said the bugfix in that PR was lacking from laplacian, and it was wrong about that. However, going through laplacian found that it also has a bug with writing pixel data-- it is using the wrong surface's information about what to write.

For laplacian--
Previously, the color gathered in acolor was mapped using the source surface's information, and then written into the destination surface. Since destination surfaces are restricted to the same depth, this did work most of the time, but would not work if two surfaces had the same depth but different pixel layouts. Except for in the 24 bit path, which would map RGB, then unmap with source format, then remap into channels in destination format.

Simplified 24 bit writes--
These are using mapped colors, they can be stored directly into the pixel buffer. There is no need to "unmap" them using the pixelformat and store them in the red, green, and blue channels separately.
(This is related because simplifying the 24 bit writes broke the laplacian test, because of the aforementioned bug)