### PR TITLE
Replace Py_INCREF + assignment/return with Py_NewRef

### DIFF
--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -146,8 +146,7 @@ surf_colorspace(PyObject *self, PyObject *arg)
     SDL_UnlockSurface(newsurf);
 
     if (surfobj2) {
-        Py_INCREF(surfobj2);
-        return (PyObject *)surfobj2;
+        return (PyObject *)Py_NewRef(surfobj2);
     }
     else {
         return (PyObject *)pgSurface_New(newsurf);
@@ -432,8 +431,7 @@ camera_get_image(pgCameraObject *self, PyObject *arg)
     }
 
     if (surfobj) {
-        Py_INCREF(surfobj);
-        return (PyObject *)surfobj;
+        return (PyObject *)Py_NewRef(surfobj);
     }
     else {
         return (PyObject *)pgSurface_New(surf);
@@ -470,8 +468,7 @@ camera_get_image(pgCameraObject *self, PyObject *arg)
     }
 
     if (surfobj) {
-        Py_INCREF(surfobj);
-        return (PyObject *)surfobj;
+        return (PyObject *)Py_NewRef(surfobj);
     }
     else {
         return (PyObject *)pgSurface_New(surf);

--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -146,7 +146,7 @@ surf_colorspace(PyObject *self, PyObject *arg)
     SDL_UnlockSurface(newsurf);
 
     if (surfobj2) {
-        return (PyObject *)Py_NewRef(surfobj2);
+        return Py_NewRef(surfobj2);
     }
     else {
         return (PyObject *)pgSurface_New(newsurf);
@@ -431,7 +431,7 @@ camera_get_image(pgCameraObject *self, PyObject *arg)
     }
 
     if (surfobj) {
-        return (PyObject *)Py_NewRef(surfobj);
+        return Py_NewRef(surfobj);
     }
     else {
         return (PyObject *)pgSurface_New(surf);
@@ -468,7 +468,7 @@ camera_get_image(pgCameraObject *self, PyObject *arg)
     }
 
     if (surfobj) {
-        return (PyObject *)Py_NewRef(surfobj);
+        return Py_NewRef(surfobj);
     }
     else {
         return (PyObject *)pgSurface_New(surf);

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -793,8 +793,7 @@ _ftfont_init(pgFontObject *self, PyObject *args, PyObject *kwds)
         }
     }
     else {
-        Py_INCREF(file);
-        path = file;
+        path = Py_NewRef(file);
     }
 
     if (path) {
@@ -1140,8 +1139,7 @@ _ftfont_getpath(pgFontObject *self, void *closure)
         PyErr_SetString(PyExc_AttributeError, "path unavailable");
         return 0;
     }
-    Py_INCREF(path);
-    return path;
+    return Py_NewRef(path);
 }
 
 static PyObject *
@@ -1435,8 +1433,7 @@ get_metrics(FontRenderMode *render, pgFontObject *font, PGFT_String *text)
                              &minx, &maxx, &miny, &maxy, &advance_x,
                              &advance_y) == 0) {
             if (gindex == 0) {
-                Py_INCREF(Py_None);
-                item = Py_None;
+                item = Py_NewRef(Py_None);
             }
             else {
                 item = Py_BuildValue("lllldd", minx, maxx, miny, maxy,
@@ -1448,8 +1445,7 @@ get_metrics(FontRenderMode *render, pgFontObject *font, PGFT_String *text)
             }
         }
         else {
-            Py_INCREF(Py_None);
-            item = Py_None;
+            item = Py_NewRef(Py_None);
         }
         PyList_SET_ITEM(list, i, item);
     }

--- a/src_c/_sdl2/controller.c
+++ b/src_c/_sdl2/controller.c
@@ -477,8 +477,7 @@ controller_new(PyTypeObject *subtype, PyObject *args, PyObject *kwargs)
     cur = _first_controller;
     while (cur) {
         if (cur->controller == controller) {
-            Py_INCREF(cur);
-            return (PyObject *)cur;
+            return Py_NewRef(cur);
         }
 
         if (!cur->next) {

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -1134,8 +1134,7 @@ pgObject_GetBuffer(PyObject *obj, pg_buffer *pg_view_p, int flags)
             Py_DECREF(cobj);
             return -1;
         }
-        Py_INCREF(obj);
-        view_p->obj = obj;
+        view_p->obj = Py_NewRef(obj);
         Py_DECREF(cobj);
         success = 1;
     }
@@ -1148,8 +1147,7 @@ pgObject_GetBuffer(PyObject *obj, pg_buffer *pg_view_p, int flags)
             Py_DECREF(dict);
             return -1;
         }
-        Py_INCREF(obj);
-        view_p->obj = obj;
+        view_p->obj = Py_NewRef(obj);
         Py_DECREF(dict);
         success = 1;
     }

--- a/src_c/bufferproxy.c
+++ b/src_c/bufferproxy.c
@@ -82,14 +82,12 @@ _get_buffer_from_dict(PyObject *dict, Py_buffer *view_p, int flags)
     if (!obj) {
         obj = Py_None;
     }
-    Py_INCREF(obj);
     py_callback = PyDict_GetItemString(dict, "before");
 
     if (py_callback) {
         PyObject *py_rval;
 
-        Py_INCREF(py_callback);
-        py_rval = PyObject_CallOneArg(py_callback, obj);
+        py_rval = PyObject_CallOneArg(Py_NewRef(py_callback), Py_NewRef(obj));
         Py_DECREF(py_callback);
         if (!py_rval) {
             pgBuffer_Release(pg_dict_view_p);
@@ -98,8 +96,7 @@ _get_buffer_from_dict(PyObject *dict, Py_buffer *view_p, int flags)
         }
         Py_DECREF(py_rval);
     }
-    Py_INCREF(dict);
-    dict_view_p->obj = dict;
+    dict_view_p->obj = Py_NewRef(dict);
     view_p->obj = obj;
     view_p->buf = dict_view_p->buf;
     view_p->len = dict_view_p->len;
@@ -134,8 +131,7 @@ _release_buffer_from_dict(Py_buffer *view_p)
     if (py_callback) {
         PyObject *py_rval;
 
-        Py_INCREF(py_callback);
-        py_rval = PyObject_CallOneArg(py_callback, obj);
+        py_rval = PyObject_CallOneArg(Py_NewRef(py_callback), obj);
         if (py_rval) {
             Py_DECREF(py_rval);
         }
@@ -321,8 +317,7 @@ proxy_get_parent(pgBufferProxyObject *self, PyObject *closure)
         return 0;
     }
     obj = view_p->obj ? view_p->obj : Py_None;
-    Py_INCREF(obj);
-    return obj;
+    return Py_NewRef(obj);
 }
 
 static PyObject *
@@ -334,8 +329,7 @@ proxy_get___dict__(pgBufferProxyObject *self, PyObject *closure)
             return 0;
         }
     }
-    Py_INCREF(self->dict);
-    return self->dict;
+    return Py_NewRef(self->dict);
 }
 
 static PyObject *
@@ -475,8 +469,7 @@ proxy_getbuffer(pgBufferProxyObject *self, Py_buffer *view_p, int flags)
         PyMem_Free(obj_view_p);
         return -1;
     }
-    Py_INCREF(self);
-    view_p->obj = (PyObject *)self;
+    view_p->obj = (PyObject *)Py_NewRef(self);
     view_p->buf = obj_view_p->buf;
     view_p->len = obj_view_p->len;
     view_p->readonly = obj_view_p->readonly;

--- a/src_c/bufferproxy.c
+++ b/src_c/bufferproxy.c
@@ -471,7 +471,7 @@ proxy_getbuffer(pgBufferProxyObject *self, Py_buffer *view_p, int flags)
         PyMem_Free(obj_view_p);
         return -1;
     }
-    view_p->obj = (PyObject *)Py_NewRef(self);
+    view_p->obj = Py_NewRef(self);
     view_p->buf = obj_view_p->buf;
     view_p->len = obj_view_p->len;
     view_p->readonly = obj_view_p->readonly;

--- a/src_c/bufferproxy.c
+++ b/src_c/bufferproxy.c
@@ -82,12 +82,14 @@ _get_buffer_from_dict(PyObject *dict, Py_buffer *view_p, int flags)
     if (!obj) {
         obj = Py_None;
     }
+    Py_INCREF(obj);
     py_callback = PyDict_GetItemString(dict, "before");
 
     if (py_callback) {
         PyObject *py_rval;
 
-        py_rval = PyObject_CallOneArg(Py_NewRef(py_callback), Py_NewRef(obj));
+        Py_INCREF(py_callback);
+        py_rval = PyObject_CallOneArg(py_callback, obj);
         Py_DECREF(py_callback);
         if (!py_rval) {
             pgBuffer_Release(pg_dict_view_p);

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -769,8 +769,7 @@ pg_get_surface(PyObject *self, PyObject *_null)
         if (!surface) {
             Py_RETURN_NONE;
         }
-        Py_INCREF(surface);
-        return (PyObject *)surface;
+        return (PyObject *)Py_NewRef(surface);
     }
     else if (win == NULL) {
         Py_RETURN_NONE;
@@ -785,11 +784,9 @@ pg_get_surface(PyObject *self, PyObject *_null)
                 return NULL;
             }
             pg_SetDefaultWindowSurface(new_surface);
-            Py_INCREF((PyObject *)new_surface);
-            return (PyObject *)new_surface;
+            return (PyObject *)Py_NewRef(new_surface);
         }
-        Py_INCREF(old_surface);
-        return (PyObject *)old_surface;
+        return (PyObject *)Py_NewRef(old_surface);
     }
     return NULL;
 }
@@ -1877,8 +1874,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
     }
 
     /*return the window's surface (screen)*/
-    Py_INCREF(surface);
-    return (PyObject *)surface;
+    return (PyObject *)Py_NewRef(surface);
 
 DESTROY_WINDOW:
 
@@ -2406,8 +2402,7 @@ pg_set_palette(PyObject *self, PyObject *args)
         return RAISE(pgExc_SDLError, "No display mode is set");
     }
 
-    Py_INCREF(surface);
-    surf = pgSurface_AsSurface(surface);
+    surf = pgSurface_AsSurface(Py_NewRef(surface));
     pal = PG_GetSurfacePalette(surf);
     if (PG_SURF_BytesPerPixel(surf) != 1 || !pal) {
         Py_DECREF(surface);
@@ -2708,9 +2703,8 @@ pg_set_icon(PyObject *self, PyObject *surface)
             return NULL;
         }
     }
-    Py_INCREF(surface);
     Py_XDECREF(state->icon);
-    state->icon = surface;
+    state->icon = Py_NewRef(surface);
     if (win) {
         SDL_SetWindowIcon(win, pgSurface_AsSurface(surface));
     }

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -769,7 +769,7 @@ pg_get_surface(PyObject *self, PyObject *_null)
         if (!surface) {
             Py_RETURN_NONE;
         }
-        return (PyObject *)Py_NewRef(surface);
+        return Py_NewRef(surface);
     }
     else if (win == NULL) {
         Py_RETURN_NONE;
@@ -784,9 +784,9 @@ pg_get_surface(PyObject *self, PyObject *_null)
                 return NULL;
             }
             pg_SetDefaultWindowSurface(new_surface);
-            return (PyObject *)Py_NewRef(new_surface);
+            return Py_NewRef(new_surface);
         }
-        return (PyObject *)Py_NewRef(old_surface);
+        return Py_NewRef(old_surface);
     }
     return NULL;
 }
@@ -1874,7 +1874,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
     }
 
     /*return the window's surface (screen)*/
-    return (PyObject *)Py_NewRef(surface);
+    return Py_NewRef(surface);
 
 DESTROY_WINDOW:
 

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -875,8 +875,7 @@ pg_post_event(Uint32 type, PyObject *dict)
         return SDL_SetError("insufficient memory (internal malloc failed)");
     }
 
-    Py_INCREF(dict);
-    dict_proxy->dict = dict;
+    dict_proxy->dict = Py_NewRef(dict);
     /* initially set to 0 - unlocked state */
     dict_proxy->lock = 0;
     dict_proxy->num_on_queue = 0;
@@ -1607,8 +1606,7 @@ dict_from_event(SDL_Event *event)
 #endif
         pgWindow = Py_None;
     }
-    Py_INCREF(pgWindow);
-    _pg_insobj(dict, "window", pgWindow);
+    _pg_insobj(dict, "window", Py_NewRef(pgWindow));
     return dict;
 }
 
@@ -1728,8 +1726,7 @@ pg_event_richcompare(PyObject *o1, PyObject *o2, int opid)
     }
 
 Unimplemented:
-    Py_INCREF(Py_NotImplemented);
-    return Py_NotImplemented;
+    return Py_NewRef(Py_NotImplemented);
 }
 
 static int
@@ -1749,8 +1746,7 @@ pg_event_init(pgEventObject *self, PyObject *args, PyObject *kwargs)
 
     if (!dict) {
         if (kwargs) {
-            dict = kwargs;
-            Py_INCREF(dict);
+            dict = Py_NewRef(kwargs);
         }
         else {
             dict = PyDict_New();
@@ -2017,8 +2013,7 @@ _pg_eventtype_as_seq(PyObject *obj, Py_ssize_t *len)
     if (PySequence_Check(obj)) {
         *len = PySequence_Size(obj);
         /* The returned object gets decref'd later, so incref now */
-        Py_INCREF(obj);
-        return obj;
+        return Py_NewRef(obj);
     }
     else if (PyLong_Check(obj)) {
         return Py_BuildValue("(O)", obj);

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -1043,8 +1043,7 @@ font_metrics(PyObject *self, PyObject *textobj)
         }
         else {
             /* Not UCS-2 (and old SDL) or no matching metrics. */
-            Py_INCREF(Py_None);
-            listitem = Py_None;
+            listitem = Py_NewRef(Py_None);
         }
         if (0 != PyList_Append(list, listitem)) {
             Py_DECREF(list);

--- a/src_c/freetype/ft_unicode.c
+++ b/src_c/freetype/ft_unicode.c
@@ -51,8 +51,7 @@ raise_unicode_error(const char *codec, PyObject *unistr, Py_ssize_t start,
         return;
     }
 
-    Py_INCREF(PyExc_UnicodeEncodeError);
-    PyErr_Restore(PyExc_UnicodeEncodeError, e, 0);
+    PyErr_Restore(Py_NewRef(PyExc_UnicodeEncodeError), e, 0);
 }
 
 /* Helper for _PGFT_EncodePyString to handle PyUnicode object */

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1572,8 +1572,7 @@ image_frombuffer(PyObject *self, PyObject *arg, PyObject *kwds)
         return RAISE(pgExc_SDLError, SDL_GetError());
     }
     surfobj = (pgSurfaceObject *)pgSurface_New(surf);
-    Py_INCREF(buffer);
-    surfobj->dependency = buffer;
+    surfobj->dependency = Py_NewRef(buffer);
     return (PyObject *)surfobj;
 }
 

--- a/src_c/include/pythoncapi_compat.h
+++ b/src_c/include/pythoncapi_compat.h
@@ -60,8 +60,7 @@ extern "C" {
 #if PY_VERSION_HEX < 0x030A00A3 && !defined(Py_NewRef)
 static inline PyObject* _Py_NewRef(PyObject *obj)
 {
-    Py_INCREF(obj);
-    return obj;
+    return Py_NewRef(obj);
 }
 #define Py_NewRef(obj) _Py_NewRef(_PyObject_CAST(obj))
 #endif

--- a/src_c/include/pythoncapi_compat.h
+++ b/src_c/include/pythoncapi_compat.h
@@ -60,7 +60,8 @@ extern "C" {
 #if PY_VERSION_HEX < 0x030A00A3 && !defined(Py_NewRef)
 static inline PyObject* _Py_NewRef(PyObject *obj)
 {
-    return Py_NewRef(obj);
+    Py_INCREF(obj);
+    return obj;
 }
 #define Py_NewRef(obj) _Py_NewRef(_PyObject_CAST(obj))
 #endif

--- a/src_c/joystick.c
+++ b/src_c/joystick.c
@@ -646,8 +646,7 @@ pgJoystick_New(int id)
     cur = joylist_head;
     while (cur) {
         if (cur->joy == joy) {
-            Py_INCREF(cur);
-            return (PyObject *)cur;
+            return (PyObject *)Py_NewRef(cur);
         }
         cur = cur->next;
     }

--- a/src_c/joystick.c
+++ b/src_c/joystick.c
@@ -646,7 +646,7 @@ pgJoystick_New(int id)
     cur = joylist_head;
     while (cur) {
         if (cur->joy == joy) {
-            return (PyObject *)Py_NewRef(cur);
+            return Py_NewRef(cur);
         }
         cur = cur->next;
     }

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -2620,7 +2620,6 @@ pgMask_GetBuffer(pgMaskObject *self, Py_buffer *view, int flags)
         view->format = NULL;
     }
     view->suboffsets = NULL;
-
     view->obj = Py_NewRef(self);
 
     return 0;

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -217,8 +217,7 @@ mask_set_at(PyObject *self, PyObject *args, PyObject *kwargs)
         PyErr_Format(PyExc_IndexError, "%d, %d is out of bounds", x, y);
         return NULL;
     }
-    Py_INCREF(Py_None);
-    return Py_None;
+    return Py_NewRef(Py_None);
 }
 
 static PyObject *
@@ -248,8 +247,7 @@ mask_overlap(PyObject *self, PyObject *args, PyObject *kwargs)
         return pg_tuple_couple_from_values_int(xp, yp);
     }
     else {
-        Py_INCREF(Py_None);
-        return Py_None;
+        return Py_NewRef(Py_None);
     }
 }
 
@@ -2623,8 +2621,7 @@ pgMask_GetBuffer(pgMaskObject *self, Py_buffer *view, int flags)
     }
     view->suboffsets = NULL;
 
-    Py_INCREF(self);
-    view->obj = (PyObject *)self;
+    view->obj = Py_NewRef(self);
 
     return 0;
 }

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -3729,8 +3729,7 @@ vector_iter(PyObject *vec)
         return NULL;
     }
     it->it_index = 0;
-    Py_INCREF(vec);
-    it->vec = (pgVector *)vec;
+    it->vec = (pgVector *)Py_NewRef(vec);
     return (PyObject *)it;
 }
 
@@ -4323,8 +4322,7 @@ vector_elementwise(pgVector *vec, PyObject *_null)
     if (proxy == NULL) {
         return NULL;
     }
-    Py_INCREF(vec);
-    proxy->vec = (pgVector *)vec;
+    proxy->vec = (pgVector *)Py_NewRef(vec);
 
     return (PyObject *)proxy;
 }

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -676,8 +676,7 @@ pgSound_Play(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_XDECREF(channeldata[channelnum].sound);
     Py_XDECREF(channeldata[channelnum].queue);
     channeldata[channelnum].queue = NULL;
-    channeldata[channelnum].sound = self;
-    Py_INCREF(self);
+    channeldata[channelnum].sound = Py_NewRef(self);
 
     // make sure volume on this arbitrary channel is set to full
     Mix_Volume(channelnum, 128);
@@ -1049,8 +1048,7 @@ snd_getbuffer(PyObject *obj, Py_buffer *view, int flags)
             strides[ndim - 1] = itemsize;
         }
     }
-    Py_INCREF(obj);
-    view->obj = obj;
+    view->obj = Py_NewRef(obj);
     view->buf = chunk->abuf;
     view->len = (Py_ssize_t)chunk->alen;
     view->readonly = 0;
@@ -1141,9 +1139,8 @@ chan_play(PyObject *self, PyObject *args, PyObject *kwargs)
 
     Py_XDECREF(channeldata[channelnum].sound);
     Py_XDECREF(channeldata[channelnum].queue);
-    channeldata[channelnum].sound = sound;
+    channeldata[channelnum].sound = Py_NewRef(sound);
     channeldata[channelnum].queue = NULL;
-    Py_INCREF(sound);
     Py_RETURN_NONE;
 }
 
@@ -1178,14 +1175,11 @@ chan_queue(PyObject *self, PyObject *sound)
             Mix_GroupChannel(channelnum, (int)(intptr_t)chunk);
         }
         Py_END_ALLOW_THREADS;
-
-        channeldata[channelnum].sound = sound;
-        Py_INCREF(sound);
+        channeldata[channelnum].sound = Py_NewRef(sound);
     }
     else {
         Py_XDECREF(channeldata[channelnum].queue);
-        channeldata[channelnum].queue = sound;
-        Py_INCREF(sound);
+        channeldata[channelnum].queue = Py_NewRef(sound);
     }
     Py_RETURN_NONE;
 }
@@ -1358,8 +1352,7 @@ chan_get_sound(PyObject *self, PyObject *_null)
         Py_RETURN_NONE;
     }
 
-    Py_INCREF(sound);
-    return sound;
+    return Py_NewRef(sound);
 }
 
 static PyObject *
@@ -1373,8 +1366,7 @@ chan_get_queue(PyObject *self, PyObject *_null)
         Py_RETURN_NONE;
     }
 
-    Py_INCREF(sound);
-    return sound;
+    return Py_NewRef(sound);
 }
 
 static PyObject *

--- a/src_c/newbuffer.c
+++ b/src_c/newbuffer.c
@@ -378,8 +378,7 @@ buffer_get_obj(BufferObject *self, void *closure)
     if (!self->view_p->obj) {
         Py_RETURN_NONE;
     }
-    Py_INCREF(self->view_p->obj);
-    return self->view_p->obj;
+    return Py_NewRef(self->view_p->obj);
 }
 
 static int
@@ -397,8 +396,7 @@ buffer_set_obj(BufferObject *self, PyObject *value, void *closure)
     }
     tmp = self->view_p->obj;
     if (value != Py_None) {
-        Py_INCREF(value);
-        self->view_p->obj = value;
+        self->view_p->obj = Py_NewRef(value);
     }
     else {
         self->view_p->obj = 0;

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -416,8 +416,7 @@ _pxarray_get_dict(pgPixelArrayObject *self, void *closure)
         }
         self->dict = dict;
     }
-    Py_INCREF(dict);
-    return dict;
+    return Py_NewRef(dict);
 }
 
 /**
@@ -620,8 +619,7 @@ _pxarray_getbuffer(pgPixelArrayObject *self, Py_buffer *view_p, int flags)
     else {
         view_p->format = 0;
     }
-    Py_INCREF(self);
-    view_p->obj = (PyObject *)self;
+    view_p->obj = Py_NewRef(self);
     view_p->buf = self->pixels;
     view_p->len = len;
     view_p->readonly = 0;
@@ -1620,8 +1618,7 @@ _pxarray_subscript(pgPixelArrayObject *array, PyObject *op)
 
         if (size == 0) {
             /* array[,], array[()] ... */
-            Py_INCREF(array);
-            return (PyObject *)array;
+            return Py_NewRef(array);
         }
         if (size > 2 || (size == 2 && !dim1)) {
             return RAISE(PyExc_IndexError, "too many indices for the array");
@@ -1671,8 +1668,7 @@ _pxarray_subscript(pgPixelArrayObject *array, PyObject *op)
                                            ystop, ystep);
     }
     else if (op == Py_Ellipsis) {
-        Py_INCREF(array);
-        return (PyObject *)array;
+        return Py_NewRef(array);
     }
     else if (PySlice_Check(op)) {
         /* A slice */

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -1082,8 +1082,7 @@ _close_array(pgPixelArrayObject *array, PyObject *args)
 static PyObject *
 _enter_context(pgPixelArrayObject *array, PyObject *args)
 {
-    Py_INCREF(array);
-    return (PyObject *)array;
+    return Py_NewRef(array);
 }
 
 static PyObject *

--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -2401,8 +2401,7 @@ RectExport_richcompare(PyObject *o1, PyObject *o2, int opid)
     }
 
 Unimplemented:
-    Py_INCREF(Py_NotImplemented);
-    return Py_NotImplemented;
+    return Py_NewRef(Py_NotImplemented);
 }
 
 /*width*/

--- a/src_c/render.c
+++ b/src_c/render.c
@@ -85,8 +85,7 @@ renderer_from_window(PyTypeObject *cls, PyObject *args, PyObject *kwargs)
         return RAISE(pgExc_SDLError, SDL_GetError());
     }
     self->target = NULL;
-    Py_INCREF(self);
-    return (PyObject *)self;
+    return Py_NewRef(self);
 }
 
 static PyObject *
@@ -402,8 +401,7 @@ renderer_blit(pgRendererObject *self, PyObject *args, PyObject *kwargs)
     if (Py_IsNone(destobj)) {
         return renderer_get_viewport(self, NULL);
     }
-    Py_INCREF(destobj);
-    return destobj;
+    return Py_NewRef(destobj);
 }
 
 static PyObject *
@@ -548,8 +546,7 @@ renderer_get_target(pgRendererObject *self, void *closure)
     if (self->target == NULL) {
         Py_RETURN_NONE;
     }
-    Py_INCREF(self->target);
-    return (PyObject *)self->target;
+    return Py_NewRef(self->target);
 }
 
 static int
@@ -989,8 +986,7 @@ texture_update(pgTextureObject *self, PyObject *args, PyObject *kwargs)
 static PyObject *
 texture_get_renderer(pgTextureObject *self, void *closure)
 {
-    Py_INCREF(self->renderer);
-    return (PyObject *)self->renderer;
+    return Py_NewRef(self->renderer);
 }
 
 static PyObject *

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -167,8 +167,7 @@ _trydecode_pathlibobj(PyObject *obj)
     if (!ret) {
         /* A valid object was not passed. But we do not consider it an error */
         PyErr_Clear();
-        Py_INCREF(obj);
-        return obj;
+        return Py_NewRef(obj);
     }
     return ret;
 }

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -275,8 +275,7 @@ _scrap_get_scrap(PyObject *self, PyObject *args)
             Py_RETURN_NONE;
         }
 
-        Py_INCREF(val);
-        return val;
+        return Py_NewRef(val);
     }
 
     /* pygame_get_scrap() only returns NULL or !NULL, but won't set any

--- a/src_c/system.c
+++ b/src_c/system.c
@@ -155,8 +155,7 @@ pg_system_get_pref_locales(PyObject *self, PyObject *_null)
             }
         }
         else {
-            Py_INCREF(Py_None);
-            val = Py_None;
+            val = Py_NewRef(Py_None);
         }
         if (PyDict_SetItemString(dict, "country", val)) {
             goto error;
@@ -199,16 +198,14 @@ pg_system_get_power_state(PyObject *self, PyObject *_null)
     }
 
     if (sec == -1) {
-        sec_py = Py_None;
-        Py_INCREF(Py_None);
+        sec_py = Py_NewRef(Py_None);
     }
     else {
         sec_py = PyLong_FromLong(sec);
     }
 
     if (pct == -1) {
-        pct_py = Py_None;
-        Py_INCREF(Py_None);
+        pct_py = Py_NewRef(Py_None);
     }
     else {
         pct_py = PyLong_FromLong(pct);

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -550,8 +550,7 @@ surf_scale(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (surfobj2) {
-        Py_INCREF(surfobj2);
-        return (PyObject *)surfobj2;
+        return Py_NewRef(surfobj2);
     }
     else {
         return (PyObject *)pgSurface_New(newsurf);
@@ -588,8 +587,7 @@ surf_scale_by(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (surfobj2) {
-        Py_INCREF(surfobj2);
-        return (PyObject *)surfobj2;
+        return Py_NewRef(surfobj2);
     }
     else {
         return (PyObject *)pgSurface_New(newsurf);
@@ -651,8 +649,7 @@ surf_scale2x(PyObject *self, PyObject *args, PyObject *kwargs)
     SDL_UnlockSurface(newsurf);
 
     if (surfobj2) {
-        Py_INCREF(surfobj2);
-        return surfobj2;
+        return Py_NewRef(surfobj2);
     }
     else {
         return (PyObject *)pgSurface_New(newsurf);
@@ -680,8 +677,7 @@ surf_rotate(PyObject *self, PyObject *args, PyObject *kwargs)
     SURF_INIT_CHECK(surf)
 
     if (surf->w < 1 || surf->h < 1) {
-        Py_INCREF(surfobj);
-        return (PyObject *)surfobj;
+        return Py_NewRef(surfobj);
     }
 
     if (PG_SURF_BytesPerPixel(surf) == 0 || PG_SURF_BytesPerPixel(surf) > 4) {
@@ -1610,8 +1606,7 @@ surf_scalesmooth(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (surfobj2) {
-        Py_INCREF(surfobj2);
-        return (PyObject *)surfobj2;
+        return Py_NewRef(surfobj2);
     }
     else {
         return (PyObject *)pgSurface_New(newsurf);
@@ -1648,8 +1643,7 @@ surf_scalesmooth_by(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (surfobj2) {
-        Py_INCREF(surfobj2);
-        return (PyObject *)surfobj2;
+        return Py_NewRef(surfobj2);
     }
     else {
         return (PyObject *)pgSurface_New(newsurf);
@@ -2360,8 +2354,7 @@ surf_grayscale(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (surfobj2) {
-        Py_INCREF(surfobj2);
-        return (PyObject *)surfobj2;
+        return Py_NewRef(surfobj2);
     }
     else {
         return (PyObject *)pgSurface_New(newsurf);
@@ -2565,8 +2558,7 @@ surf_solid_overlay(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (surfobj2) {
-        Py_INCREF(surfobj2);
-        return (PyObject *)surfobj2;
+        return Py_NewRef(surfobj2);
     }
     else {
         return (PyObject *)pgSurface_New(newsurf);
@@ -2851,8 +2843,7 @@ surf_hsl(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_END_ALLOW_THREADS;
 
     if (surfobj2) {
-        Py_INCREF(surfobj2);
-        return (PyObject *)surfobj2;
+        return Py_NewRef(surfobj2);
     }
     else {
         return (PyObject *)pgSurface_New(dst);
@@ -3118,8 +3109,7 @@ surf_laplacian(PyObject *self, PyObject *args, PyObject *kwargs)
     SDL_UnlockSurface(newsurf);
 
     if (surfobj2) {
-        Py_INCREF(surfobj2);
-        return surfobj2;
+        return Py_NewRef(surfobj2);
     }
     else {
         return (PyObject *)pgSurface_New(newsurf);
@@ -3449,8 +3439,7 @@ surf_average_surfaces(PyObject *self, PyObject *args, PyObject *kwargs)
         SDL_UnlockSurface(newsurf);
 
         if (surfobj2) {
-            Py_INCREF(surfobj2);
-            ret = surfobj2;
+            ret = Py_NewRef(surfobj2);
         }
         else {
             ret = (PyObject *)pgSurface_New(newsurf);
@@ -4040,8 +4029,7 @@ surf_box_blur(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (dst_surf_obj) {
-        Py_INCREF(dst_surf_obj);
-        return (PyObject *)dst_surf_obj;
+        return Py_NewRef(dst_surf_obj);
     }
 
     return (PyObject *)pgSurface_New(new_surf);
@@ -4073,8 +4061,7 @@ surf_gaussian_blur(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (dst_surf_obj) {
-        Py_INCREF(dst_surf_obj);
-        return (PyObject *)dst_surf_obj;
+        return Py_NewRef(dst_surf_obj);
     }
 
     return (PyObject *)pgSurface_New(new_surf);
@@ -4188,8 +4175,7 @@ surf_invert(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (surfobj2) {
-        Py_INCREF(surfobj2);
-        return (PyObject *)surfobj2;
+        return Py_NewRef(surfobj2);
     }
     return (PyObject *)pgSurface_New(newsurf);
 }
@@ -4246,8 +4232,7 @@ surf_pixelate(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (dst) {
-        Py_INCREF(dst);
-        return (PyObject *)dst;
+        return Py_NewRef(dst);
     }
 
     return (PyObject *)pgSurface_New(new_surf);


### PR DESCRIPTION
Closes #3789

This PR replaces uses of Py_INCREF plus assignment with Py_NewRef. It also replaces some instances where the value is returned or passed into a function.

I have also replaced some instances where the ref count is incremented after assignment as suggests by @oddbookworm  where they wouldn’t cause an issue.