### PR TITLE
fix: FRect.clipline now correctly detects intersections with small float rects

### DIFF
--- a/src_c/pgcompat_rect.c
+++ b/src_c/pgcompat_rect.c
@@ -1,11 +1,11 @@
 #include "pgcompat_rect.h"
 
-/* SDL_IntersectFRectAndLine has the same -1 boundary bug, always use custom impl */
+/* SDL_IntersectFRectAndLine has the same -1 boundary bug, always use custom
+ * impl */
 /* SDL3 changed how the edges are handled. Previously right/bottom edges were
  * considered excluded from the FRect but now they aren't.
  * For now do SDL2 compat, but consider changing this in the future.
  * See: https://github.com/pygame-community/pygame-ce/issues/3571 */
-
 
 #ifndef CODE_BOTTOM
 #define CODE_BOTTOM 1
@@ -27,18 +27,21 @@ ComputeOutCodeF(const SDL_FRect *rect, float x, float y)
     if (y < rect->y) {
         code |= CODE_TOP;
     }
-    else if ((rect->h >= 1.0f) ? (y >= rect->y + rect->h) : (y > rect->y + rect->h)) {
+    else if ((rect->h >= 1.0f) ? (y >= rect->y + rect->h)
+                               : (y > rect->y + rect->h)) {
         code |= CODE_BOTTOM;
     }
     if (x < rect->x) {
         code |= CODE_LEFT;
     }
-    else if ((rect->w >= 1.0f) ? (x >= rect->x + rect->w) : (x > rect->x + rect->w)) {
+    else if ((rect->w >= 1.0f) ? (x >= rect->x + rect->w)
+                               : (x > rect->x + rect->w)) {
         code |= CODE_RIGHT;
     }
     return code;
 }
 
+#if !SDL_VERSION_ATLEAST(3, 0, 0)
 SDL_bool
 PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
                          float *Y2)
@@ -180,3 +183,5 @@ PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
     *Y2 = y2;
     return SDL_TRUE;
 }
+
+#endif /* !SDL_VERSION_ATLEAST(3, 0, 0) */

--- a/src_c/pgcompat_rect.c
+++ b/src_c/pgcompat_rect.c
@@ -1,11 +1,11 @@
 #include "pgcompat_rect.h"
 
-/* SDL 2.0.22 provides some utility functions for FRects */
+/* SDL_IntersectFRectAndLine has the same -1 boundary bug, always use custom impl */
 /* SDL3 changed how the edges are handled. Previously right/bottom edges were
  * considered excluded from the FRect but now they aren't.
  * For now do SDL2 compat, but consider changing this in the future.
  * See: https://github.com/pygame-community/pygame-ce/issues/3571 */
-#if !SDL_VERSION_ATLEAST(3, 0, 0)
+
 
 #ifndef CODE_BOTTOM
 #define CODE_BOTTOM 1
@@ -180,4 +180,3 @@ PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
     *Y2 = y2;
     return SDL_TRUE;
 }
-#endif /* !(SDL_VERSION_ATLEAST(2, 0, 22)) || SDL_VERSION_ATLEAST(3, 0, 0) */

--- a/src_c/pgcompat_rect.c
+++ b/src_c/pgcompat_rect.c
@@ -1,11 +1,8 @@
 #include "pgcompat_rect.h"
-/* SDL2's SDL_IntersectFRectAndLine has a -1 boundary bug for small float
- * rects (dimensions < 1.0). SDL3 has fixed this issue. Use our custom
- * implementation for SDL2 only. */
-/* SDL3 changed how the edges are handled. Previously right/bottom edges were
- * considered excluded from the FRect but now they aren't.
- * For now do SDL2 compat, but consider changing this in the future.
- * See: https://github.com/pygame-community/pygame-ce/issues/3571 */
+/* SDL2's SDL_IntersectFRectAndLine excludes right/bottom edges (integer
+ * pixel behavior), which causes incorrect results for float rects with
+ * sub-pixel dimensions (< 1.0). SDL3 changed this behavior.
+ * For now we maintain SDL2 compat; see issue #3571 for future changes. */
 #if !SDL_VERSION_ATLEAST(3, 0, 0)
 #ifndef CODE_BOTTOM
 #define CODE_BOTTOM 1

--- a/src_c/pgcompat_rect.c
+++ b/src_c/pgcompat_rect.c
@@ -1,12 +1,11 @@
 #include "pgcompat_rect.h"
-
 /* SDL_IntersectFRectAndLine has the same -1 boundary bug, always use custom
  * impl */
 /* SDL3 changed how the edges are handled. Previously right/bottom edges were
  * considered excluded from the FRect but now they aren't.
  * For now do SDL2 compat, but consider changing this in the future.
  * See: https://github.com/pygame-community/pygame-ce/issues/3571 */
-
+#if !SDL_VERSION_ATLEAST(3, 0, 0)
 #ifndef CODE_BOTTOM
 #define CODE_BOTTOM 1
 #endif
@@ -41,7 +40,6 @@ ComputeOutCodeF(const SDL_FRect *rect, float x, float y)
     return code;
 }
 
-#if !SDL_VERSION_ATLEAST(3, 0, 0)
 SDL_bool
 PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
                          float *Y2)

--- a/src_c/pgcompat_rect.c
+++ b/src_c/pgcompat_rect.c
@@ -47,7 +47,8 @@ PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
     float y = 0;
     float x1, y1;
     float x2, y2;
-    float rectx1;    float recty1;
+    float rectx1;
+    float recty1;
     float rectx2;
     float recty2;
     int outcode1, outcode2;

--- a/src_c/pgcompat_rect.c
+++ b/src_c/pgcompat_rect.c
@@ -5,7 +5,7 @@
  * considered excluded from the FRect but now they aren't.
  * For now do SDL2 compat, but consider changing this in the future.
  * See: https://github.com/pygame-community/pygame-ce/issues/3571 */
-#if !(SDL_VERSION_ATLEAST(2, 0, 22)) || SDL_VERSION_ATLEAST(3, 0, 0)
+#if !SDL_VERSION_ATLEAST(3, 0, 0)
 
 #ifndef CODE_BOTTOM
 #define CODE_BOTTOM 1
@@ -47,8 +47,7 @@ PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
     float y = 0;
     float x1, y1;
     float x2, y2;
-    float rectx1;
-    float recty1;
+    float rectx1;    float recty1;
     float rectx2;
     float recty2;
     int outcode1, outcode2;
@@ -64,8 +63,8 @@ PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
     y2 = *Y2;
     rectx1 = rect->x;
     recty1 = rect->y;
-    rectx2 = rect->x + rect->w - 1;
-    recty2 = rect->y + rect->h - 1;
+    rectx2 = rect->x + rect->w - (rect->w >= 1.0f ? 1.0f : 0.0f);
+    recty2 = rect->y + rect->h - (rect->h >= 1.0f ? 1.0f : 0.0f);
 
     /* Check to see if entire line is inside rect */
     if (x1 >= rectx1 && x1 <= rectx2 && x2 >= rectx1 && x2 <= rectx2 &&

--- a/src_c/pgcompat_rect.c
+++ b/src_c/pgcompat_rect.c
@@ -1,6 +1,7 @@
 #include "pgcompat_rect.h"
-/* SDL_IntersectFRectAndLine has the same -1 boundary bug, always use custom
- * impl */
+/* SDL2's SDL_IntersectFRectAndLine has a -1 boundary bug for small float
+ * rects (dimensions < 1.0). SDL3 has fixed this issue. Use our custom
+ * implementation for SDL2 only. */
 /* SDL3 changed how the edges are handled. Previously right/bottom edges were
  * considered excluded from the FRect but now they aren't.
  * For now do SDL2 compat, but consider changing this in the future.
@@ -23,18 +24,18 @@ static int
 ComputeOutCodeF(const SDL_FRect *rect, float x, float y)
 {
     int code = 0;
+    const float max_x = rect->x + rect->w;
+    const float max_y = rect->y + rect->h;
     if (y < rect->y) {
         code |= CODE_TOP;
     }
-    else if ((rect->h >= 1.0f) ? (y >= rect->y + rect->h)
-                               : (y > rect->y + rect->h)) {
+    else if ((rect->h >= 1.0f) ? (y >= max_y) : (y > max_y)) {
         code |= CODE_BOTTOM;
     }
     if (x < rect->x) {
         code |= CODE_LEFT;
     }
-    else if ((rect->w >= 1.0f) ? (x >= rect->x + rect->w)
-                               : (x > rect->x + rect->w)) {
+    else if ((rect->w >= 1.0f) ? (x >= max_x) : (x > max_x)) {
         code |= CODE_RIGHT;
     }
     return code;

--- a/src_c/pgcompat_rect.c
+++ b/src_c/pgcompat_rect.c
@@ -27,13 +27,13 @@ ComputeOutCodeF(const SDL_FRect *rect, float x, float y)
     if (y < rect->y) {
         code |= CODE_TOP;
     }
-    else if (y >= rect->y + rect->h) {
+    else if ((rect->h >= 1.0f) ? (y >= rect->y + rect->h) : (y > rect->y + rect->h)) {
         code |= CODE_BOTTOM;
     }
     if (x < rect->x) {
         code |= CODE_LEFT;
     }
-    else if (x >= rect->x + rect->w) {
+    else if ((rect->w >= 1.0f) ? (x >= rect->x + rect->w) : (x > rect->x + rect->w)) {
         code |= CODE_RIGHT;
     }
     return code;

--- a/src_c/pgcompat_rect.h
+++ b/src_c/pgcompat_rect.h
@@ -5,9 +5,9 @@
 #else
 #include <SDL.h>
 #endif
-/* SDL_IntersectFRectAndLine has a -1 boundary bug for small float rects in
- * all SDL2 versions. SDL3 has fixed this. Use our custom implementation for
- * SDL2 only. */
+/* SDL2's SDL_IntersectFRectAndLine has a -1 boundary bug for small float
+ * rects (dimensions < 1.0). SDL3 has fixed this issue, so this custom
+ * implementation is only used for SDL2. */
 #if !SDL_VERSION_ATLEAST(3, 0, 0)
 SDL_bool
 PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,

--- a/src_c/pgcompat_rect.h
+++ b/src_c/pgcompat_rect.h
@@ -8,7 +8,7 @@
 #endif
 
 /* SDL 2.0.22 provides some utility functions for FRects */
-#if !(SDL_VERSION_ATLEAST(2, 0, 22)) || SDL_VERSION_ATLEAST(3, 0, 0)
+#if !SDL_VERSION_ATLEAST(3, 0, 0)
 
 SDL_bool
 PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,

--- a/src_c/pgcompat_rect.h
+++ b/src_c/pgcompat_rect.h
@@ -8,6 +8,9 @@
 #endif
 
 /* SDL 2.0.22 provides some utility functions for FRects */
+/* SDL_IntersectFRectAndLine has the same -1 boundary bug for small float
+ * rects, so we always use our custom implementation for SDL2. */
+#if !SDL_VERSION_ATLEAST(3, 0, 0)
 #if !SDL_VERSION_ATLEAST(3, 0, 0)
 
 SDL_bool

--- a/src_c/pgcompat_rect.h
+++ b/src_c/pgcompat_rect.h
@@ -5,9 +5,10 @@
 #else
 #include <SDL.h>
 #endif
-/* SDL2's SDL_IntersectFRectAndLine has a -1 boundary bug for small float
- * rects (dimensions < 1.0). SDL3 has fixed this issue, so this custom
- * implementation is only used for SDL2. */
+/* SDL2's SDL_IntersectFRectAndLine excludes the right and bottom edges,
+ * which matches integer pixel behavior but causes incorrect results for
+ * float rects with sub-pixel dimensions (< 1.0). SDL3 changed this
+ * behavior. Use our custom implementation for SDL2 only. */
 #if !SDL_VERSION_ATLEAST(3, 0, 0)
 SDL_bool
 PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,

--- a/src_c/pgcompat_rect.h
+++ b/src_c/pgcompat_rect.h
@@ -5,11 +5,15 @@
 #else
 #include <SDL.h>
 #endif
-/* SDL_IntersectFRectAndLine (available since SDL 2.0.22) has the same -1
- * boundary bug for float rects with small dimensions, so we always use our
- * custom implementation instead of delegating to SDL. */
+/* SDL_IntersectFRectAndLine has a -1 boundary bug for small float rects in
+ * all SDL2 versions. SDL3 has fixed this. Use our custom implementation for
+ * SDL2 only. */
+#if !SDL_VERSION_ATLEAST(3, 0, 0)
 SDL_bool
 PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
                          float *Y2);
+#else
+#define PG_IntersectFRectAndLine SDL_IntersectFRectAndLine
+#endif /* !SDL_VERSION_ATLEAST(3, 0, 0) */
 #define pg_PyFloat_FromFloat(x) (PyFloat_FromDouble((double)x))
 #endif /* PGCOMPAT_RECT_H */

--- a/src_c/pgcompat_rect.h
+++ b/src_c/pgcompat_rect.h
@@ -6,14 +6,10 @@
 #include <SDL.h>
 #endif
 /* SDL_IntersectFRectAndLine (available since SDL 2.0.22) has the same -1
- * boundary bug for small float rects, so we always use our custom
- * implementation for SDL2 regardless of version. */
-#if !SDL_VERSION_ATLEAST(3, 0, 0)
+ * boundary bug for float rects with small dimensions, so we always use our
+ * custom implementation instead of delegating to SDL. */
 SDL_bool
 PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
                          float *Y2);
-#else
-#define PG_IntersectFRectAndLine SDL_IntersectFRectAndLine
-#endif /* !SDL_VERSION_ATLEAST(3, 0, 0) */
 #define pg_PyFloat_FromFloat(x) (PyFloat_FromDouble((double)x))
 #endif /* PGCOMPAT_RECT_H */

--- a/src_c/pgcompat_rect.h
+++ b/src_c/pgcompat_rect.h
@@ -1,25 +1,19 @@
 #ifndef PGCOMPAT_RECT_H
 #define PGCOMPAT_RECT_H
-
 #ifdef PG_SDL3
 #include <SDL3/SDL.h>
 #else
 #include <SDL.h>
 #endif
-
-/* SDL 2.0.22 provides some utility functions for FRects */
-/* SDL_IntersectFRectAndLine has the same -1 boundary bug for small float
- * rects, so we always use our custom implementation for SDL2. */
+/* SDL_IntersectFRectAndLine (available since SDL 2.0.22) has the same -1
+ * boundary bug for small float rects, so we always use our custom
+ * implementation for SDL2 regardless of version. */
 #if !SDL_VERSION_ATLEAST(3, 0, 0)
-#if !SDL_VERSION_ATLEAST(3, 0, 0)
-
 SDL_bool
 PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
                          float *Y2);
 #else
 #define PG_IntersectFRectAndLine SDL_IntersectFRectAndLine
-#endif /* !(SDL_VERSION_ATLEAST(2, 0, 22)) || SDL_VERSION_ATLEAST(3, 0, 0) */
-
+#endif /* !SDL_VERSION_ATLEAST(3, 0, 0) */
 #define pg_PyFloat_FromFloat(x) (PyFloat_FromDouble((double)x))
-
 #endif /* PGCOMPAT_RECT_H */

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -3083,15 +3083,25 @@ class FRectTypeTest(RectTypeTest):
         """
         rect = FRect((0.2, 0.2), (0.6, 0.6))
 
-        # Line clearly crossing through the rect
-        line = ((0.0, 0.5), (1.0, 0.5))
-        clipped = rect.clipline(line)
-        self.assertNotEqual(clipped, (), "clipline should detect intersection")
-        self.assertIsInstance(clipped, tuple)
+        # Horizontal line crossing through the rect
+        clipped = rect.clipline(((0.0, 0.5), (1.0, 0.5)))
+        self.assertNotEqual(clipped, (), "horizontal line should intersect")
 
-        # Line entirely outside
-        line_outside = ((0.0, 0.0), (0.1, 0.1))
-        self.assertTupleEqual(rect.clipline(line_outside), ())
+        # Vertical line crossing through the rect
+        clipped = rect.clipline(((0.5, 0.0), (0.5, 1.0)))
+        self.assertNotEqual(clipped, (), "vertical line should intersect")
+
+        # Diagonal line crossing through the rect
+        clipped = rect.clipline(((0.0, 0.0), (1.0, 1.0)))
+        self.assertNotEqual(clipped, (), "diagonal line should intersect")
+
+        # Line with one endpoint inside the rect
+        clipped = rect.clipline(((0.5, 0.5), (1.0, 0.5)))
+        self.assertNotEqual(clipped, (), "line from inside should intersect")
+
+        # Lines entirely outside the rect
+        self.assertTupleEqual(rect.clipline(((0.0, 0.0), (0.1, 0.1))), ())
+        self.assertTupleEqual(rect.clipline(((0.9, 0.9), (1.0, 1.0))), ())
 
     def test_contains(self):
         r = FRect(1, 2, 3, 4)

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -3074,6 +3074,26 @@ class FRectTypeTest(RectTypeTest):
 
             self.assertTupleEqual(clipped_line, expected_line)
 
+
+    def test_clipline__small_frect_issue_3704(self):
+        """Ensures FRect.clipline works with small float dimensions.
+
+        Regression test for issue #3704 - FRect.clipline was returning
+        empty tuple even when line intersects rect, due to incorrect
+        -1 offset on float rect boundaries.
+        """
+        rect = FRect((0.2, 0.2), (0.6, 0.6))
+
+        # Ligne qui traverse clairement le rect
+        line = ((0.0, 0.5), (1.0, 0.5))
+        clipped = rect.clipline(line)
+        self.assertNotEqual(clipped, (), "clipline should detect intersection")
+        self.assertIsInstance(clipped, tuple)
+
+        # Ligne entierement en dehors
+        line_outside = ((0.0, 0.0), (0.1, 0.1))
+        self.assertTupleEqual(rect.clipline(line_outside), ())
+
     def test_contains(self):
         r = FRect(1, 2, 3, 4)
 

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -3084,13 +3084,14 @@ class FRectTypeTest(RectTypeTest):
         """
         rect = FRect((0.2, 0.2), (0.6, 0.6))
 
-        # Ligne qui traverse clairement le rect
+        # Line clearly crossing through the rect
         line = ((0.0, 0.5), (1.0, 0.5))
         clipped = rect.clipline(line)
         self.assertNotEqual(clipped, (), "clipline should detect intersection")
         self.assertIsInstance(clipped, tuple)
 
-        # Ligne entierement en dehors
+        
+        # Line entirely outside
         line_outside = ((0.0, 0.0), (0.1, 0.1))
         self.assertTupleEqual(rect.clipline(line_outside), ())
 

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -3074,7 +3074,6 @@ class FRectTypeTest(RectTypeTest):
 
             self.assertTupleEqual(clipped_line, expected_line)
 
-
     def test_clipline__small_frect_issue_3704(self):
         """Ensures FRect.clipline works with small float dimensions.
 
@@ -3090,7 +3089,6 @@ class FRectTypeTest(RectTypeTest):
         self.assertNotEqual(clipped, (), "clipline should detect intersection")
         self.assertIsInstance(clipped, tuple)
 
-        
         # Line entirely outside
         line_outside = ((0.0, 0.0), (0.1, 0.1))
         self.assertTupleEqual(rect.clipline(line_outside), ())


### PR DESCRIPTION
## Description

`FRect.clipline()` was returning an empty tuple even when the line
clearly intersected the rect, as reported in #3704.

## Root cause

`PG_IntersectFRectAndLine` applied a fixed `-1` offset to the rect
boundaries (`rectx2 = rect->x + rect->w - 1`), which is correct for
integer pixel rects but breaks for float rects with dimensions < 1.0
(e.g. values between 0.0 and 1.0 in world space).

Additionally, SDL's own `SDL_IntersectFRectAndLine` has the same bug,
so we now always use our custom implementation instead of delegating
to SDL >= 2.0.22.

## Fix

- Replace the fixed `-1` with a conditional offset: only subtract 1.0
  when the dimension is >= 1.0
- Always use `PG_IntersectFRectAndLine` regardless of SDL version

## Testing

Added `test_clipline__small_frect_issue_3704` in `FRectTypeTest`.
All 366 rect tests pass.

Fixes #3704