### PR TITLE
Remove obsolete mousewheel flip compat

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1345,13 +1345,9 @@ dict_from_event(SDL_Event *event)
             break;
         case SDL_MOUSEWHEEL:
             /* https://wiki.libsdl.org/SDL_MouseWheelEvent */
-#ifndef NO_SDL_MOUSEWHEEL_FLIPPED
             _pg_insobj(dict, "flipped",
                        PyBool_FromLong(event->wheel.direction ==
                                        SDL_MOUSEWHEEL_FLIPPED));
-#else
-            _pg_insobj(dict, "flipped", PyBool_FromLong(0));
-#endif
             _pg_insobj(dict, "x", PyLong_FromLong((long)event->wheel.x));
             _pg_insobj(dict, "y", PyLong_FromLong((long)event->wheel.y));
 

--- a/src_c/include/pgcompat.h
+++ b/src_c/include/pgcompat.h
@@ -46,8 +46,4 @@ typedef uint8_t Uint8;
 
 #endif /* defined(SDL_VERSION_ATLEAST) */
 
-#ifndef SDL_MOUSEWHEEL_FLIPPED
-#define NO_SDL_MOUSEWHEEL_FLIPPED
-#endif
-
 #endif /* ~defined(PGCOMPAT_H) */


### PR DESCRIPTION
According to SDL2 whatsnew (https://github.com/libsdl-org/SDL/blob/SDL2/WhatsNew.txt), the direction field has existed since SDL 2.0.4. (Our minimum SDL version is 2.0.14)

So, there is no need to test for the existence of the SDL_MOUSEWHEEL_FLIPPED enum value, and have a codepath if it is not found.

- ancient SDL: FLIPPED is not defined, so NO_SDL_MOUSEWHEEL_F is defined, so it hardcodes false.
- SDL: FLIPPED is defined, so NO_SDL_MOUSEWHEEL_F is not defined, so it checks direction.