### PR TITLE
Fix Sound.play return type to Channel | None (#3810)

### DIFF
--- a/buildconfig/stubs/pygame/mixer.pyi
+++ b/buildconfig/stubs/pygame/mixer.pyi
@@ -56,7 +56,7 @@ class Sound:
         loops: int = 0,
         maxtime: int = 0,
         fade_ms: int = 0,
-    ) -> Channel: ...
+    ) -> Channel | None: ...
     # possibly going to be deprecated/removed soon, in which case these
     # typestubs must be removed too
     @property

--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -384,11 +384,10 @@ The following file formats are supported
    .. method:: play
 
       | :sl:`begin sound playback`
-      | :sg:`play(loops=0, maxtime=0, fade_ms=0) -> Channel`
+      | :sg:`play(loops=0, maxtime=0, fade_ms=0) -> Channel | None`
 
       Begin playback of the Sound (i.e., on the computer's speakers) on an
-      available Channel. This will forcibly select a Channel, so playback may
-      cut off a currently playing sound if necessary.
+      available Channel.
 
       The loops argument controls how many times the sample will be repeated
       after being played the first time. A value of 5 means that the sound will
@@ -404,7 +403,10 @@ The following file formats are supported
       fade up to full volume over the time given. The sample may end before the
       fade-in is complete.
 
-      This returns the Channel object for the channel that was selected.
+      Returns the Channel object for the channel that was selected, or
+      ``None`` if no Channel was available to play the Sound (i.e. every
+      channel was already busy). Use :func:`pygame.mixer.find_channel` with
+      ``force=True`` first if you need a guaranteed Channel.
 
       .. ## Sound.play ##
 

--- a/src_c/doc/mixer_doc.h
+++ b/src_c/doc/mixer_doc.h
@@ -18,7 +18,7 @@
 #define DOC_MIXER_GETBUSY "get_busy() -> bool\ntest if any sound is being mixed"
 #define DOC_MIXER_GETSDLMIXERVERSION "get_sdl_mixer_version() -> (major, minor, patch)\nget_sdl_mixer_version(linked=True) -> (major, minor, patch)\nget the mixer's SDL version"
 #define DOC_MIXER_SOUND "Sound(filename) -> Sound\nSound(file=filename) -> Sound\nSound(file=pathlib_path) -> Sound\nSound(buffer) -> Sound\nSound(buffer=buffer) -> Sound\nSound(object) -> Sound\nSound(file=object) -> Sound\nSound(array=object) -> Sound\nCreate a new Sound object from a file or buffer object"
-#define DOC_MIXER_SOUND_PLAY "play(loops=0, maxtime=0, fade_ms=0) -> Channel\nbegin sound playback"
+#define DOC_MIXER_SOUND_PLAY "play(loops=0, maxtime=0, fade_ms=0) -> Channel | None\nbegin sound playback"
 #define DOC_MIXER_SOUND_STOP "stop() -> None\nstop sound playback"
 #define DOC_MIXER_SOUND_FADEOUT "fadeout(time, /) -> None\nstop sound playback after fading out"
 #define DOC_MIXER_SOUND_SETVOLUME "set_volume(value, /) -> None\nset the playback volume for this Sound"


### PR DESCRIPTION
Fixes #3810.

Sound.play() can return None when no free channel is available, but the stub said `-> Channel` and the docs claimed it 'forcibly' selects one. The C implementation in `src_c/mixer.c` returns None when `Mix_PlayChannelTimed` / `Mix_FadeInChannelTimed` returns -1.

## Changes
- `mixer.pyi`: `Sound.play` return type → `Channel | None`
- `mixer.rst`: drop the inaccurate 'forcibly select' line; document the None case and point users to `find_channel(force=True)`
- `mixer_doc.h`: regenerated to match

## Note on PR #3809
This touches the same three files as #3809 but at different lines (#3809 fixes `find_channel`, `get_init`, `get_sound`, `get_queue`). No semantic overlap; minor textual rebase only.