### PR TITLE
Fixed certain render tests failing when using specific macos versions

### DIFF
--- a/test/render_test.py
+++ b/test/render_test.py
@@ -47,6 +47,8 @@ class RendererTest(unittest.TestCase):
             self.renderer.to_surface(small_surf)
 
     def test_blit(self):
+        self.renderer.draw_color = "BLACK"
+        self.renderer.clear()
         surface = pygame.Surface((10, 10))
         surface.fill((80, 120, 160, 200))
         texture = _render.Texture.from_surface(self.renderer, surface)
@@ -79,6 +81,8 @@ class RendererTest(unittest.TestCase):
                 self.assertEqual(surf.get_at((x, y)), pygame.Color(255, 255, 0, 255))
 
     def test_draw_point(self):
+        self.renderer.draw_color = "BLACK"
+        self.renderer.clear()
         self.renderer.draw_color = "YELLOW"
         self.renderer.draw_point((10, 10))
         surf = self.renderer.to_surface()
@@ -308,6 +312,9 @@ class TextureTest(unittest.TestCase):
         self.assertEqual(surf_size, (texture2.width, texture2.height))
 
     def test_draw_triangle(self):
+        self.renderer.draw_color = "BLACK"
+        self.renderer.clear()
+
         texture2 = self.create_texture_from_surface()
         texture2.draw_triangle(
             (50, 10),

--- a/test/render_test.py
+++ b/test/render_test.py
@@ -23,6 +23,9 @@ class RendererTest(unittest.TestCase):
         self.window = pygame.Window(size=(100, 100))
         self.renderer = _render.Renderer(self.window)
 
+        self.renderer.draw_color = "BLACK"
+        self.renderer.clear()
+
     def test_to_surface(self):
         self.renderer.draw_color = "YELLOW"
         self.renderer.draw_point((10, 10))  # assumes Renderer.draw_point works
@@ -47,8 +50,6 @@ class RendererTest(unittest.TestCase):
             self.renderer.to_surface(small_surf)
 
     def test_blit(self):
-        self.renderer.draw_color = "BLACK"
-        self.renderer.clear()
         surface = pygame.Surface((10, 10))
         surface.fill((80, 120, 160, 200))
         texture = _render.Texture.from_surface(self.renderer, surface)
@@ -81,8 +82,6 @@ class RendererTest(unittest.TestCase):
                 self.assertEqual(surf.get_at((x, y)), pygame.Color(255, 255, 0, 255))
 
     def test_draw_point(self):
-        self.renderer.draw_color = "BLACK"
-        self.renderer.clear()
         self.renderer.draw_color = "YELLOW"
         self.renderer.draw_point((10, 10))
         surf = self.renderer.to_surface()
@@ -312,9 +311,6 @@ class TextureTest(unittest.TestCase):
         self.assertEqual(surf_size, (texture2.width, texture2.height))
 
     def test_draw_triangle(self):
-        self.renderer.draw_color = "BLACK"
-        self.renderer.clear()
-
         texture2 = self.create_texture_from_surface()
         texture2.draw_triangle(
             (50, 10),

--- a/test/render_test.py
+++ b/test/render_test.py
@@ -23,7 +23,6 @@ class RendererTest(unittest.TestCase):
         self.window = pygame.Window(size=(100, 100))
         self.renderer = _render.Renderer(self.window)
 
-        self.renderer.draw_color = "BLACK"
         self.renderer.clear()
 
     def test_to_surface(self):

--- a/test/render_test.py
+++ b/test/render_test.py
@@ -23,7 +23,10 @@ class RendererTest(unittest.TestCase):
         self.window = pygame.Window(size=(100, 100))
         self.renderer = _render.Renderer(self.window)
 
+        init_draw_color = self.renderer.draw_color
+        self.renderer.draw_color = "BLACK"
         self.renderer.clear()
+        self.renderer.draw_color = init_draw_color
 
     def test_to_surface(self):
         self.renderer.draw_color = "YELLOW"
@@ -237,6 +240,7 @@ class TextureTest(unittest.TestCase):
     def setUp(self):
         self.window = pygame.Window(size=(100, 100))
         self.renderer = _render.Renderer(self.window)
+        self.renderer.clear()
         self.texture = _render.Texture(self.renderer, (80, 60))
 
     def create_texture_from_surface(self):


### PR DESCRIPTION
Some render tests were failing due to the fact that the renderer was not cleared before performing said tests. This causes the renderer to contain garbage data on some macos computers, and since some tests expect the untouched renderer data to be pure black, they obviously fail. 