### PR TITLE
Added web as imcompatible with Briefcase

### DIFF
--- a/src_py/__briefcase/pygame_ce.py
+++ b/src_py/__briefcase/pygame_ce.py
@@ -2,7 +2,7 @@ from briefcase.bootstraps.base import BaseGuiBootstrap
 
 
 class PygameCEGuiBootstrap(BaseGuiBootstrap):
-    display_name_annotation = "does not support iOS/Android deployment"
+    display_name_annotation = "does not support iOS/Android/Web deployment"
 
     def app_source(self):
         return """\


### PR DESCRIPTION
Changed display_name_annotation in src_py/__briefcase/pygame_ce.py to include web as incompatible, matching previous style guides.