### PR TITLE
Fix typo in vector __str__ NotImplementedError message

### DIFF
--- a/src_c/math.c
+++ b/src_c/math.c
@@ -1968,7 +1968,7 @@ vector_str(pgVector *self)
     else {
         return RAISE(
             PyExc_NotImplementedError,
-            "repr() for Vectors of higher dimensions are not implemented yet");
+            "str() for Vectors of higher dimensions are not implemented yet");
     }
 
     if (!_vector_check_snprintf_success(tmp, STRING_BUF_SIZE_STR)) {


### PR DESCRIPTION
While reviewing issue #3828, I noticed the `NotImplementedError` raised by
`vector_str` in `src_c/math.c` (line 1971) incorrectly referred to itself as
`repr()`. The function is registered as `tp_str` (Python's `__str__`), so the
message should say `str()`.

The corresponding `repr()` function on line 1940 correctly mentions
`repr()`, so this only touches the str branch.

Closes #3828

## Testing

- Verified the diff only changes the str function (line 1971)
- Did not run the C build since this is a one-character text fix in an error
  message, no logic change