### PR TITLE
Improve FRect note in docs

### DIFF
--- a/docs/reST/ref/rect.rst
+++ b/docs/reST/ref/rect.rst
@@ -17,7 +17,10 @@
    | :sg:`FRect(object, /) -> FRect`
    | :sg:`FRect() -> FRect`
 
-   .. versionchanged:: 2.2 Since version 2.2 there is another class called FRect that serves the same purpose as as `Rect` but it can hold floats instead of integers.
+   .. versionadded:: 2.2
+      Added ``FRect`` class that is functionally identical to ``Rect`` but uses
+      floats instead of integers, enabling fractional precision and avoiding
+      truncation error while being interchangeable with standard Rects.
 
    Pygame uses Rect objects to store and manipulate rectangular areas. A Rect
    can be created from a combination of left, top, width, and height values.


### PR DESCRIPTION
Fix typo "same purpose as as \`Rect\`...", change from `versionchanged` to `versionadded`, and improve description.