### PR TITLE
Fix win32+SDL3 scrap/camera

### DIFF
--- a/src_c/camera.h
+++ b/src_c/camera.h
@@ -50,7 +50,7 @@
 /* At the time of writing of this comment, _camera does not compile on windows
  * while using the MinGW compiler (due to missing API). So we do a _MSC_VER
  * check here to compile this only under the MSVC compiler */
-#if defined(__WIN32__) && defined(_MSC_VER)
+#if defined(WIN32) && defined(_MSC_VER)
 #define PYGAME_WINDOWS_CAMERA 1
 
 #include <mfapi.h>

--- a/src_c/camera_windows.c
+++ b/src_c/camera_windows.c
@@ -752,6 +752,12 @@ int
 windows_process_image(pgCameraObject *self, BYTE *data, DWORD length,
                       SDL_Surface *surf)
 {
+    PG_PixelFormat *format = PG_GetSurfaceFormat(surf);
+    if (format == NULL) {
+        PyErr_SetString(pgExc_SDLError, SDL_GetError());
+        return 0;
+    }
+
     SDL_LockSurface(surf);
 
     int size = self->width * self->height;
@@ -763,15 +769,15 @@ windows_process_image(pgCameraObject *self, BYTE *data, DWORD length,
                 /* optimized version for 32 bit output surfaces*/
                 /* memcpy(surf->pixels, data, length); */
 
-                bgr32_to_rgb(data, surf->pixels, size, surf->format);
+                bgr32_to_rgb(data, surf->pixels, size, format);
                 break;
             case YUV_OUT:
                 rgb_to_yuv(data, surf->pixels, size, V4L2_PIX_FMT_XBGR32,
-                           surf->format);
+                           format);
                 break;
             case HSV_OUT:
                 rgb_to_hsv(data, surf->pixels, size, V4L2_PIX_FMT_XBGR32,
-                           surf->format);
+                           format);
                 break;
         }
     }
@@ -779,15 +785,15 @@ windows_process_image(pgCameraObject *self, BYTE *data, DWORD length,
     if (self->pixelformat == MFVideoFormat_YUY2.Data1) {
         switch (self->color_out) {
             case YUV_OUT:
-                yuyv_to_yuv(data, surf->pixels, size, surf->format);
+                yuyv_to_yuv(data, surf->pixels, size, format);
                 break;
             case RGB_OUT:
-                yuyv_to_rgb(data, surf->pixels, size, surf->format);
+                yuyv_to_rgb(data, surf->pixels, size, format);
                 break;
             case HSV_OUT:
-                yuyv_to_rgb(data, surf->pixels, size, surf->format);
+                yuyv_to_rgb(data, surf->pixels, size, format);
                 rgb_to_hsv(surf->pixels, surf->pixels, size, V4L2_PIX_FMT_YUYV,
-                           surf->format);
+                           format);
                 break;
         }
     }

--- a/src_c/include/pgplatform.h
+++ b/src_c/include/pgplatform.h
@@ -48,7 +48,7 @@
 /* SDL needs WIN32 */
 #if !defined(WIN32) &&                                           \
     (defined(MS_WIN32) || defined(_WIN32) || defined(__WIN32) || \
-     defined(__WIN32__) || defined(_WINDOWS))
+     defined(__WIN32__) || defined(_WINDOWS) || defined(SDL_PLATFORM_WIN32))
 #define WIN32
 #endif
 

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -66,11 +66,11 @@ static PyObject *
 _scrap_has_text(PyObject *self, PyObject *args);
 
 /* Determine what type of clipboard we are using */
-#if !defined(__WIN32__)
+#if !defined(WIN32)
 #define SDL2_SCRAP
 #include "scrap_sdl2.c"
 
-#elif defined(__WIN32__)
+#elif defined(WIN32)
 #define WIN_SCRAP
 #include "scrap_win.c"
 


### PR DESCRIPTION
The `__WIN32__` was from SDL2, so SDL2->SDL3 `__WIN32__` -> `SDL_PLATFORM_WIN32` was unintentionally breaking some windows scrap tests, along with pygame.examples.camera. This exposed a minor pixelformat compile error in camera_windows.c, which I've fixed.

See https://github.com/libsdl-org/SDL/blob/main/docs/README-migration.md