### PR TITLE
Fix reference leak in Renderer.from_window() 🤖🤖🤖

### DIFF
--- a/src_c/render.c
+++ b/src_c/render.c
@@ -85,7 +85,7 @@ renderer_from_window(PyTypeObject *cls, PyObject *args, PyObject *kwargs)
         return RAISE(pgExc_SDLError, SDL_GetError());
     }
     self->target = NULL;
-    return Py_NewRef(self);
+    return (PyObject *)self;
 }
 
 static PyObject *

--- a/test/render_test.py
+++ b/test/render_test.py
@@ -1,10 +1,13 @@
 import gc
+import platform
 import sys
 import unittest
 import weakref
 
 import pygame
 import pygame._render as _render
+
+IS_PYPY = "PyPy" == platform.python_implementation()
 
 
 class DrawableObject:
@@ -236,6 +239,7 @@ class RendererTest(unittest.TestCase):
         self.renderer.draw_color = "YELLOW"
         self.assertEqual(self.renderer.draw_color, pygame.Color(255, 255, 0, 255))
 
+    @unittest.skipIf(IS_PYPY, "PyPy doesn't have sys.getrefcount")
     def test_from_window__no_reference_leak(self):
         # Renderer.from_window() used to return an object with an extra,
         # untracked reference (see issue #3799): the object it returned

--- a/test/render_test.py
+++ b/test/render_test.py
@@ -1,4 +1,5 @@
 import gc
+import sys
 import unittest
 import weakref
 
@@ -234,6 +235,23 @@ class RendererTest(unittest.TestCase):
         self.assertEqual(self.renderer.draw_color, pygame.Color(0, 0, 0, 0))
         self.renderer.draw_color = "YELLOW"
         self.assertEqual(self.renderer.draw_color, pygame.Color(255, 255, 0, 255))
+
+    def test_from_window__no_reference_leak(self):
+        # Renderer.from_window() used to return an object with an extra,
+        # untracked reference (see issue #3799): the object it returned
+        # already came back from Renderer.tp_new() with a refcount of 1,
+        # but from_window() incremented it again before returning, so the
+        # object was never freed even after the caller's only reference
+        # to it was dropped.
+        pygame.display.set_mode((100, 100), pygame.SCALED)
+        self.addCleanup(pygame.display.quit)
+        window = pygame.Window.from_display_module()
+
+        renderer = _render.Renderer.from_window(window)
+        # getrefcount()'s own argument adds a temporary reference, so a
+        # renderer held by exactly one real reference (the local variable
+        # here) should report a refcount of 2, not 3.
+        self.assertEqual(sys.getrefcount(renderer), 2)
 
 
 class TextureTest(unittest.TestCase):


### PR DESCRIPTION
## What

`Renderer.from_window()` leaked one reference on every call.

`renderer_from_window()` in `src_c/render.c` creates the new object via
`cls->tp_new(cls, NULL, NULL)`, which already returns a reference with
refcount 1. The function then called `Py_NewRef(self)` before returning,
bumping the refcount to 2 for an object only one reference is actually
handed back to the caller. That extra reference was never released
anywhere, so every `Renderer` created via `.from_window()` was leaked
and never garbage collected.

The fix removes the extra increment and returns the `tp_new()` reference
directly, matching the existing pattern used by
`window_from_display_module()` in `src_c/window.c`, which uses the same
`tp_new()` call and correctly returns the object as-is on the
fresh-object path (it only uses `Py_NewRef()` on the *other* branch,
where it returns an existing, borrowed object it doesn't own a fresh
reference to).

Fixes #3799.

## How I verified it

- Reproduced the exact leak from the issue against current `main`
  (before the fix) with the refcount script from
  [oddbookworm's comment](https://github.com/pygame-community/pygame-ce/issues/3799#issuecomment-4464009280):
  `sys.getrefcount()` on a freshly created renderer reported `3` instead
  of the expected `2`. On Windows, `pygame.display.set_mode()` doesn't
  attach an `SDL_Renderer` by default, so I used the `SCALED` flag to
  get one (also confirmed this works headless under
  `SDL_VIDEODRIVER=dummy`).
- Built `pygame-ce` locally from source (MinGW-w64 GCC + the repo's
  prebuilt Windows SDL2 dependencies) and confirmed the same script
  reports `2` after the fix.
- Ran the existing `test/render_test.py` suite (34 tests) against the
  built extension — all pass, 1 unrelated skip.
- Added a regression test (`test_from_window__no_reference_leak`) and
  confirmed it fails against the unpatched code (`3 != 2`) and passes
  against the patched code.
- Stress-tested 200 create/use/`present()`/delete cycles of
  `Renderer.from_window()` in a loop with `gc.collect()` at the end —
  no crash, no growth in refcount, confirming the fix doesn't
  over-correct into a double-free/use-after-free.

## AI disclosure

Per CONTRIBUTING.md: this fix was researched, implemented, and verified
by an AI agent (Claude, operating this GitHub account with the owner's
knowledge and oversight). The root cause and suggested fix direction
were already identified in the issue by @oddbookworm; I located and
applied the fix, built the project from source, reproduced the bug,
confirmed the fix resolves it, ran the existing test suite, and added
a new regression test — all steps described above were actually
executed, not just described.
