### PR TITLE
Simplify ptr -> Python int code

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -901,11 +901,7 @@ snd_get_samples_address(PyObject *self, PyObject *closure)
 
     MIXER_INIT_CHECK();
 
-#if SIZEOF_VOID_P > SIZEOF_LONG
-    return PyLong_FromUnsignedLongLong((unsigned PY_LONG_LONG)chunk->abuf);
-#else
-    return PyLong_FromUnsignedLong((unsigned long)chunk->abuf);
-#endif
+    return PyLong_FromVoidPtr(chunk->abuf);
 }
 
 PyMethodDef sound_methods[] = {

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -520,13 +520,7 @@ _pxarray_get_arrayinterface(pgPixelArrayObject *self, void *closure)
 static PyObject *
 _pxarray_get_pixelsaddress(pgPixelArrayObject *self, void *closure)
 {
-    void *address = self->pixels;
-
-#if SIZEOF_VOID_P > SIZEOF_LONG
-    return PyLong_FromUnsignedLongLong((unsigned PY_LONG_LONG)address);
-#else
-    return PyLong_FromUnsignedLong((unsigned long)address);
-#endif
+    return PyLong_FromVoidPtr(self->pixels);
 }
 
 static int

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -4330,20 +4330,12 @@ static PyObject *
 surf_get_pixels_address(PyObject *self, PyObject *closure)
 {
     SDL_Surface *surface = pgSurface_AsSurface(self);
-    void *address;
 
     if (!surface) {
         Py_RETURN_NONE;
     }
-    if (!surface->pixels) {
-        return PyLong_FromLong(0L);
-    }
-    address = surface->pixels;
-#if SIZEOF_VOID_P > SIZEOF_LONG
-    return PyLong_FromUnsignedLongLong((unsigned PY_LONG_LONG)address);
-#else
-    return PyLong_FromUnsignedLong((unsigned long)address);
-#endif
+
+    return PyLong_FromVoidPtr(surface->pixels);
 }
 
 static int


### PR DESCRIPTION
I was looking at the 3.15 release notes, and it said that PY_LONG_LONG is now soft deprecated. So I found some instances of us using it, and switched to using PyLong_FromVoidPtr instead of different size variants for different pointer sizes