### PR TITLE
Use Py_CLEAR / Py_XSETREF for some refcount operations

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -733,8 +733,7 @@ _ftfont_init(pgFontObject *self, PyObject *args, PyObject *kwds)
         _PGFT_Quit(self->freetype);
         self->freetype = 0;
     }
-    Py_XDECREF(self->path);
-    self->path = 0;
+    Py_CLEAR(self->path);
     self->is_scalable = 0;
 
     self->face_size = face_size;

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -1179,10 +1179,7 @@ pgBuffer_Release(pg_buffer *pg_view_p)
 void
 _pg_release_buffer_generic(Py_buffer *view_p)
 {
-    if (view_p->obj) {
-        Py_XDECREF(view_p->obj);
-        view_p->obj = 0;
-    }
+    Py_CLEAR(view_p->obj);
 }
 
 void

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -83,10 +83,7 @@ _display_state_cleanup(_DisplayState *state)
         free(state->title);
         state->title = NULL;
     }
-    if (state->icon) {
-        Py_XDECREF(state->icon);
-        state->icon = NULL;
-    }
+    Py_CLEAR(state->icon);
     if (state->gl_context) {
         SDL_GL_DeleteContext(state->gl_context);
         state->gl_context = NULL;
@@ -2703,8 +2700,7 @@ pg_set_icon(PyObject *self, PyObject *surface)
             return NULL;
         }
     }
-    Py_XDECREF(state->icon);
-    state->icon = Py_NewRef(surface);
+    Py_XSETREF(state->icon, Py_NewRef(surface));
     if (win) {
         SDL_SetWindowIcon(win, pgSurface_AsSurface(surface));
     }

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -3680,8 +3680,7 @@ vectoriter_next(vectoriter *it)
         return PyFloat_FromDouble(item);
     }
 
-    Py_DECREF(it->vec);
-    it->vec = NULL;
+    Py_CLEAR(it->vec);
     return NULL;
 }
 

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -299,8 +299,7 @@ endsound_callback(int channel)
             PyGILState_STATE gstate = PyGILState_Ensure();
             int channelnum;
             Mix_Chunk *sound = pgSound_AsChunk(channeldata[channel].queue);
-            Py_XDECREF(channeldata[channel].sound);
-            channeldata[channel].sound = channeldata[channel].queue;
+            Py_XSETREF(channeldata[channel].sound, channeldata[channel].queue);
             channeldata[channel].queue = NULL;
             PyGILState_Release(gstate);
             channelnum = Mix_PlayChannelTimed(channel, sound, 0, -1);
@@ -310,8 +309,7 @@ endsound_callback(int channel)
         }
         else {
             PyGILState_STATE gstate = PyGILState_Ensure();
-            Py_XDECREF(channeldata[channel].sound);
-            channeldata[channel].sound = NULL;
+            Py_CLEAR(channeldata[channel].sound);
             PyGILState_Release(gstate);
             Mix_GroupChannel(channel, -1);
         }
@@ -673,10 +671,8 @@ pgSound_Play(PyObject *self, PyObject *args, PyObject *kwargs)
         Py_RETURN_NONE;
     }
 
-    Py_XDECREF(channeldata[channelnum].sound);
-    Py_XDECREF(channeldata[channelnum].queue);
-    channeldata[channelnum].queue = NULL;
-    channeldata[channelnum].sound = Py_NewRef(self);
+    Py_CLEAR(channeldata[channelnum].queue);
+    Py_XSETREF(channeldata[channelnum].sound, Py_NewRef(self));
 
     // make sure volume on this arbitrary channel is set to full
     Mix_Volume(channelnum, 128);
@@ -1137,10 +1133,8 @@ chan_play(PyObject *self, PyObject *args, PyObject *kwargs)
     }
     Py_END_ALLOW_THREADS;
 
-    Py_XDECREF(channeldata[channelnum].sound);
-    Py_XDECREF(channeldata[channelnum].queue);
-    channeldata[channelnum].sound = Py_NewRef(sound);
-    channeldata[channelnum].queue = NULL;
+    Py_CLEAR(channeldata[channelnum].queue);
+    Py_XSETREF(channeldata[channelnum].sound, Py_NewRef(sound));
     Py_RETURN_NONE;
 }
 
@@ -1178,8 +1172,7 @@ chan_queue(PyObject *self, PyObject *sound)
         channeldata[channelnum].sound = Py_NewRef(sound);
     }
     else {
-        Py_XDECREF(channeldata[channelnum].queue);
-        channeldata[channelnum].queue = Py_NewRef(sound);
+        Py_XSETREF(channeldata[channelnum].queue, Py_NewRef(sound));
     }
     Py_RETURN_NONE;
 }

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -118,16 +118,14 @@ fetch_object_methods(pgRWHelper *helper, PyObject *obj)
 
     if (PyObject_HasAttrString(obj, "read")) {
         helper->read = PyObject_GetAttrString(obj, "read");
-        if (helper->read && !PyCallable_Check(helper->read)) {
-            Py_DECREF(helper->read);
-            helper->read = NULL;
+        if (!PyCallable_Check(helper->read)) {
+            Py_CLEAR(helper->read);
         }
     }
     if (PyObject_HasAttrString(obj, "write")) {
         helper->write = PyObject_GetAttrString(obj, "write");
-        if (helper->write && !PyCallable_Check(helper->write)) {
-            Py_DECREF(helper->write);
-            helper->write = NULL;
+        if (!PyCallable_Check(helper->write)) {
+            Py_CLEAR(helper->write);
         }
     }
     if (!helper->read && !helper->write) {
@@ -136,23 +134,20 @@ fetch_object_methods(pgRWHelper *helper, PyObject *obj)
     }
     if (PyObject_HasAttrString(obj, "seek")) {
         helper->seek = PyObject_GetAttrString(obj, "seek");
-        if (helper->seek && !PyCallable_Check(helper->seek)) {
-            Py_DECREF(helper->seek);
-            helper->seek = NULL;
+        if (!PyCallable_Check(helper->seek)) {
+            Py_CLEAR(helper->seek);
         }
     }
     if (PyObject_HasAttrString(obj, "tell")) {
         helper->tell = PyObject_GetAttrString(obj, "tell");
-        if (helper->tell && !PyCallable_Check(helper->tell)) {
-            Py_DECREF(helper->tell);
-            helper->tell = NULL;
+        if (!PyCallable_Check(helper->tell)) {
+            Py_CLEAR(helper->tell);
         }
     }
     if (PyObject_HasAttrString(obj, "close")) {
         helper->close = PyObject_GetAttrString(obj, "close");
-        if (helper->close && !PyCallable_Check(helper->close)) {
-            Py_DECREF(helper->close);
-            helper->close = NULL;
+        if (!PyCallable_Check(helper->close)) {
+            Py_CLEAR(helper->close);
         }
     }
     return 0;

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -410,15 +410,8 @@ surface_cleanup(pgSurfaceObject *self)
         PyMem_Free(self->subsurface);
         self->subsurface = NULL;
     }
-    if (self->dependency) {
-        Py_DECREF(self->dependency);
-        self->dependency = NULL;
-    }
-
-    if (self->locklist) {
-        Py_DECREF(self->locklist);
-        self->locklist = NULL;
-    }
+    Py_CLEAR(self->dependency);
+    Py_CLEAR(self->locklist);
     self->owner = 0;
 }
 
@@ -4256,8 +4249,7 @@ _release_buffer(Py_buffer *view_p)
 
     Py_DECREF(consumer_ref);
     PyMem_Free(internal);
-    Py_DECREF(view_p->obj);
-    view_p->obj = 0;
+    Py_CLEAR(view_p->obj);
 }
 
 static int

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -157,9 +157,7 @@ window_destroy(pgWindowObject *self, PyObject *_null)
         // since this surface will be deallocated by SDL when the window is
         // destroyed.
         self->surf->surf = NULL;
-
-        Py_DECREF(self->surf);
-        self->surf = NULL;
+        Py_CLEAR(self->surf);
     }
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
This PR is in the same train of thought as https://github.com/pygame-community/pygame-ce/pull/3797

These macros have safety benefits:

CLEAR is XDECREF + setting NULL, but it sets the field to NULL before the decref, so it's safer. The field goes from valid object to NULL, at no point is it ever pointing to a dead object.

XSETREF is XDECREF + setting a new object, but the new object's pointer is written to the location before the old object at that location is decref-ed. Therefore, from any external perspective it goes from one valid object to another, never pointing to a potentially dead object.

Refcounting macro documentation, for reference: https://docs.python.org/3.16/c-api/refcounting.html

These safety benefits may actually mean something without the GIL, or if we convert more types to use GC (heap types need to use GC), but right now the benefit I see is making the code more modern and more concise.
