### PR TITLE
Do degrees/radian divs at compile time

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -548,6 +548,10 @@ if cc.get_argument_syntax() == 'msvc'
     # base warnings on msvc
     add_global_arguments(['/W3', '/wd4142', '/wd4996'], language: 'c')
 
+    # UNCOMMENT TO see .cod files in the mesonbuild directory with assembly
+    # in them
+    # add_global_arguments(['/FAcs'], language: 'c')
+
     if get_option('error_on_warns') and not is_pypy
         warnings_error += '/WX'
     endif

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -51,9 +51,6 @@
 
 #define TWO_PI (2. * M_PI)
 
-#define RAD_TO_DEG (180.0 / M_PI)
-#define DEG_TO_RAD (M_PI / 180.0)
-
 #ifndef M_PI_2
 #define M_PI_2 (M_PI / 2.0)
 #endif /* M_PI_2 */
@@ -96,8 +93,8 @@ static PyTypeObject pgVectorIter_Type;
 #define _vector_subtype_new(x) \
     ((pgVector *)(Py_TYPE(x)->tp_new(Py_TYPE(x), NULL, NULL)))
 
-#define DEG2RAD(angle) ((angle) * M_PI / 180.)
-#define RAD2DEG(angle) ((angle) * 180. / M_PI)
+#define DEG2RAD(angle) ((angle) * (M_PI / 180.))
+#define RAD2DEG(angle) ((angle) * (180. / M_PI))
 
 typedef struct {
     PyObject_HEAD double coords[VECTOR_MAX_SIZE]; /* Coordinates */
@@ -1360,9 +1357,8 @@ static PyObject *
 vector_get_angle(pgVector *self, void *closure)
 {
     double angle_rad = _pg_atan2(self->coords[1], self->coords[0]);
-    double angle_deg = angle_rad * RAD_TO_DEG;
 
-    return PyFloat_FromDouble(angle_deg);
+    return PyFloat_FromDouble(RAD2DEG(angle_rad));
 }
 
 static PyObject *


### PR DESCRIPTION
And consolidate 2 disparate pairs of conversion macros.

Previously there were 2 different pairs of conversion macros, one of which just calculated the scalar of the conversion, (and was only used in 1 spot), and another that took the angle as an argument and ran the math. However, this second pair of macros was written such that the multiplication and division couldn't be constant folded before runtime, so the divisions were happening at runtime (division is the slowest arithmetic operation). This commit adds another pair of parentheses to that macro so it can do that math first and then multiply against the angle. Cuts the number of divsd instructions generated on my system in the math module from 55 to 37. This theoretically could change the output by a very small amount because it rounds differently, but it's double precision math, I wasn't able to get it to deviate record-ably at all in testing.

Also added the way I get the assembly to meson.build, for future reference by me or others.

| Benchmark             | main2   | remove_divs           |
|-----------------------|:-------:|:---------------------:|
| rotate_ip             | 16.0 ns | 15.7 ns: 1.02x faster |
| as_polar              | 40.5 ns | 38.9 ns: 1.04x faster |
| angle_to vec          | 28.9 ns | 26.4 ns: 1.09x faster |
| angle_to vec subclass | 29.2 ns | 26.6 ns: 1.10x faster |
| angle_to tuple        | 35.6 ns | 33.3 ns: 1.07x faster |
| cross int             | 32.6 ns | 33.0 ns: 1.01x slower |
| cross float           | 21.4 ns | 21.7 ns: 1.01x slower |
| cross vector          | 13.6 ns | 13.9 ns: 1.03x slower |
| Geometric mean        | (ref)   | 1.02x faster          |

Benchmark hidden because not significant (3): add vector, add tuple, CONTROL_length


<details>
<summary>Benchmark script</summary>

```py
# python .\bench.py -o main2.json
# python .\bench.py -o remove_divs.json
# pyperf compare_to main2.json remove_divs.json --table --table-format=md

import pyperf
runner = pyperf.Runner()

import pygame

class MyVecSubclass(pygame.Vector2):
    pass

S = "import pygame; v = pygame.Vector2(1.0, 2.0)"
runner.timeit("rotate_ip",     "r(37.0)",   setup=S + "; r = v.rotate_ip")
runner.timeit("as_polar",      "f()",       setup=S + "; f = v.as_polar")
runner.timeit("angle_to vec",      "f(o)",      setup=S + "; f = v.angle_to; o = pygame.Vector2(3.0, 4.0)")
runner.timeit("angle_to vec subclass",      "f(o)",      setup=S + "; f = v.angle_to; o = MyVecSubclass(3.0, 4.0)", globals={"MyVecSubclass": MyVecSubclass})
runner.timeit("angle_to tuple",      "f(t)",      setup=S + "; f = v.angle_to; t = (3.0, 4.0)")
runner.timeit("cross int",     "c((37,14))",   setup=S + "; c = v.cross")
runner.timeit("cross float",     "c((37.0,14.2))",   setup=S + "; c = v.cross")
runner.timeit("cross vector",     "c(v2)",   setup=S + "; c = v.cross ; v2 = pygame.Vector2(37.0,14.2)")
runner.timeit("add vector",     "v + v2",   setup=S + "; v2 = pygame.Vector2(37.0,14.2)")
runner.timeit("add tuple",     "v + t",   setup=S + "; t = (37.0,14.2)")
runner.timeit("CONTROL_length","f()",       setup=S + "; f = v.length")
```

</details>

I was trying to do another optimization as well, which didn't work. But that's why there are some strange tests in the benchmark (like vector subclass through angle_to).

This should impact the follow functions:
```py
Vector2
	.rotate*()
	.angle_to()
	.as_polar()
	.angle

Vector3
	.rotate*()
	.angle_to()
	.as_spherical()
```