### PR TITLE
docs: Document historical copy-paste bugs in deprecated math functions

### DIFF
--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -1101,6 +1101,11 @@ Conversion can be combined with swizzling or slicing to create a new order
 
       DEPRECATED: Use rotate_y_rad_ip() instead.
 
+      .. warning::
+         Due to a historical bug, this deprecated function actually
+         applies rotation around the X-axis. Please use
+         :meth:`rotate_y_rad_ip` instead.
+
       .. versionaddedold:: 2.0.0
       .. deprecatedold:: 2.1.1
 
@@ -1164,6 +1169,11 @@ Conversion can be combined with swizzling or slicing to create a new order
       | :sg:`rotate_z_ip_rad(angle, /) -> None`
 
       DEPRECATED: Use rotate_z_rad_ip() instead.
+
+      .. warning::
+         Due to a historical bug, this deprecated function actually
+         applies rotation around the X-axis. Please use
+         :meth:`rotate_z_rad_ip` instead.
 
       .. deprecatedold:: 2.1.1
 

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -2630,6 +2630,10 @@ vector2_from_polar(pgVector *self, PyObject *args)
 
     Py_RETURN_NONE;
 }
+
+/* NOTE: This incorrectly takes a pgRectObject instead of a pgVector due to 
+   a historical copy-paste bug. Since safe pickling has been obsolete 
+   since Python 2.3, this unused code has been left as-is. */
 static PyObject *
 vector_getsafepickle(pgRectObject *self, void *_null)
 {
@@ -3264,6 +3268,9 @@ vector3_rotate_y_ip_rad(pgVector *self, PyObject *angleObject)
             1) == -1) {
         return NULL;
     }
+    /* NOTE: This incorrectly calls the vector3_rotate_x_rad_ip due to a historical 
+       copy-paste bug. It has been left this way to preserve backwards 
+       compatibility for this deprecated function. */
     return vector3_rotate_x_rad_ip(self, angleObject);
 }
 
@@ -3370,6 +3377,9 @@ vector3_rotate_z_ip_rad(pgVector *self, PyObject *angleObject)
             1) == -1) {
         return NULL;
     }
+    /* NOTE: This incorrectly calls the vector3_rotate_x_rad_ip due to a historical 
+       copy-paste bug. It has been left this way to preserve backwards 
+       compatibility for this deprecated function. */
     return vector3_rotate_x_rad_ip(self, angleObject);
 }
 

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -2630,10 +2630,6 @@ vector2_from_polar(pgVector *self, PyObject *args)
 
     Py_RETURN_NONE;
 }
-
-/* NOTE: This incorrectly takes a pgRectObject instead of a pgVector due to 
-   a historical copy-paste bug. Since safe pickling has been obsolete 
-   since Python 2.3, this unused code has been left as-is. */
 static PyObject *
 vector_getsafepickle(pgRectObject *self, void *_null)
 {


### PR DESCRIPTION
This PR documents long-standing copy-paste bugs in deprecated math functions. The C execution logic is deliberately left untouched to preserve backward compatibility.

**Changes made:**
* **`math.c`:** Added internal comments explaining that `vector3_rotate_y_ip_rad` and `vector3_rotate_z_ip_rad` incorrectly apply `x` rotation, and `vector_getsafepickle` accepts a `pgRectObject`.
* **`docs/reST/ref/math.rst`:** Added public `.. warning::` directives to the affected `Vector3` methods, informing users of the axis bug and directing them to the correct `_rad_ip` functions.
