### PR TITLE
fix: resolve copy-paste bugs in deprecated vector3_rotate_y_ip_rad and vector3_rotate_z_ip_rad

### DIFF
--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -1102,9 +1102,8 @@ Conversion can be combined with swizzling or slicing to create a new order
       DEPRECATED: Use rotate_y_rad_ip() instead.
 
       .. note::
-         Due to a historical bug, in pygame-ce versions prior to 2.5.7 (and upstream pygame), 
-         this function incorrectly applied rotation around the X-axis. This has been fixed to 
-         correctly rotate around the Y-axis.
+         Due to a historical bug, this function incorrectly applied rotation around the X-axis. 
+         This has been fixed to correctly rotate around the Y-axis.
 
       .. versionchanged:: 2.5.8 Fixed rotation axis bug (previously rotated around X-axis).
       .. versionaddedold:: 2.0.0
@@ -1172,9 +1171,8 @@ Conversion can be combined with swizzling or slicing to create a new order
       DEPRECATED: Use rotate_z_rad_ip() instead.
 
       .. note::
-         Due to a historical bug, in pygame-ce versions prior to 2.5.7 (and upstream pygame), 
-         this function incorrectly applied rotation around the X-axis. This has been fixed to 
-         correctly rotate around the Z-axis.
+         Due to a historical bug, this function incorrectly applied rotation around the X-axis. 
+         This has been fixed to correctly rotate around the Z-axis.
 
       .. versionchanged:: 2.5.8 Fixed rotation axis bug (previously rotated around X-axis).
       .. deprecatedold:: 2.1.1

--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -1105,7 +1105,6 @@ Conversion can be combined with swizzling or slicing to create a new order
          Due to a historical bug, this function incorrectly applied rotation around the X-axis. 
          This has been fixed to correctly rotate around the Y-axis.
 
-      .. versionchanged:: 2.5.8 Fixed rotation axis bug (previously rotated around X-axis).
       .. versionaddedold:: 2.0.0
       .. deprecatedold:: 2.1.1
 
@@ -1174,7 +1173,6 @@ Conversion can be combined with swizzling or slicing to create a new order
          Due to a historical bug, this function incorrectly applied rotation around the X-axis. 
          This has been fixed to correctly rotate around the Z-axis.
 
-      .. versionchanged:: 2.5.8 Fixed rotation axis bug (previously rotated around X-axis).
       .. deprecatedold:: 2.1.1
 
       .. ## Vector3.rotate_z_ip_rad ##

--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -1101,12 +1101,12 @@ Conversion can be combined with swizzling or slicing to create a new order
 
       DEPRECATED: Use rotate_y_rad_ip() instead.
 
-      .. note::
-         Due to a historical bug, this function incorrectly applied rotation around the X-axis. 
-         This has been fixed to correctly rotate around the Y-axis.
-
       .. versionaddedold:: 2.0.0
       .. deprecatedold:: 2.1.1
+      .. versionchanged:: 2.5.8
+         Fixed a regression introduced in 2.1.1 where this method incorrectly rotated
+         around the X-axis instead of the Y-axis. In versions prior to 2.1.1, rotation
+         around the Y-axis worked correctly.
 
       .. ## Vector3.rotate_y_ip_rad ##
 
@@ -1169,11 +1169,12 @@ Conversion can be combined with swizzling or slicing to create a new order
 
       DEPRECATED: Use rotate_z_rad_ip() instead.
 
-      .. note::
-         Due to a historical bug, this function incorrectly applied rotation around the X-axis. 
-         This has been fixed to correctly rotate around the Z-axis.
-
+      .. versionaddedold:: 2.0.0
       .. deprecatedold:: 2.1.1
+      .. versionchanged:: 2.5.8
+         Fixed a regression introduced in 2.1.1 where this method incorrectly rotated
+         around the X-axis instead of the Z-axis. In versions prior to 2.1.1, rotation
+         around the Z-axis worked correctly.
 
       .. ## Vector3.rotate_z_ip_rad ##
 

--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -1101,6 +1101,12 @@ Conversion can be combined with swizzling or slicing to create a new order
 
       DEPRECATED: Use rotate_y_rad_ip() instead.
 
+      .. note::
+         Due to a historical bug, in pygame-ce versions prior to 2.5.7 (and upstream pygame), 
+         this function incorrectly applied rotation around the X-axis. This has been fixed to 
+         correctly rotate around the Y-axis.
+
+      .. versionchanged:: 2.5.8 Fixed rotation axis bug (previously rotated around X-axis).
       .. versionaddedold:: 2.0.0
       .. deprecatedold:: 2.1.1
 
@@ -1165,6 +1171,12 @@ Conversion can be combined with swizzling or slicing to create a new order
 
       DEPRECATED: Use rotate_z_rad_ip() instead.
 
+      .. note::
+         Due to a historical bug, in pygame-ce versions prior to 2.5.7 (and upstream pygame), 
+         this function incorrectly applied rotation around the X-axis. This has been fixed to 
+         correctly rotate around the Z-axis.
+
+      .. versionchanged:: 2.5.8 Fixed rotation axis bug (previously rotated around X-axis).
       .. deprecatedold:: 2.1.1
 
       .. ## Vector3.rotate_z_ip_rad ##

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -3264,7 +3264,7 @@ vector3_rotate_y_ip_rad(pgVector *self, PyObject *angleObject)
             1) == -1) {
         return NULL;
     }
-    return vector3_rotate_x_rad_ip(self, angleObject);
+    return vector3_rotate_y_rad_ip(self, angleObject);
 }
 
 static PyObject *
@@ -3370,7 +3370,7 @@ vector3_rotate_z_ip_rad(pgVector *self, PyObject *angleObject)
             1) == -1) {
         return NULL;
     }
-    return vector3_rotate_x_rad_ip(self, angleObject);
+    return vector3_rotate_z_rad_ip(self, angleObject);
 }
 
 static PyObject *

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -2180,6 +2180,23 @@ class Vector3TypeTest(unittest.TestCase):
         vec.rotate_y_rad_ip(math.pi / 2)
         self.assertEqual(vec, (0, 0, -1))
 
+    def test_rotate_y_ip_rad(self):
+        import warnings
+
+        vec = Vector3(1, 0, 0)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", DeprecationWarning)
+            
+            # This previously (and incorrectly) rotated around the X axis
+            vec.rotate_y_ip_rad(math.pi / 2)
+            
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("vector3_rotate_y_rad_ip", str(w[-1].message))
+            
+        # Verify it now correctly rotates around the Y axis
+        self.assertEqual(vec, (0, 0, -1))
+
     def test_rotate_z(self):
         v1 = Vector3(1, 0, 0)
         v2 = v1.rotate_z(90)
@@ -2227,6 +2244,23 @@ class Vector3TypeTest(unittest.TestCase):
     def test_rotate_z_rad_ip(self):
         vec = Vector3(1, 0, 0)
         vec.rotate_z_rad_ip(math.pi / 2)
+        self.assertEqual(vec, (0, 1, 0))
+
+    def test_rotate_z_ip_rad(self):
+        import warnings
+
+        vec = Vector3(1, 0, 0)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", DeprecationWarning)
+            
+            # This previously (and incorrectly) rotated around the X axis
+            vec.rotate_z_ip_rad(math.pi / 2)
+            
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("vector3_rotate_z_rad_ip", str(w[-1].message))
+            
+        # Verify it now correctly rotates around the Z axis
         self.assertEqual(vec, (0, 1, 0))
 
     def test_normalize(self):

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -2186,14 +2186,14 @@ class Vector3TypeTest(unittest.TestCase):
         vec = Vector3(1, 0, 0)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", DeprecationWarning)
-            
+
             # This previously (and incorrectly) rotated around the X axis
             vec.rotate_y_ip_rad(math.pi / 2)
-            
+
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
             self.assertIn("vector3_rotate_y_rad_ip", str(w[-1].message))
-            
+
         # Verify it now correctly rotates around the Y axis
         self.assertEqual(vec, (0, 0, -1))
 
@@ -2252,14 +2252,14 @@ class Vector3TypeTest(unittest.TestCase):
         vec = Vector3(1, 0, 0)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", DeprecationWarning)
-            
+
             # This previously (and incorrectly) rotated around the X axis
             vec.rotate_z_ip_rad(math.pi / 2)
-            
+
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
             self.assertIn("vector3_rotate_z_rad_ip", str(w[-1].message))
-            
+
         # Verify it now correctly rotates around the Z axis
         self.assertEqual(vec, (0, 1, 0))
 


### PR DESCRIPTION
This PR fixes a long-standing copy-paste bug in the deprecated `Vector3` rotation methods. Previously, both `rotate_y_ip_rad` and `rotate_z_ip_rad` incorrectly applied rotation around the X-axis instead of their respective axes. 

Following @Starbuck5 maintainer feedback, this PR implements the actual code fix rather than just documenting the broken behavior.

### Changes made:
* **Code (`src_c/math.c`)**: Corrected the internal function calls so `vector3_rotate_y_ip_rad` and `vector3_rotate_z_ip_rad` now correctly call the Y and Z rotation functions.
* **Tests (`test/math_test.py`)**: Added unit tests to verify that these deprecated methods raise the appropriate `DeprecationWarning` and now produce the mathematically correct coordinates.
* **Docs (`docs/reST/ref/math.rst`)**: Added a note and `versionchanged` directive to inform users that this historical X-axis bug has been resolved.