### PR TITLE
Use more ideal PyLong_ functions

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -845,7 +845,7 @@ pg_view_get_shape_obj(Py_buffer *view)
         return 0;
     }
     for (i = 0; i < view->ndim; ++i) {
-        lengthobj = PyLong_FromLong((long)view->shape[i]);
+        lengthobj = PyLong_FromSsize_t(view->shape[i]);
         if (!lengthobj) {
             Py_DECREF(shapeobj);
             return 0;
@@ -866,7 +866,7 @@ pg_view_get_strides_obj(Py_buffer *view)
         return 0;
     }
     for (i = 0; i < view->ndim; ++i) {
-        lengthobj = PyLong_FromLong((long)view->strides[i]);
+        lengthobj = PyLong_FromSsize_t(view->strides[i]);
         if (!lengthobj) {
             Py_DECREF(shapeobj);
             return 0;
@@ -966,7 +966,7 @@ _pg_shape_as_tuple(PyArrayInterface *inter_p)
         return 0;
     }
     for (i = 0; i < inter_p->nd; ++i) {
-        lengthobj = PyLong_FromLong((long)inter_p->shape[i]);
+        lengthobj = PyLong_FromSsize_t(inter_p->shape[i]);
         if (!lengthobj) {
             Py_DECREF(shapeobj);
             return 0;
@@ -999,7 +999,7 @@ _pg_strides_as_tuple(PyArrayInterface *inter_p)
         return 0;
     }
     for (i = 0; i < inter_p->nd; ++i) {
-        lengthobj = PyLong_FromLong((long)inter_p->strides[i]);
+        lengthobj = PyLong_FromSsize_t(inter_p->strides[i]);
         if (!lengthobj) {
             Py_DECREF(stridesobj);
             return 0;

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -360,8 +360,7 @@ _pg_rw_size(SDL_RWops *context)
         goto end;
     }
 
-    size = PyLong_AsLongLong(tmp);
-    if (size == -1 && PyErr_Occurred() != NULL) {
+    if (PyLong_AsInt64(tmp, &size) == -1) {
         PyErr_Print();
         goto end;
     }
@@ -584,9 +583,9 @@ _pg_rw_seek(SDL_RWops *context, Sint64 offset, int whence)
         goto end;
     }
 
-    retval = PyLong_AsLongLong(result);
-    if (retval == -1 && PyErr_Occurred()) {
+    if (PyLong_AsInt64(result, &retval) == -1) {
         PyErr_Clear();
+        retval = -1;
     }
 
     Py_DECREF(result);


### PR DESCRIPTION
This one is super minor, but I noticed that instead of casting to long in base.c, it can just use PyLong_FromSsize_t. This is more correct on large values. Py_ssize_t is 8 bytes, long is 4 bytes, so huge values would be truncated(?).

And in rwobject.c, instead of assuming long long is the same as int64 (which it probably always is though), we can use the fancy new sized API PyLong_AsInt64, a new function from CPython that no longer needs to call PyErr_Occurred.