### PR TITLE
Coerce strikethrough to a bool in ftfont set_strikethrough

### DIFF
--- a/src_py/ftfont.py
+++ b/src_py/ftfont.py
@@ -141,12 +141,14 @@ class Font(_Font):
     def set_strikethrough(self, value):
         """set_strikethrough(bool) -> None
         control if the text is rendered struck through"""
-        self.strikethrough = bool(value)
+        self._strikethrough = bool(value)
 
     def get_strikethrough(self):
         """get_strikethrough() -> bool
         check if the text will be rendered struck through"""
-        return self.strikethrough
+        return self._strikethrough
+
+    strikethrough = property(get_strikethrough, set_strikethrough)
 
     def metrics(self, text):
         """metrics(text) -> list

--- a/src_py/ftfont.py
+++ b/src_py/ftfont.py
@@ -141,7 +141,7 @@ class Font(_Font):
     def set_strikethrough(self, value):
         """set_strikethrough(bool) -> None
         control if the text is rendered struck through"""
-        self.strikethrough = value
+        self.strikethrough = bool(value)
 
     def get_strikethrough(self):
         """get_strikethrough() -> bool

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -548,6 +548,11 @@ class FontTypeTest(unittest.TestCase):
         self.assertTrue(f.get_strikethrough())
         f.set_strikethrough(False)
         self.assertFalse(f.get_strikethrough())
+        # a non-bool value is coerced to a bool
+        f.set_strikethrough(1)
+        self.assertIs(f.get_strikethrough(), True)
+        f.set_strikethrough(0)
+        self.assertIs(f.get_strikethrough(), False)
 
     def test_bold_attr(self):
         f = pygame_font.Font(None, 20)

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -585,6 +585,11 @@ class FontTypeTest(unittest.TestCase):
         self.assertTrue(f.strikethrough)
         f.strikethrough = False
         self.assertFalse(f.strikethrough)
+        # a non-bool value is coerced to a bool
+        f.strikethrough = 4
+        self.assertIs(f.strikethrough, True)
+        f.strikethrough = 0
+        self.assertIs(f.strikethrough, False)
 
     def test_set_align_property(self):
         if pygame_font.__name__ == "pygame.ftfont":


### PR DESCRIPTION
### Summary

`ftfont.Font.set_strikethrough` stores the value without coercing it to a bool, so `get_strikethrough()` can return a non-bool even though its docstring documents a `bool` return:

```python
import pygame.ftfont, pygame.font

f = pygame.ftfont.Font(None, 20)
f.set_strikethrough(5)
f.get_strikethrough()      # -> 5    (int)   -- wrong

c = pygame.font.Font(None, 20)   # canonical C Font
c.set_strikethrough(5)
c.get_strikethrough()      # -> True (bool)  -- correct
```

`ftfont.Font` is documented as a drop-in freetype alternative to `font.Font`, so its style API should behave the same.

### Cause

In `src_py/ftfont.py`, the three sibling setters coerce to bool but `set_strikethrough` does not:

```python
self.wide = bool(value)          # set_bold
self.oblique = bool(value)       # set_italic
self.underline = bool(value)     # set_underline
self.strikethrough = value       # set_strikethrough  <-- no bool()
```

The C implementation (`src_c/font.c`) also coerces (`font_set_strikethrough` via `PyObject_IsTrue`, and `get_strikethrough` returns a strict bool).

### Fix

```python
self.strikethrough = bool(value)
```

### Tests

Extended `test_set_strikethrough` in `test/font_test.py` (which runs against both `pygame.font` and `pygame.ftfont`) to assert that a non-bool value is coerced: `set_strikethrough(1)` → `get_strikethrough() is True`, `set_strikethrough(0)` → `is False`. This already passed for the C font and fails for `ftfont` on `main`; it passes with the fix.