### PR TITLE
Set python exception as SDL error in rwops code

### DIFF
--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -82,10 +82,21 @@ _pg_sdl_error_from_py_exc()
             value ? PyUnicode_FromFormat("Got %S: %S", type, value)
                   : PyUnicode_FromFormat("Got %S", type);
 
-        SDL_SetError("%s", error_str
-                               ? PyUnicode_AsUTF8(error_str)
-                               : "An unknown error occured, probably some "
-                                 "memory allocation failed");
+        const char *message =
+            "An unknown error occurred, a memory allocation probably failed";
+        if (error_str) {
+            const char *utf8_message = PyUnicode_AsUTF8(error_str);
+            if (utf8_message) {
+                message = utf8_message;
+            }
+            else {
+                PyErr_Clear();
+            }
+        }
+        else {
+            PyErr_Clear();
+        }
+        SDL_SetError("%s", message);
         Py_XDECREF(error_str);
     }
     Py_XDECREF(type);
@@ -647,9 +658,10 @@ _pg_rw_read(SDL_RWops *context, void *ptr, size_t size, size_t maxnum)
         goto end;
     }
 
+    /* TODO: Handle other bytes-like objects here */
     if (!PyBytes_Check(result)) {
         Py_DECREF(result);
-        _pg_sdl_error_from_py_exc();
+        SDL_SetError("read returned non-bytes object when bytes was expected");
         retval = 0;
         goto end;
     }

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -70,6 +70,29 @@ static int
 _pg_rw_close(SDL_RWops *);
 #endif
 
+/* If a python exception is set, it is cleared and a corresponding SDL error is
+ * set */
+static void
+_pg_sdl_error_from_py_exc()
+{
+    PyObject *type, *value, *traceback;
+    PyErr_Fetch(&type, &value, &traceback);
+    if (type) {
+        PyObject *error_str =
+            value ? PyUnicode_FromFormat("Got %S: %S", type, value)
+                  : PyUnicode_FromFormat("Got %S", type);
+
+        SDL_SetError("%s", error_str
+                               ? PyUnicode_AsUTF8(error_str)
+                               : "An unknown error occured, probably some "
+                                 "memory allocation failed");
+        Py_XDECREF(error_str);
+    }
+    Py_XDECREF(type);
+    Py_XDECREF(value);
+    Py_XDECREF(traceback);
+}
+
 /* Converter function used by PyArg_ParseTupleAndKeywords with the "O&" format.
  *
  * Returns: 1 on success
@@ -339,7 +362,7 @@ _pg_rw_size(SDL_RWops *context)
      */
     pos = PyObject_CallNoArgs(helper->tell);
     if (!pos) {
-        PyErr_Print();
+        _pg_sdl_error_from_py_exc();
         goto end;
     }
 
@@ -347,7 +370,7 @@ _pg_rw_size(SDL_RWops *context)
      */
     tmp = PyObject_CallFunction(helper->seek, "ii", 0, SEEK_END);
     if (!tmp) {
-        PyErr_Print();
+        _pg_sdl_error_from_py_exc();
         goto end;
     }
     Py_DECREF(tmp);
@@ -356,12 +379,12 @@ _pg_rw_size(SDL_RWops *context)
      */
     tmp = PyObject_CallNoArgs(helper->tell);
     if (!tmp) {
-        PyErr_Print();
+        _pg_sdl_error_from_py_exc();
         goto end;
     }
 
     if (PyLong_AsInt64(tmp, &size) == -1) {
-        PyErr_Print();
+        _pg_sdl_error_from_py_exc();
         goto end;
     }
     Py_DECREF(tmp);
@@ -370,7 +393,7 @@ _pg_rw_size(SDL_RWops *context)
      */
     tmp = PyObject_CallOneArg(helper->seek, pos);
     if (!tmp) {
-        PyErr_Print();
+        _pg_sdl_error_from_py_exc();
         goto end;
     }
 
@@ -404,7 +427,7 @@ _pg_rw_write(SDL_RWops *context, const void *ptr, size_t size, size_t num)
     size_t retval;
 
     if (!helper->write) {
-        return -1;
+        return 0;
     }
 
     PyGILState_STATE state = PyGILState_Ensure();
@@ -412,8 +435,8 @@ _pg_rw_write(SDL_RWops *context, const void *ptr, size_t size, size_t num)
     result = PyObject_CallFunction(helper->write, "y#", (const char *)ptr,
                                    (Py_ssize_t)size * num);
     if (!result) {
-        PyErr_Print();
-        retval = -1;
+        _pg_sdl_error_from_py_exc();
+        retval = 0;
         goto end;
     }
 
@@ -448,7 +471,7 @@ _pg_rw_close(SDL_RWops *context)
     if (helper->close) {
         result = PyObject_CallNoArgs(helper->close);
         if (!result) {
-            PyErr_Print();
+            _pg_sdl_error_from_py_exc();
 #if SDL_VERSION_ATLEAST(3, 0, 0)
             retval = false;
 #else
@@ -569,7 +592,7 @@ _pg_rw_seek(SDL_RWops *context, Sint64 offset, int whence)
         result = PyObject_CallFunction(helper->seek, "Li", (long long)offset,
                                        whence);
         if (!result) {
-            PyErr_Print();
+            _pg_sdl_error_from_py_exc();
             retval = -1;
             goto end;
         }
@@ -578,13 +601,13 @@ _pg_rw_seek(SDL_RWops *context, Sint64 offset, int whence)
 
     result = PyObject_CallNoArgs(helper->tell);
     if (!result) {
-        PyErr_Print();
+        _pg_sdl_error_from_py_exc();
         retval = -1;
         goto end;
     }
 
     if (PyLong_AsInt64(result, &retval) == -1) {
-        PyErr_Clear();
+        _pg_sdl_error_from_py_exc();
         retval = -1;
     }
 
@@ -612,22 +635,22 @@ _pg_rw_read(SDL_RWops *context, void *ptr, size_t size, size_t maxnum)
     Py_ssize_t retval;
 
     if (!helper->read) {
-        return -1;
+        return 0;
     }
 
     PyGILState_STATE state = PyGILState_Ensure();
     result = PyObject_CallFunction(helper->read, "K",
                                    (unsigned long long)size * maxnum);
     if (!result) {
-        PyErr_Print();
-        retval = -1;
+        _pg_sdl_error_from_py_exc();
+        retval = 0;
         goto end;
     }
 
     if (!PyBytes_Check(result)) {
         Py_DECREF(result);
-        PyErr_Print();
-        retval = -1;
+        _pg_sdl_error_from_py_exc();
+        retval = 0;
         goto end;
     }
 

--- a/test/rwobject_test.py
+++ b/test/rwobject_test.py
@@ -187,10 +187,11 @@ class RWopsUnderlyingFileErrorTest(unittest.TestCase):
                 surface,
                 FailingFileObject("write", error),
             )
-            # SDL_image forwards the underlying error message in the save path
-            # for now, but if this changes in the future the below assertion is
-            # safe to remove
-            self.assertIn(str(error), str(context.exception))
+
+        # SDL_image forwards the underlying error message in the save path
+        # for now, but if this changes in the future the below assertion is
+        # safe to remove
+        self.assertIn(str(error), str(context.exception))
 
     def test_seek_error(self):
         error = RuntimeError("seek operation failed")

--- a/test/rwobject_test.py
+++ b/test/rwobject_test.py
@@ -1,9 +1,12 @@
+import io
 import pathlib
 import platform
 import sys
 import unittest
 
+import pygame
 from pygame import encode_file_path, encode_string
+from pygame.tests.test_utils import example_path
 
 IS_PYPY = "PyPy" == platform.python_implementation()
 
@@ -128,6 +131,72 @@ class RWopsEncodeFilePathTest(unittest.TestCase):
 
         for etype in ("SyntaxError", self):
             self.assertRaises(TypeError, encode_file_path, "test", etype)
+
+
+class FailingFileObject:
+    """File-like object that raises a Python exception on a selected operation."""
+
+    def __init__(self, operation, exception):
+        with open(example_path("data/alien1.png"), "rb") as f:
+            self._file = io.BytesIO(f.read())
+
+        self._operation = operation
+        self._exception = exception
+
+    def read(self, *args, **kwargs):
+        if self._operation == "read":
+            raise self._exception
+        return self._file.read(*args, **kwargs)
+
+    def write(self, *args, **kwargs):
+        if self._operation == "write":
+            raise self._exception
+        return self._file.write(*args, **kwargs)
+
+    def seek(self, *args, **kwargs):
+        if self._operation == "seek":
+            raise self._exception
+        return self._file.seek(*args, **kwargs)
+
+    def tell(self):
+        return self._file.tell()
+
+    def flush(self):
+        return self._file.flush()
+
+    def close(self):
+        return self._file.close()
+
+
+class RWopsUnderlyingFileErrorTest(unittest.TestCase):
+    """
+    Test Python exceptions from file-like object operations.
+    """
+
+    def test_read_error(self):
+        error = RuntimeError("read operation failed")
+
+        with self.assertRaises(pygame.error):
+            pygame.image.load(FailingFileObject("read", error))
+
+    def test_write_error(self):
+        error = RuntimeError("write operation failed")
+        surface = pygame.Surface((10, 10))
+        with self.assertRaises(pygame.error) as context:
+            pygame.image.save(
+                surface,
+                FailingFileObject("write", error),
+            )
+            # SDL_image forwards the underlying error message in the save path
+            # for now, but if this changes in the future the below assertion is
+            # safe to remove
+            self.assertIn(str(error), str(context.exception))
+
+    def test_seek_error(self):
+        error = RuntimeError("seek operation failed")
+
+        with self.assertRaises(pygame.error):
+            pygame.image.load(FailingFileObject("seek", error))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In our rwops code we currently print exceptions when the underlying python file-like object raises errors. Printing exceptions isn't a good way of dealing with them because the user cannot easily handle what's printed, and may not expect any stdout/stderr. The simplest solution is to convert the python exception to an SDL error.

It is upto SDL to decide what to do with this error: it may be forwarded to the caller which generally results in the same error message resurfacing back as a `pygame.error` exception for the pygame user; or SDL may just rewrite this message entirely in which case the pygame user would see a more generic error message.

This PR also addresses `-1` return issue from unsigned functions, of #3871