### PR TITLE
Fix rwobject test for 3.15

### DIFF
--- a/test/rwobject_test.py
+++ b/test/rwobject_test.py
@@ -76,7 +76,7 @@ class RWopsEncodeStringTest(unittest.TestCase):
         upath = bpath.decode("ascii")
         before = sys.getrefcount(bpath)
         bpath = encode_string(bpath)
-        self.assertEqual(sys.getrefcount(bpath), before)
+        self.assertEqual(sys.getrefcount(bpath), 2)
         bpath = encode_string(upath)
         self.assertIn(sys.getrefcount(bpath), (before, before - 1))
 


### PR DESCRIPTION
Previously, "before" was 2, but in 3.15 it became 1. Keep in mind sys.getrefcount is supposed to give an answer 1 over the true count, so it's reporting a true refcount of zero. I think because of 3.15 optimizations it's being put into a code constant and borrowed, instead of being a true local variable. Anyways, what we want to see here is that bpath has only 1 reference, e.g. 2 reported references.

Fixes #3872