### PR TITLE
Add thread safety warning to `pygame.Window` documentation

### DIFF
--- a/buildconfig/stubs/pygame/window.pyi
+++ b/buildconfig/stubs/pygame/window.pyi
@@ -17,6 +17,9 @@ class Window:
     window class will continue to be developed, and we're excited to share
     the new functionality this class offers.
 
+    .. note:: You can only call window-related functions (e.g. setting title, 
+        position, etc.) from the same thread that created the Window instance.
+
     :param str title: The title of the window.
     :param (int, int) size: The size of the window, in screen coordinates.
     :param (int, int) or int position: A tuple specifying the window position, or

--- a/buildconfig/stubs/pygame/window.pyi
+++ b/buildconfig/stubs/pygame/window.pyi
@@ -17,7 +17,7 @@ class Window:
     window class will continue to be developed, and we're excited to share
     the new functionality this class offers.
 
-    .. note:: You can only call window-related functions (e.g. setting title, 
+    .. note:: You can only call window-related functions (e.g. setting title,
         position, etc.) from the same thread that created the Window instance.
 
     :param str title: The title of the window.


### PR DESCRIPTION
I was browsing old issues when I came across #3719. When I was looking at it, I came to agree that lack of thread-safety should be documented for the `Window` class, hence this PR. All this PR does is modify the `window.pyi` stub file to add a note stating the lack of thread-safety, but since this is my first time working with RST, please let me know if I made any mistakes!

Closes #3719 