### PR TITLE
Remove redundant Color stub catch-alls 🤖🤖🤖

### DIFF
--- a/buildconfig/stubs/pygame/color.pyi
+++ b/buildconfig/stubs/pygame/color.pyi
@@ -244,9 +244,7 @@ class Color(Collection[int]):
     def from_cmy(cls, object: tuple[float, float, float], /) -> Color: ...
     @overload
     @classmethod
-    def from_cmy(cls, c: float, m: float, y: float, /) -> Color: ...
-    @classmethod  # type: ignore
-    def from_cmy(cls, *args) -> Color:  # type: ignore
+    def from_cmy(cls, c: float, m: float, y: float, /) -> Color:
         """Returns a Color object from a CMY representation.
 
         Creates a Color object from the given CMY components. Refer to :attr:`Color.cmy`
@@ -260,9 +258,7 @@ class Color(Collection[int]):
     def from_hsva(cls, object: tuple[float, float, float, float], /) -> Color: ...
     @overload
     @classmethod
-    def from_hsva(cls, h: float, s: float, v: float, a: float, /) -> Color: ...
-    @classmethod  # type: ignore
-    def from_hsva(cls, *args) -> Color:  # type: ignore
+    def from_hsva(cls, h: float, s: float, v: float, a: float, /) -> Color:
         """Returns a Color object from an HSVA representation.
 
         Creates a Color object from the given HSVA components. Refer to :attr:`Color.hsva`
@@ -276,9 +272,7 @@ class Color(Collection[int]):
     def from_hsla(cls, object: tuple[float, float, float, float], /) -> Color: ...
     @overload
     @classmethod
-    def from_hsla(cls, h: float, s: float, l: float, a: float, /) -> Color: ...
-    @classmethod  # type: ignore
-    def from_hsla(cls, *args) -> Color:  # type: ignore
+    def from_hsla(cls, h: float, s: float, l: float, a: float, /) -> Color:
         """Returns a Color object from an HSLA representation.
 
         Creates a Color object from the given HSLA components. Refer to :attr:`Color.hsla`
@@ -292,9 +286,7 @@ class Color(Collection[int]):
     def from_i1i2i3(cls, object: tuple[float, float, float], /) -> Color: ...
     @overload
     @classmethod
-    def from_i1i2i3(cls, i1: float, i2: float, i3: float, /) -> Color: ...
-    @classmethod  # type: ignore
-    def from_i1i2i3(cls, *args) -> Color:  # type: ignore
+    def from_i1i2i3(cls, i1: float, i2: float, i3: float, /) -> Color:
         """Returns a Color object from a I1I2I3 representation.
 
         Creates a Color object from the given I1I2I3 components. Refer to :attr:`Color.i1i2i3`
@@ -308,9 +300,7 @@ class Color(Collection[int]):
     def from_normalized(cls, object: tuple[float, float, float, float], /) -> Color: ...
     @overload
     @classmethod
-    def from_normalized(cls, r: float, g: float, b: float, a: float, /) -> Color: ...
-    @classmethod  # type: ignore
-    def from_normalized(cls, *args) -> Color:  # type: ignore
+    def from_normalized(cls, r: float, g: float, b: float, a: float, /) -> Color:
         """Returns a Color object from a Normalized representation.
 
         Creates a Color object from the given Normalized components. Refer to :attr:`Color.normalized`


### PR DESCRIPTION
## Summary

- remove the redundant catch-all declarations from five `Color.from_*` overload sets
- retain all ten precise overload signatures
- keep each existing method docstring on the final overload declaration

## Why

Stub files do not need a concrete catch-all declaration after a complete overload set. The `*args` declarations weakened the public typing information exposed for these classmethods.

No runtime behavior changes. No new tests were added because this is a stub-only precision fix verified by formatting, static type checking, and a structural audit.

Closes #3890.

## Validation

- `python3 -m ruff format --check buildconfig/stubs/pygame/color.pyi`
- `uvx --from mypy mypy --no-incremental --ignore-missing-imports --follow-imports=skip --disable-error-code=overload-cannot-match --disable-error-code=attr-defined buildconfig/stubs/pygame/color.pyi`
- `git diff --check`
- structural audit: 10 affected overloads, 0 affected catch-alls, and 5 preserved docstrings

## AI usage disclosure

The one-file patch and this PR description were prepared with OpenAI Codex. GPT-5.6 Terra (High) produced the implementation, the primary GPT-5.6 Sol (High) session inspected the complete diff and reran all checks, and a fresh GPT-5.6 Sol (High) review returned `ship` with no findings. No handwritten code was added during this task.
