### PR TITLE
Add 3.15

### DIFF
--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -77,7 +77,7 @@ jobs:
       with:
         persist-credentials: false
 
-    - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+    - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
       env:
         CIBW_PLATFORM: pyodide
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -112,7 +112,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         with:
           extras: uv
 

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -76,7 +76,7 @@ jobs:
         CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/${{ github.repository }}_aarch64:${{ steps.meta.outputs.version }}
         CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: ghcr.io/${{ github.repository }}_aarch64:${{ steps.meta.outputs.version }}
 
-      uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+      uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
 
     # We upload the generated files under github actions assets
     - name: Upload dist

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -46,7 +46,7 @@ jobs:
           arch: ${{ matrix.msvc-dev-arch }}
 
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         with:
           extras: uv
 
@@ -153,7 +153,7 @@ jobs:
           path: ${{ github.workspace }}/pygame_win_deps_${{ matrix.winarch }}
 
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         with:
           extras: uv
 

--- a/buildconfig/manylinux-build/docker_base/Dockerfile-aarch64
+++ b/buildconfig/manylinux-build/docker_base/Dockerfile-aarch64
@@ -1,5 +1,5 @@
 # pin version on image for CI stability
-FROM quay.io/pypa/manylinux2014_aarch64:2025.10.10-1
+FROM quay.io/pypa/manylinux2014_aarch64:2026.08.08-1
 ENV MAKEFLAGS="-j 4"
 ENV PG_DEP_PREFIX="/usr/local"
 

--- a/buildconfig/manylinux-build/docker_base/Dockerfile-i686
+++ b/buildconfig/manylinux-build/docker_base/Dockerfile-i686
@@ -1,5 +1,5 @@
 # pin version on image for CI stability
-FROM quay.io/pypa/manylinux2014_i686:2025.10.10-1
+FROM quay.io/pypa/manylinux2014_i686:2026.08.08-1
 ENV MAKEFLAGS="-j 4"
 ENV PG_DEP_PREFIX="/usr/local"
 

--- a/buildconfig/manylinux-build/docker_base/Dockerfile-x86_64
+++ b/buildconfig/manylinux-build/docker_base/Dockerfile-x86_64
@@ -1,5 +1,5 @@
 # pin version on image for CI stability
-FROM quay.io/pypa/manylinux2014_x86_64:2025.10.10-1
+FROM quay.io/pypa/manylinux2014_x86_64:2026.08.08-1
 ENV MAKEFLAGS="-j 4"
 ENV PG_DEP_PREFIX="/usr/local"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ build = "cp313-*"  # build only for the latest python version.
 # to cibuildwheel and/or pyodide.
 before-build = """
 sed -i 's/var SUPPORT_LONGJMP *= *[^;]*;/var SUPPORT_LONGJMP = "wasm";/' \
-  /home/runner/.cache/cibuildwheel/pyodide-build-0.35.0/0.29.4/emsdk/upstream/emscripten/src/settings.js &&
+  /home/runner/.cache/cibuildwheel/pyodide-build-0.39.0/0.29.4/emsdk/upstream/emscripten/src/settings.js &&
 embuilder --pic --force build \
   sdl2 libhtml5 sdl2_ttf 'sdl2_mixer:formats=ogg,mp3,mod,mid' \
   'sdl2_image:formats=bmp,gif,jpg,lbm,pcx,png,pnm,qoi,svg,tga,xcf,xpm,xv'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Games/Entertainment",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ build-frontend = "build[uv]"
 # here we build wheels for all supported python versions. We do not support musllinux
 # and free threaded builds as of now. We also skip Python 3.10 build on ARM Windows
 # because it is very very unlikely to be used (numpy does it too).
-build = "cp3{10,11,12,13,14}-* pp311-*"
+build = "cp3{10,11,12,13,14,15}-* pp311-*"
 skip = ["*-musllinux_*", "cp31?t-*", "cp310-win_arm64"]
 # build[uv] is verbose by default, so below flag is not needed here
 # build-verbosity = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ only-binary = ["numpy"]
 # 2. skip all pypy+arm combinations
 # 3. skip pypy 3.11 manylinux and cpython 3.14 manylinux (numpy has newer manylinux
 # wheels for this which is incompatible with our manylinux version)
+# 4. skip all 3.15 (numpy doesn't have release with wheels yet)
 [[tool.cibuildwheel.overrides]]
-select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,cp314-manylinux_*}"
+select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,cp314-manylinux_*,cp315-*}"
 test-requires = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tox:tox]
-envlist = py{310,311,312,313,314}
+envlist = py{310,311,312,313,314,315}
 skip_missing_interpreters = True
 skipsdist = True
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ METADATA = {
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",
+        "Programming Language :: Python :: 3.15",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Games/Entertainment",

--- a/test/rwobject_test.py
+++ b/test/rwobject_test.py
@@ -76,7 +76,7 @@ class RWopsEncodeStringTest(unittest.TestCase):
         upath = bpath.decode("ascii")
         before = sys.getrefcount(bpath)
         bpath = encode_string(bpath)
-        self.assertEqual(sys.getrefcount(bpath), before)
+        self.assertEqual(sys.getrefcount(bpath), 2)
         bpath = encode_string(upath)
         self.assertIn(sys.getrefcount(bpath), (before, before - 1))
 


### PR DESCRIPTION
Updates from CIBW 4.1.0 to CIBW 4.2.0, which just came out a few days ago with support for 3.15rc1.

Fixes the emsdk path again, edits to show we support 3.15.

Bundles the test fix from https://github.com/pygame-community/pygame-ce/pull/3879

