### PR TITLE
Add unit test for surface.convert_alpha argument check (#599)

### DIFF
--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -979,10 +979,11 @@ class SurfaceTypeTest(unittest.TestCase):
         try:
             # Open a tiny dummy window format to set Pygame's video conversion rules
             pygame.display.set_mode((1, 1), pygame.HIDDEN)
-            
-            # Create a base surface and a dummy target surface
+            # Create base surface and fill with non-default distinct RGBA data
             base_surf = pygame.Surface((10, 10), pygame.SRCALPHA)
-            target_surf = pygame.Surface((10, 10), pygame.SRCALPHA)
+            base_surf.fill((17, 34, 51, 127))
+            # Create a target surface with an entirely different pixel format (16-bit, no alpha)
+            target_surf = pygame.Surface((10, 10), 0, 16)
             
             # Test without an argument
             res_no_arg = base_surf.convert_alpha()
@@ -992,10 +993,16 @@ class SurfaceTypeTest(unittest.TestCase):
                 warnings.simplefilter("ignore", DeprecationWarning)
                 res_with_arg = base_surf.convert_alpha(target_surf)
             
-            # Verify both outputs exist and match properties exactly (proving the argument does nothing)
+            # Verify both outputs match exactly, proving target_surf is ignored 
+            # and doesn't corrupt pixel data or force its own format layout
             self.assertIsInstance(res_with_arg, pygame.Surface)
             self.assertEqual(res_no_arg.get_size(), res_with_arg.get_size())
             self.assertEqual(res_no_arg.get_flags(), res_with_arg.get_flags())
+            self.assertEqual(res_no_arg.get_bitsize(), res_with_arg.get_bitsize())
+            
+            # Verify pixel data matches across boundary coordinates
+            for point in ((0, 0), (9, 9)):
+                self.assertEqual(res_no_arg.get_at(point), res_with_arg.get_at(point))
         finally:
             pygame.display.quit()
 

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -972,6 +972,34 @@ class SurfaceTypeTest(unittest.TestCase):
         self.assertEqual(background.get_at((99, 99)), background_color)
         self.assertEqual(background.get_at((450, 450)), background_color)
 
+    def test_convert_alpha_with_argument(self):
+        """Ensures passing a target surface to convert_alpha doesn't crash or alter output (#599)."""
+        import warnings
+        pygame.display.init()
+        try:
+            # Open a tiny dummy window format to set Pygame's video conversion rules
+            pygame.display.set_mode((1, 1), pygame.HIDDEN)
+            
+            # Create a base surface and a dummy target surface
+            base_surf = pygame.Surface((10, 10), pygame.SRCALPHA)
+            target_surf = pygame.Surface((10, 10), pygame.SRCALPHA)
+            
+            # Test without an argument
+            res_no_arg = base_surf.convert_alpha()
+            
+            # Test with an argument (suppressing the internal positional deprecation warning)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                res_with_arg = base_surf.convert_alpha(target_surf)
+            
+            # Verify both outputs exist and match properties exactly (proving the argument does nothing)
+            self.assertIsInstance(res_with_arg, pygame.Surface)
+            self.assertEqual(res_no_arg.get_size(), res_with_arg.get_size())
+            self.assertEqual(res_no_arg.get_flags(), res_with_arg.get_flags())
+        finally:
+            pygame.display.quit()
+
+
 
 class TestSurfaceBlit(unittest.TestCase):
     """Tests basic blitting functionality and options."""


### PR DESCRIPTION
Hi! This PR adds an automated unit test to verify the behavior of `surface.convert_alpha` when passed an explicit surface argument. It ensures the framework safely processes the parameter format without crashing and behaves identically to an empty parameter call. Closes #599.
