### PR TITLE
Fix Color factory overload stubs 🤖🤖🤖

### DIFF
--- a/buildconfig/stubs/pygame/color.pyi
+++ b/buildconfig/stubs/pygame/color.pyi
@@ -244,9 +244,7 @@ class Color(Collection[int]):
     def from_cmy(cls, object: tuple[float, float, float], /) -> Color: ...
     @overload
     @classmethod
-    def from_cmy(cls, c: float, m: float, y: float, /) -> Color: ...
-    @classmethod  # type: ignore
-    def from_cmy(cls, *args) -> Color:  # type: ignore
+    def from_cmy(cls, c: float, m: float, y: float, /) -> Color:
         """Returns a Color object from a CMY representation.
 
         Creates a Color object from the given CMY components. Refer to :attr:`Color.cmy`
@@ -260,9 +258,7 @@ class Color(Collection[int]):
     def from_hsva(cls, object: tuple[float, float, float, float], /) -> Color: ...
     @overload
     @classmethod
-    def from_hsva(cls, h: float, s: float, v: float, a: float, /) -> Color: ...
-    @classmethod  # type: ignore
-    def from_hsva(cls, *args) -> Color:  # type: ignore
+    def from_hsva(cls, h: float, s: float, v: float, a: float, /) -> Color:
         """Returns a Color object from an HSVA representation.
 
         Creates a Color object from the given HSVA components. Refer to :attr:`Color.hsva`
@@ -276,9 +272,7 @@ class Color(Collection[int]):
     def from_hsla(cls, object: tuple[float, float, float, float], /) -> Color: ...
     @overload
     @classmethod
-    def from_hsla(cls, h: float, s: float, l: float, a: float, /) -> Color: ...
-    @classmethod  # type: ignore
-    def from_hsla(cls, *args) -> Color:  # type: ignore
+    def from_hsla(cls, h: float, s: float, l: float, a: float, /) -> Color:
         """Returns a Color object from an HSLA representation.
 
         Creates a Color object from the given HSLA components. Refer to :attr:`Color.hsla`
@@ -292,9 +286,7 @@ class Color(Collection[int]):
     def from_i1i2i3(cls, object: tuple[float, float, float], /) -> Color: ...
     @overload
     @classmethod
-    def from_i1i2i3(cls, i1: float, i2: float, i3: float, /) -> Color: ...
-    @classmethod  # type: ignore
-    def from_i1i2i3(cls, *args) -> Color:  # type: ignore
+    def from_i1i2i3(cls, i1: float, i2: float, i3: float, /) -> Color:
         """Returns a Color object from a I1I2I3 representation.
 
         Creates a Color object from the given I1I2I3 components. Refer to :attr:`Color.i1i2i3`
@@ -308,9 +300,7 @@ class Color(Collection[int]):
     def from_normalized(cls, object: tuple[float, float, float, float], /) -> Color: ...
     @overload
     @classmethod
-    def from_normalized(cls, r: float, g: float, b: float, a: float, /) -> Color: ...
-    @classmethod  # type: ignore
-    def from_normalized(cls, *args) -> Color:  # type: ignore
+    def from_normalized(cls, r: float, g: float, b: float, a: float, /) -> Color:
         """Returns a Color object from a Normalized representation.
 
         Creates a Color object from the given Normalized components. Refer to :attr:`Color.normalized`


### PR DESCRIPTION
## Summary

Remove the catch-all `*args` declarations from five `Color.from_*` factory overload sets. Each factory now keeps its exact tuple and positional overloads, with the existing documentation attached to the final overload body.

This follows the same stub documentation pattern already used for the OkLab/OkLch work in #3882 and does not change runtime behavior.

## Validation

- `python3 -m py_compile buildconfig/stubs/pygame/color.pyi`
- Mypy 1.18.2 on `color.pyi` — success after disabling only `overload-cannot-match` and `attr-defined`, which current main triggers in unrelated `surface.pyi`, `rwobject.pyi`, and package-init declarations
- Ruff 0.14.0 format check — already formatted
- AST contract check — all five factories have exactly two overloads, no varargs, and a preserved docstring
- `git diff --check`

## AI assistance

This change was implemented with OpenAI Codex. Codex made the mechanical one-file edit and ran the validation above. The final diff was checked against issue #3890 and the established overload/docstring pattern in #3882.

Closes #3890
