### PR TITLE
mixer: don't index channeldata[-1] when chan_play's playback call fails

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1129,6 +1129,10 @@ chan_play(PyObject *self, PyObject *args, PyObject *kwargs)
     }
     Py_END_ALLOW_THREADS;
 
+    if (channelnum == -1) { /* playback failed, no channel to track */
+        Py_RETURN_NONE;
+    }
+
     Py_CLEAR(channeldata[channelnum].queue);
     Py_XSETREF(channeldata[channelnum].sound, Py_NewRef(sound));
     Py_RETURN_NONE;


### PR DESCRIPTION
Fixes #3856.

`Mix_PlayChannelTimed` / `Mix_FadeInChannelTimed` return `-1` when playback can't be started. `chan_play` assigned that return value back into `channelnum` and then used it to index `channeldata` unconditionally:

```c
if (channelnum != -1) {
    Mix_GroupChannel(channelnum, (int)(intptr_t)chunk);
}
Py_END_ALLOW_THREADS;

Py_CLEAR(channeldata[channelnum].queue);
Py_XSETREF(channeldata[channelnum].sound, Py_NewRef(sound));
```

The `Mix_GroupChannel` call is already guarded, but the two refcount operations below it are not, so a failed play reads and writes `channeldata[-1]`.

The fix returns early on `-1`, so the queued sound is only cleared and the active sound reference only replaced when a valid channel was returned. The successful-playback path is unchanged.

### Note on `chan_queue`

`chan_queue` has the same unguarded pattern at `channeldata[channelnum].sound = Py_NewRef(sound);` after its own `Mix_PlayChannelTimed` call. I left it alone to keep this PR to the scope of the issue — happy to fold it in here or open a separate PR, whichever you prefer.

### Testing

I did not add a regression test. Reaching the failure path from Python requires `Mix_PlayChannelTimed` to fail for an already-validated channel index; the closest candidate I tried was holding a `Channel` object across a shrinking `set_num_channels`, but SDL_mixer still returned a valid channel there, so I couldn't force `-1` deterministically. Rather than add a test that doesn't actually exercise the guard, I left this as a defensive fix. If there's a known way to force the failure in this repo's test setup, I'll gladly add one.

Verified locally on macOS (arm64, Python 3.14, SDL 2.32.70):

```
$ python -m pygame.tests mixer mixer_music -v
Ran 30 tests in 1.654s
OK
Ran 80 tests in 4.875s
OK

$ python -m pygame.tests --exclude opengl,timing,music
Ran 2355 tests in 13.783s
OK
```

### AI disclosure

Per CONTRIBUTING.md: this change was written with AI assistance (Claude). The AI located the unguarded index, wrote the four-line guard and the commit message, and drafted this description. I reviewed the diff and ran the build and the test runs quoted above myself. The `chan_queue` observation came out of that review.
