### PR TITLE
Have dependabot group updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    # Group all updates into a single PR, if there are multiple updates found
+    groups:
+      all-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
Most updates we rubber stamp anyways, this just minimizes the amount of PRs and CI time that go towards this.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--