### PR TITLE
Make Rect and FRect constructors reject keyword arguments 🤖🤖🤖

### DIFF
--- a/src_c/rect_impl.h
+++ b/src_c/rect_impl.h
@@ -885,6 +885,12 @@ RectExport_dealloc(RectObject *self)
 static int
 RectExport_init(RectObject *self, PyObject *args, PyObject *kwds)
 {
+    if (kwds && PyDict_GET_SIZE(kwds)) {
+        PyErr_SetString(PyExc_TypeError,
+                        ObjectName "() does not accept keyword arguments");
+        return -1;
+    }
+
     if (PyTuple_GET_SIZE(args) == 0) {
         return 0;
     }

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -16,6 +16,22 @@ class RectTypeTest(unittest.TestCase):
     def _assertCountEqual(self, *args, **kwargs):
         self.assertCountEqual(*args, **kwargs)
 
+    def test_rect_constructor__no_keywords(self):
+        """Ensures Rect creation is positional-only and rejects keywords."""
+        with self.assertRaises(TypeError):
+            Rect(left=1, top=2, width=3, height=4)
+        with self.assertRaises(TypeError):
+            Rect(single_arg=(1, 2, 3, 4))
+        with self.assertRaises(TypeError):
+            Rect(x=1, y=2, w=3, h=4)
+        with self.assertRaises(TypeError):
+            Rect((1, 2, 3, 4), width=5)
+
+        # Positional forms are unaffected.
+        self.assertEqual(Rect(1, 2, 3, 4), Rect((1, 2), (3, 4)))
+        self.assertEqual(Rect((1, 2, 3, 4)), Rect((1, 2), (3, 4)))
+        self.assertEqual(Rect(), Rect(0, 0, 0, 0))
+
     def testConstructionXYWidthHeight(self):
         r = Rect(1, 2, 3, 4)
         self.assertEqual(1, r.left)


### PR DESCRIPTION
Fixes the silent zero-rect behaviour reported in https://github.com/pygame-community/pygame-ce/issues/3539.

## What changed

`Rect(left=1, top=2, width=3, height=4)` (or any keyword form, e.g. `Rect(single_arg=(1, 2, 3, 4))`) silently created `Rect(0, 0, 0, 0)` because `RectExport_init` returned early when there were no positional args, ignoring `kwds` entirely.

Per maintainer discussion in #3539 the constructor is **positional-only by design** (keyword parsing is too slow for the hot rect-creation path). So instead of adding kwarg support, `RectExport_init` now raises `TypeError` when keyword arguments are passed — for `Rect` and `FRect` alike (shared `rect_impl.h`), with the type name in the message. The `.pyi` stubs already mark `__init__` as positional-only (`/`), so runtime now matches the type hints.

```python
>>> pygame.Rect(left=1, top=2, width=3, height=4)
TypeError: pygame.rect.Rect() does not accept keyword arguments
```

## Verification

- Built pygame-ce from source (3.0.0.dev1, CPython 3.14, Windows) and confirmed:
  - all keyword forms raise `TypeError` for both `Rect` and `FRect`, including mixed positional+keyword;
  - positional forms are unaffected: `Rect(1, 2, 3, 4)`, `Rect((1, 2), (3, 4))`, `Rect((1, 2, 3, 4))`, `Rect()` → `Rect(0, 0, 0, 0)`.
- Added `test_rect_constructor__no_keywords` (inherited by `FRectTypeTest`).
- Full `test/rect_test.py` suite: **367 tests, all passing** (`python -m unittest test.rect_test`).

> [!INFO] *AI disclosure*: This contribution was prepared with AI assistance on behalf of karlsune. The change is ~10 lines of C; the AI drafted the patch and test, and karlsune verified the build, the runtime behaviour listed above, and the full rect test suite locally.