### PR TITLE
Fix typos in pixelarray API docs

### DIFF
--- a/docs/reST/ref/pixelarray.rst
+++ b/docs/reST/ref/pixelarray.rst
@@ -191,15 +191,13 @@
       To calculate the byte offset, the index for each dimension is multiplied
       by the corresponding stride, and then added up (for 2D pixel arrays).
 
-      For example, a standard PixelArray's strides
-      for a typical 10x20 Surface is ``(4, 40)``.
-
-      Each pixel in the Surface is 4 bytes: 1 byte for each of the standard 3 color
-      channels (RGB/BGR) plus the 1 potentially unused alpha channel (A).
-
-      The ``4`` x stride is because each pixel is 4 bytes.
-      The ``40`` y stride is 4 times width; each row of 10 pixels is 40 bytes, so
-      increasing the y index by 1 corresponds to moving 40 bytes forward to skip a row.
+      For example, a PixelArray's strides for a typical 32-bit 10x20 Surface
+      would be ``(4, 40)``. The ``4`` in the x stride is because each
+      pixel is 32-bits, 4 bytes. The ``40`` in the y stride represents the
+      number of bytes to skip forward a row. In this case, the surface pixels
+      are contiguous, so it is equivalent to the size of a pixel * the width
+      of the surface, 4 * 10. Some Surfaces can have strides greater than the
+      width and pixel count.
 
       A stride can be negative, for an array that is inverted (has a negative step).
 

--- a/docs/reST/ref/pixelarray.rst
+++ b/docs/reST/ref/pixelarray.rst
@@ -183,10 +183,14 @@
       | :sl:`Returns byte offsets for each array dimension.`
       | :sg:`strides -> tuple of int's`
 
-      A tuple of length :attr:`ndim` giving the strides in bytes. When an index
-      is multiplied by the corresponding stride, it gives the offset in bytes
-      from the start of the array for that index. A stride is negative
-      for an array that is inverted (has a negative step).
+      A tuple of length :attr:`ndim` giving each stride in bytes. Multiplying
+      the index and its corresponding stride gives the offset in bytes for that
+      index, which are summed together from each index (for 2D pixel arrays)
+      to get the total byte offset from the start of the array.
+
+      For example, a standard PixelArray's strides for a 10x20 Surface is ``(4, 40)``.
+
+      A stride is negative for an array that is inverted (has a negative step).
 
       .. versionaddedold:: 1.9.2
 

--- a/docs/reST/ref/pixelarray.rst
+++ b/docs/reST/ref/pixelarray.rst
@@ -183,14 +183,20 @@
       | :sl:`Returns byte offsets for each array dimension.`
       | :sg:`strides -> tuple of int's`
 
-      A tuple of length :attr:`ndim` giving each stride in bytes. Multiplying
-      the index and its corresponding stride gives the offset in bytes for that
-      index, which are summed together from each index (for 2D pixel arrays)
-      to get the total byte offset from the start of the array.
+      A tuple of length :attr:`ndim` giving each stride in bytes.
+
+      For a given 1D or 2D index, its "byte offset" is the position in bytes of the
+      pixel in the pixel array, relative to the start of the array's data.
+
+      To calculate the byte offset, the index for each dimension is multiplied
+      by the corresponding stride, and then added up (for 2D pixel arrays).
 
       For example, a standard PixelArray's strides for a 10x20 Surface is ``(4, 40)``.
+      The ``4`` is because each pixel is 4 bytes.
+      The ``40`` is 4 times width; each row of 10 pixels is 40 bytes, so increasing
+      the y index by 1 corresponds to moving 40 bytes forward to skip a row.
 
-      A stride is negative for an array that is inverted (has a negative step).
+      A stride can be negative, for an array that is inverted (has a negative step).
 
       .. versionaddedold:: 1.9.2
 

--- a/docs/reST/ref/pixelarray.rst
+++ b/docs/reST/ref/pixelarray.rst
@@ -119,7 +119,6 @@
     - For assignment, a tuple can only be a color. Any other sequence type
       is a sequence of colors.
 
-
    .. versionaddedold: 1.8.0
       Subscript support
 
@@ -174,7 +173,7 @@
       | :sl:`Returns the array size.`
       | :sg:`shape -> tuple of int's`
 
-      A tuple or length :attr:`ndim` giving the length of each
+      A tuple of length :attr:`ndim` giving the length of each
       dimension. Analogous to :meth:`Surface.get_size`.
 
       .. versionaddedold:: 1.9.2
@@ -184,10 +183,10 @@
       | :sl:`Returns byte offsets for each array dimension.`
       | :sg:`strides -> tuple of int's`
 
-      A tuple or length :attr:`ndim` byte counts. When a stride is
-      multiplied by the corresponding index it gives the offset
-      of that index from the start of the array. A stride is negative
-      for an array that has is inverted (has a negative step).
+      A tuple of length :attr:`ndim` giving the strides in bytes. When an index
+      is multiplied by the corresponding stride, it gives the offset in bytes
+      from the start of the array for that index. A stride is negative
+      for an array that is inverted (has a negative step).
 
       .. versionaddedold:: 1.9.2
 
@@ -215,7 +214,7 @@
       | :sg:`replace(color, repcolor, distance=0, weights=(0.299, 0.587, 0.114)) -> None`
 
       Replaces the pixels with the passed color in the PixelArray by changing
-      them them to the passed replacement color.
+      them to the passed replacement color.
 
       It uses a simple weighted Euclidean distance formula to calculate the
       distance between the colors. The distance space ranges from 0.0 to 1.0

--- a/docs/reST/ref/pixelarray.rst
+++ b/docs/reST/ref/pixelarray.rst
@@ -191,10 +191,15 @@
       To calculate the byte offset, the index for each dimension is multiplied
       by the corresponding stride, and then added up (for 2D pixel arrays).
 
-      For example, a standard PixelArray's strides for a 10x20 Surface is ``(4, 40)``.
-      The ``4`` is because each pixel is 4 bytes.
-      The ``40`` is 4 times width; each row of 10 pixels is 40 bytes, so increasing
-      the y index by 1 corresponds to moving 40 bytes forward to skip a row.
+      For example, a standard PixelArray's strides
+      for a typical 10x20 Surface is ``(4, 40)``.
+
+      Each pixel in the Surface is 4 bytes: 1 byte for each of the standard 3 color
+      channels (RGB/BGR) plus the 1 potentially unused alpha channel (A).
+
+      The ``4`` x stride is because each pixel is 4 bytes.
+      The ``40`` y stride is 4 times width; each row of 10 pixels is 40 bytes, so
+      increasing the y index by 1 corresponds to moving 40 bytes forward to skip a row.
 
       A stride can be negative, for an array that is inverted (has a negative step).
 


### PR DESCRIPTION
Also rewrite explanation of `strides`.