### PR TITLE
Add `transparent` parameter and attribute to `pygame.Window`

### DIFF
--- a/buildconfig/stubs/pygame/window.pyi
+++ b/buildconfig/stubs/pygame/window.pyi
@@ -45,13 +45,17 @@ class Window:
     :param bool always_on_top: Create a window that is always presented above
                                 others.
     :param bool utility: Create a window that doesn't appear in the task bar.
-    :param bool transparent: Create a window with a per-pixel alpha buffer,
+    :param bool transparent: Create a window that requests a per-pixel alpha buffer,
                               making the window see-through in areas where the
                               pixels' alpha value is less than 255. Note that
                               every operating system and rendering strategy
                               will expect the colors to be already pre-multiplied
                               by the intended alpha value, operation that is
-                              not performed automatically.
+                              not performed automatically. If either the window
+                              manager or rendering backend ignore or can't fulfill
+                              the transparency request, it's not guaranteed that
+                              an error will be raised and the window could be treated
+                              as transparent even if it is not.
 
     Event behavior if one Window is created: When the close button is pressed,
     the ``QUIT`` event will be sent to the event queue.
@@ -357,9 +361,15 @@ class Window:
 
     @property
     def transparent(self) -> bool:
-        """Get if the window has a per-pixel alpha buffer (**read-only**).
+        """Get if the window requested a per-pixel alpha buffer (**read-only**).
 
-        Refer to the ``transparent`` parameter of the constructor for more information.
+        Refer to the ``transparent`` parameter of the constructor for more information
+        about window transparency.
+
+        .. note:: This property only indicates if the window requested transparency at
+            creation time. If the window manager ignores or can't fulfill the request,
+            and no error was raised, this property will still return ``True`` even if
+            the window is not actually transparent.
 
         .. versionadded:: 3.0.0
         """

--- a/buildconfig/stubs/pygame/window.pyi
+++ b/buildconfig/stubs/pygame/window.pyi
@@ -45,6 +45,13 @@ class Window:
     :param bool always_on_top: Create a window that is always presented above
                                 others.
     :param bool utility: Create a window that doesn't appear in the task bar.
+    :param bool transparent: Create a window with a per-pixel alpha buffer,
+                              making the window see-through in areas where the
+                              pixels' alpha value is less than 255. Note that
+                              every operating system and rendering strategy
+                              will expect the colors to be already pre-multiplied
+                              by the intended alpha value, operation that is
+                              not performed automatically.
 
     Event behavior if one Window is created: When the close button is pressed,
     the ``QUIT`` event will be sent to the event queue.
@@ -88,6 +95,7 @@ class Window:
     .. versionadded:: 2.4.0
     .. versionchanged:: 2.5.0 when ``opengl`` is ``True``, the ``Window`` has an OpenGL context created by pygame
     .. versionchanged:: 2.5.1 Window is now a base class, allowing subclassing
+    .. versionchanged:: 3.0.0 added the ``transparent`` parameter to the constructor
     """
 
     def __init__(
@@ -113,6 +121,7 @@ class Window:
         mouse_capture: bool = ...,
         always_on_top: bool = ...,
         utility: bool = ...,
+        transparent: bool = ...,
     ) -> None: ...
 
     grab_mouse: bool
@@ -344,6 +353,15 @@ class Window:
         This only works for X11 and Windows, for other platforms, creating ``Window(utility=True)`` won't change anything.
 
         .. versionadded:: 2.5.3
+        """
+
+    @property
+    def transparent(self) -> bool:
+        """Get if the window has a per-pixel alpha buffer (**read-only**).
+
+        Refer to the ``transparent`` parameter of the constructor for more information.
+
+        .. versionadded:: 3.0.0
         """
 
     @classmethod

--- a/src_c/doc/window_doc.h
+++ b/src_c/doc/window_doc.h
@@ -1,5 +1,5 @@
 /* Auto generated file: with make_docs.py .  Docs go in docs/reST/ref/ . */
-#define DOC_WINDOW "Window(title='pygame window', size=(640, 480), position=WINDOWPOS_UNDEFINED, *, fullscreen=..., fullscreen_desktop=..., opengl=..., vulkan=..., hidden=..., borderless=..., resizable=..., minimized=..., maximized=..., mouse_grabbed=..., keyboard_grabbed=..., input_focus=..., mouse_focus=..., allow_high_dpi=..., mouse_capture=..., always_on_top=..., utility=...) -> Window\nPygame object that represents a window."
+#define DOC_WINDOW "Window(title='pygame window', size=(640, 480), position=WINDOWPOS_UNDEFINED, *, fullscreen=..., fullscreen_desktop=..., opengl=..., vulkan=..., hidden=..., borderless=..., resizable=..., minimized=..., maximized=..., mouse_grabbed=..., keyboard_grabbed=..., input_focus=..., mouse_focus=..., allow_high_dpi=..., mouse_capture=..., always_on_top=..., utility=..., transparent=...) -> Window\nPygame object that represents a window."
 #define DOC_WINDOW_GRABMOUSE "grab_mouse -> bool\nGet or set the window's mouse grab mode."
 #define DOC_WINDOW_GRABKEYBOARD "grab_keyboard -> bool\nGet or set the window's keyboard grab mode."
 #define DOC_WINDOW_MOUSEGRABBED "mouse_grabbed -> bool\nGet if the mouse cursor is confined to the window (**read-only**)."
@@ -19,6 +19,7 @@
 #define DOC_WINDOW_OPENGL "opengl -> bool\nGet if the window supports OpenGL."
 #define DOC_WINDOW_HANDLE "handle -> int\nGet the window handle provided by the window manager if supported otherwise 0"
 #define DOC_WINDOW_UTILITY "utility -> bool\nGet if the window is an utility window (**read-only**)."
+#define DOC_WINDOW_TRANSPARENT "transparent -> bool\nGet if the window has a per-pixel alpha buffer (**read-only**)."
 #define DOC_WINDOW_FROMDISPLAYMODULE "from_display_module() -> Window\nCreate a Window object using window data from display module."
 #define DOC_WINDOW_GETSURFACE "get_surface() -> Surface\nGet the window surface."
 #define DOC_WINDOW_FLIP "flip() -> None\nUpdate the display surface to the window."

--- a/src_c/doc/window_doc.h
+++ b/src_c/doc/window_doc.h
@@ -19,7 +19,7 @@
 #define DOC_WINDOW_OPENGL "opengl -> bool\nGet if the window supports OpenGL."
 #define DOC_WINDOW_HANDLE "handle -> int\nGet the window handle provided by the window manager if supported otherwise 0"
 #define DOC_WINDOW_UTILITY "utility -> bool\nGet if the window is an utility window (**read-only**)."
-#define DOC_WINDOW_TRANSPARENT "transparent -> bool\nGet if the window has a per-pixel alpha buffer (**read-only**)."
+#define DOC_WINDOW_TRANSPARENT "transparent -> bool\nGet if the window requested a per-pixel alpha buffer (**read-only**)."
 #define DOC_WINDOW_FROMDISPLAYMODULE "from_display_module() -> Window\nCreate a Window object using window data from display module."
 #define DOC_WINDOW_GETSURFACE "get_surface() -> Surface\nGet the window surface."
 #define DOC_WINDOW_FLIP "flip() -> None\nUpdate the display surface to the window."

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -966,6 +966,13 @@ window_get_utility(pgWindowObject *self, void *v)
                            SDL_WINDOW_UTILITY);
 }
 
+static PyObject *
+window_get_transparent(pgWindowObject *self, void *v)
+{
+    return PyBool_FromLong(SDL_GetWindowFlags(self->_win) &
+                           SDL_WINDOW_TRANSPARENT);
+}
+
 static void
 window_dealloc(pgWindowObject *self, PyObject *_null)
 {
@@ -1196,6 +1203,13 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
 #endif
                     }
                 }
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+                else if (!strcmp(_key_str, "transparent")) {
+                    if (_value_bool) {
+                        flags |= SDL_WINDOW_TRANSPARENT;
+                    }
+                }
+#endif
                 else {
                     PyErr_Format(PyExc_TypeError,
                                  "__init__ got an unexpected flag \'%s\'",
@@ -1456,6 +1470,8 @@ static PyGetSetDef _window_getset[] = {
     {"opengl", (getter)window_get_opengl, NULL, DOC_WINDOW_OPENGL, NULL},
     {"handle", (getter)window_get_handle, NULL, DOC_WINDOW_HANDLE, NULL},
     {"utility", (getter)window_get_utility, NULL, DOC_WINDOW_UTILITY, NULL},
+    {"transparent", (getter)window_get_transparent, NULL,
+     DOC_WINDOW_TRANSPARENT, NULL},
     {NULL, 0, NULL, NULL, NULL} /* Sentinel */
 };
 

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -969,8 +969,13 @@ window_get_utility(pgWindowObject *self, void *v)
 static PyObject *
 window_get_transparent(pgWindowObject *self, void *v)
 {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
     return PyBool_FromLong(SDL_GetWindowFlags(self->_win) &
                            SDL_WINDOW_TRANSPARENT);
+#else
+    return RAISE(pgExc_SDLError,
+                 "'pygame.Window.transparent' requires SDL 3.0.0+");
+#endif
 }
 
 static void

--- a/test/window_test.py
+++ b/test/window_test.py
@@ -290,6 +290,12 @@ class WindowTypeTest(unittest.TestCase):
         self.assertTrue(win.utility)
         win.destroy()
 
+        if SDL >= (3, 0, 0):
+            # test transparent
+            win = Window(transparent=True)
+            self.assertTrue(win.transparent)
+            win.destroy()
+
         # should raise a TypeError if keyword is random
         self.assertRaises(TypeError, lambda: Window(aaa=True))
         self.assertRaises(TypeError, lambda: Window(aaa=False))


### PR DESCRIPTION
Implements SDL3's window flag `SDL_WINDOW_TRANSPARENT` in the constructor and also export is as a read-only attribute. This change finally allows partially transparent windows natively supported by pygame. 