### PR TITLE
Add `Window.show_system_menu`

### DIFF
--- a/buildconfig/stubs/pygame/window.pyi
+++ b/buildconfig/stubs/pygame/window.pyi
@@ -1,5 +1,3 @@
-from typing import overload
-
 from pygame.locals import WINDOWPOS_UNDEFINED
 from pygame.rect import Rect
 from pygame.surface import Surface
@@ -513,18 +511,21 @@ class Window:
 
         .. versionadded:: 2.5.2
         """
+    def show_system_menu(self, pos: Point, /) -> bool:
+        """Show the system's default window menu at the given position in pixels.
 
-    @overload
-    def show_system_menu(self, x: int, y: int, /) -> None: ...
-    @overload
-    def show_system_menu(self, pos: Point, /) -> None: ...
-    def show_system_menu(self, *args) -> None:  # type: ignore
-        """Show the system's default window menu at the given position.
+        The system's window menu is a context menu provided and rendered by
+        the window manager. It lists available default operations that manage
+        the window like dragging, resizing, minimizing, maximizing, restoring,
+        and closing it.
 
-        The position is relative to the origin (top left) of the client area.
+        The position is relative to the origin (top left) of the client area,
+        which is the drawable area inside the system's window frame, title bar
+        and decoration. On borderless windows, it corresponds to the whole
+        window.
 
-        On platforms or desktops where this is unsupported, this method
-        does nothing.
+        Returns ``True`` if the operation succeeded and ``False`` if it's
+        not supported.
 
         .. versionadded:: 3.0.0
         """

--- a/buildconfig/stubs/pygame/window.pyi
+++ b/buildconfig/stubs/pygame/window.pyi
@@ -511,7 +511,8 @@ class Window:
 
         .. versionadded:: 2.5.2
         """
-    def show_system_menu(self, pos: Point, /) -> bool:
+
+    def show_system_menu(self, position: Point, /) -> bool:
         """Show the system's default window menu at the given position in pixels.
 
         The system's window menu is a context menu provided and rendered by
@@ -519,10 +520,8 @@ class Window:
         the window like dragging, resizing, minimizing, maximizing, restoring,
         and closing it.
 
-        The position is relative to the origin (top left) of the client area,
-        which is the drawable area inside the system's window frame, title bar
-        and decoration. On borderless windows, it corresponds to the whole
-        window.
+        The position is relative to the origin (top left) of the drawable area of
+        the window (on borderless windows, it corresponds to the whole window).
 
         Returns ``True`` if the operation succeeded and ``False`` if it's
         not supported.

--- a/buildconfig/stubs/pygame/window.pyi
+++ b/buildconfig/stubs/pygame/window.pyi
@@ -1,3 +1,5 @@
+from typing import overload
+
 from pygame.locals import WINDOWPOS_UNDEFINED
 from pygame.rect import Rect
 from pygame.surface import Surface
@@ -511,4 +513,20 @@ class Window:
 
         .. versionadded:: 2.5.2
         """
+
+    @overload
+    def show_system_menu(self, x: int, y: int, /) -> None: ...
+    @overload
+    def show_system_menu(self, pos: Point, /) -> None: ...
+    def show_system_menu(self, *args) -> None:  # type: ignore
+        """Show the system's default window menu at the given position.
+
+        The position is relative to the origin (top left) of the client area.
+
+        On platforms or desktops where this is unsupported, this method
+        does nothing.
+
+        .. versionadded:: 3.0.0
+        """
+
     relative_mouse: bool

--- a/src_c/doc/window_doc.h
+++ b/src_c/doc/window_doc.h
@@ -34,4 +34,4 @@
 #define DOC_WINDOW_SETICON "set_icon(icon, /) -> None\nSet the window icon."
 #define DOC_WINDOW_SETMODALFOR "set_modal_for(parent, /) -> None\nSet the window as a modal for a parent window."
 #define DOC_WINDOW_FLASH "flash(operation, /) -> None\nFlash a window to demand attention from the user."
-#define DOC_WINDOW_SHOWSYSTEMMENU "show_system_menu(x, y, /) -> None\nshow_system_menu(pos, /) -> None\nShow the system's default window menu at the given position."
+#define DOC_WINDOW_SHOWSYSTEMMENU "show_system_menu(pos, /) -> bool\nShow the system's default window menu at the given position in pixels."

--- a/src_c/doc/window_doc.h
+++ b/src_c/doc/window_doc.h
@@ -34,3 +34,4 @@
 #define DOC_WINDOW_SETICON "set_icon(icon, /) -> None\nSet the window icon."
 #define DOC_WINDOW_SETMODALFOR "set_modal_for(parent, /) -> None\nSet the window as a modal for a parent window."
 #define DOC_WINDOW_FLASH "flash(operation, /) -> None\nFlash a window to demand attention from the user."
+#define DOC_WINDOW_SHOWSYSTEMMENU "show_system_menu(x, y, /) -> None\nshow_system_menu(pos, /) -> None\nShow the system's default window menu at the given position."

--- a/src_c/doc/window_doc.h
+++ b/src_c/doc/window_doc.h
@@ -34,4 +34,4 @@
 #define DOC_WINDOW_SETICON "set_icon(icon, /) -> None\nSet the window icon."
 #define DOC_WINDOW_SETMODALFOR "set_modal_for(parent, /) -> None\nSet the window as a modal for a parent window."
 #define DOC_WINDOW_FLASH "flash(operation, /) -> None\nFlash a window to demand attention from the user."
-#define DOC_WINDOW_SHOWSYSTEMMENU "show_system_menu(pos, /) -> bool\nShow the system's default window menu at the given position in pixels."
+#define DOC_WINDOW_SHOWSYSTEMMENU "show_system_menu(position, /) -> bool\nShow the system's default window menu at the given position in pixels."

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -1355,21 +1355,17 @@ window_flash(pgWindowObject *self, PyObject *arg)
 }
 
 static PyObject *
-window_show_system_menu(pgWindowObject *self, PyObject *args)
+window_show_system_menu(pgWindowObject *self, PyObject *arg)
 {
 #if SDL_VERSION_ATLEAST(3, 0, 0)
     int x, y;
 
-    if (!pg_TwoIntsFromObj(args, &x, &y)) {
+    if (!pg_TwoIntsFromObj(arg, &x, &y)) {
         return RAISE(PyExc_TypeError,
                      "invalid position argument for Window.show_system_menu");
     }
 
-    if (!SDL_ShowWindowSystemMenu(self->_win, x, y)) {
-        return RAISE(pgExc_SDLError, SDL_GetError());
-    }
-
-    Py_RETURN_NONE;
+    return PyBool_FromLong((long)SDL_ShowWindowSystemMenu(self->_win, x, y));
 #else
     return RAISE(pgExc_SDLError,
                  "Window.show_system_menu requires SDL 3.0.0+");
@@ -1442,7 +1438,7 @@ static PyMethodDef window_methods[] = {
     {"from_display_module", (PyCFunction)window_from_display_module,
      METH_CLASS | METH_NOARGS, DOC_WINDOW_FROMDISPLAYMODULE},
     {"flash", (PyCFunction)window_flash, METH_O, DOC_WINDOW_FLASH},
-    {"show_system_menu", (PyCFunction)window_show_system_menu, METH_VARARGS,
+    {"show_system_menu", (PyCFunction)window_show_system_menu, METH_O,
      DOC_WINDOW_SHOWSYSTEMMENU},
     {NULL, NULL, 0, NULL}};
 

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -1354,7 +1354,29 @@ window_flash(pgWindowObject *self, PyObject *arg)
     Py_RETURN_NONE;
 }
 
-PyObject *
+static PyObject *
+window_show_system_menu(pgWindowObject *self, PyObject *args)
+{
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    int x, y;
+
+    if (!pg_TwoIntsFromObj(args, &x, &y)) {
+        return RAISE(PyExc_TypeError,
+                     "invalid position argument for Window.show_system_menu");
+    }
+
+    if (!SDL_ShowWindowSystemMenu(self->_win, x, y)) {
+        return RAISE(pgExc_SDLError, SDL_GetError());
+    }
+
+    Py_RETURN_NONE;
+#else
+    return RAISE(pgExc_SDLError,
+                 "Window.show_system_menu requires SDL 3.0.0+");
+#endif
+}
+
+static PyObject *
 window_repr(pgWindowObject *self)
 {
     const char *title;
@@ -1420,6 +1442,8 @@ static PyMethodDef window_methods[] = {
     {"from_display_module", (PyCFunction)window_from_display_module,
      METH_CLASS | METH_NOARGS, DOC_WINDOW_FROMDISPLAYMODULE},
     {"flash", (PyCFunction)window_flash, METH_O, DOC_WINDOW_FLASH},
+    {"show_system_menu", (PyCFunction)window_show_system_menu, METH_VARARGS,
+     DOC_WINDOW_SHOWSYSTEMMENU},
     {NULL, NULL, 0, NULL}};
 
 static PyGetSetDef _window_getset[] = {

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -1376,7 +1376,7 @@ window_show_system_menu(pgWindowObject *self, PyObject *args)
 #endif
 }
 
-static PyObject *
+PyObject *
 window_repr(pgWindowObject *self)
 {
     const char *title;

--- a/test/window_test.py
+++ b/test/window_test.py
@@ -455,11 +455,11 @@ class WindowTypeTest(unittest.TestCase):
             window.show_system_menu(0)
         with self.assertRaises(TypeError):
             window.show_system_menu("topleft")
+        with self.assertRaises(TypeError):
+            window.show_system_menu(10, 10)
 
-        result = window.show_system_menu(10, 10)
-        self.assertIsNone(result)
         result = window.show_system_menu((10, 10))
-        self.assertIsNone(result)
+        self.assertIsInstance(result, bool)
 
     def test_window_focused(self):
         window = pygame.Window()

--- a/test/window_test.py
+++ b/test/window_test.py
@@ -445,6 +445,22 @@ class WindowTypeTest(unittest.TestCase):
             except pygame.error:
                 pass
 
+    @unittest.skipIf(SDL < (3, 0, 0), "show_system_menu requires SDL3")
+    def test_window_show_system_menu(self):
+        window = pygame.Window()
+
+        with self.assertRaises(TypeError):
+            window.show_system_menu()
+        with self.assertRaises(TypeError):
+            window.show_system_menu(0)
+        with self.assertRaises(TypeError):
+            window.show_system_menu("topleft")
+
+        result = window.show_system_menu(10, 10)
+        self.assertIsNone(result)
+        result = window.show_system_menu((10, 10))
+        self.assertIsNone(result)
+
     def test_window_focused(self):
         window = pygame.Window()
         self.assertIsInstance(window.focused, bool)


### PR DESCRIPTION
Is this game changing? no...
Will this be used by most of the users? no...
Are those good reasons not to implement `SDL_ShowWindowSystemMenu`? I don't believe so, but I'm open for criticism. For now the PR exists at least. It requires minimal amount of code anyways.