### PR TITLE
Added Color.copy() and Color.__copy__() methods

### DIFF
--- a/buildconfig/stubs/pygame/color.pyi
+++ b/buildconfig/stubs/pygame/color.pyi
@@ -5,6 +5,11 @@ from typing import Any, ClassVar, SupportsIndex, overload
 from pygame.typing import ColorLike
 from typing_extensions import deprecated  # added in 3.13
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 THECOLORS: dict[str, tuple[int, int, int, int]]
 
 # Color confirms to the Collection ABC, since it also confirms to
@@ -225,6 +230,7 @@ class Color(Collection[int]):
     def __getitem__(self, s: slice) -> tuple[int, ...]: ...
     def __setitem__(self, key: int, value: int) -> None: ...
     def __iter__(self) -> Iterator[int]: ...
+    def __copy__(self) -> Self: ...
     def __add__(self, other: Color) -> Color: ...
     def __sub__(self, other: Color) -> Color: ...
     def __mul__(self, other: Color) -> Color: ...
@@ -408,4 +414,13 @@ class Color(Collection[int]):
         parameters of this function. If the alpha value was not set it will not change.
 
         .. versionaddedold:: 2.0.1
+        """
+
+    def copy(self) -> Self:
+        """Returns a copy of the Color.
+
+        Returns a new Color object with the same color values and length as the original.
+
+        .. note:: For subclasses of color, copying will not preserve arbitrary additional data, just the core color data (rgba and length).
+        .. versionadded:: 3.0.0
         """

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -91,6 +91,8 @@ static PyObject *
 _premul_alpha(pgColorObject *, PyObject *);
 static PyObject *
 _color_update(pgColorObject *self, PyObject *const *args, Py_ssize_t nargs);
+static PyObject *
+_color_copy(pgColorObject *self, PyObject *_null);
 
 /* Generic functions */
 static PyObject *
@@ -248,6 +250,8 @@ static PyMethodDef _color_methods[] = {
     {"premul_alpha", (PyCFunction)_premul_alpha, METH_NOARGS,
      DOC_COLOR_PREMULALPHA},
     {"update", (PyCFunction)_color_update, METH_FASTCALL, DOC_COLOR_UPDATE},
+    {"copy", (PyCFunction)_color_copy, METH_NOARGS, DOC_COLOR_COPY},
+    {"__copy__", (PyCFunction)_color_copy, METH_NOARGS, NULL},
 
     /**
      * While object.__bytes__(self) is listed in the Data Model reference (see:
@@ -896,6 +900,13 @@ _color_update(pgColorObject *self, PyObject *const *args, Py_ssize_t nargs)
                      "update can take only 1, 3 or 4 arguments");
     }
     Py_RETURN_NONE;
+}
+
+static PyObject *
+_color_copy(pgColorObject *self, PyObject *_null)
+{
+    return (PyObject *)_color_new_internal_length(Py_TYPE(self), self->data,
+                                                  self->len);
 }
 
 /**

--- a/src_c/doc/color_doc.h
+++ b/src_c/doc/color_doc.h
@@ -23,3 +23,4 @@
 #define DOC_COLOR_LERP "lerp(color, amount) -> Color\nReturns a linear interpolation to the given Color."
 #define DOC_COLOR_PREMULALPHA "premul_alpha() -> Color\nReturns a Color where the r,g,b components have been multiplied by the alpha."
 #define DOC_COLOR_UPDATE "update(r, g, b, a=255, /) -> None\nupdate(rgbvalue, /) -> None\nSets the elements of the color."
+#define DOC_COLOR_COPY "copy() -> Self\nReturns a copy of the Color."

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -76,6 +76,33 @@ class ColorTypeTest(unittest.TestCase):
         self.assertEqual(len(c), 4)
         self.assertEqual(c, (100, 110, 120, 128))
 
+    def test_copy(self):
+        import copy
+
+        # test color.copy()
+        c = pygame.Color(10, 20, 30, 40)
+        c_copy = c.copy()
+        self.assertIs(type(c_copy), pygame.Color)
+        self.assertEqual(c_copy, c)
+        self.assertIsNot(c_copy, c)
+        self.assertEqual(len(c_copy), len(c))
+
+        # test color.__copy__()
+        c = pygame.Color(10, 20, 30, 40)
+        c_copy = c.__copy__()
+        self.assertIs(type(c_copy), pygame.Color)
+        self.assertEqual(c_copy, c)
+        self.assertIsNot(c_copy, c)
+        self.assertEqual(len(c_copy), len(c))
+
+        # test copy.copy()
+        c = pygame.Color(10, 20, 30, 40)
+        c_copy = copy.copy(c)
+        self.assertIs(type(c_copy), pygame.Color)
+        self.assertEqual(c_copy, c)
+        self.assertIsNot(c_copy, c)
+        self.assertEqual(len(c_copy), len(c))
+
     def test_invalid_html_hex_codes(self):
         # This was a problem with the way 2 digit hex numbers were
         # calculated. The test_hex_digits test is related to the fix.
@@ -1514,8 +1541,41 @@ class ColorTypeTest(unittest.TestCase):
 class SubclassTest(unittest.TestCase):
     class MyColor(pygame.Color):
         def __init__(self, *args, **kwds):
-            super(SubclassTest.MyColor, self).__init__(*args, **kwds)
+            super().__init__(*args, **kwds)
             self.an_attribute = True
+            self.copy_dunder_called = False
+
+        def __copy__(self):
+            self.copy_dunder_called = True
+            return super().__copy__()
+
+    def test_copy(self):
+        import copy
+
+        # test color.copy()
+        c = self.MyColor(10, 20, 30, 40)
+        c_copy = c.copy()
+        self.assertIs(type(c_copy), type(c))
+        self.assertEqual(c_copy, c)
+        self.assertIsNot(c_copy, c)
+        self.assertEqual(len(c_copy), len(c))
+
+        # test color.__copy__()
+        c = self.MyColor(10, 20, 30, 40)
+        c_copy = c.__copy__()
+        self.assertIs(type(c_copy), type(c))
+        self.assertEqual(c_copy, c)
+        self.assertIsNot(c_copy, c)
+        self.assertEqual(len(c_copy), len(c))
+
+        # test copy.copy()
+        c = self.MyColor(10, 20, 30, 40)
+        c_copy = copy.copy(c)
+        self.assertIs(type(c_copy), type(c))
+        self.assertEqual(c_copy, c)
+        self.assertIsNot(c_copy, c)
+        self.assertEqual(len(c_copy), len(c))
+        self.assertTrue(c.copy_dunder_called)
 
     def test_add(self):
         mc1 = self.MyColor(128, 128, 128, 255)


### PR DESCRIPTION
This PR adds the `copy` and `__copy__()` methods of the Color class as described in #3553. Also added docs for it. I'm not sure when this will get merged, so I just put "version added" one version later than the latest release for the docs. I tested the functionality and it seemed to work as intended. The color tests via dev build also succeeded. 
