### PR TITLE
fix: use SDL3 float semantics for FRect.clipline on all SDL versions

### DIFF
--- a/src_c/pgcompat_rect.c
+++ b/src_c/pgcompat_rect.c
@@ -1,11 +1,10 @@
 #include "pgcompat_rect.h"
 
-/* SDL 2.0.22 provides some utility functions for FRects */
-/* SDL3 changed how the edges are handled. Previously right/bottom edges were
- * considered excluded from the FRect but now they aren't.
- * For now do SDL2 compat, but consider changing this in the future.
+/* Use pygame's implementation for every SDL version. SDL2's implementation
+ * clips floating-point rectangles as though their coordinates were integers,
+ * while SDL3 uses the actual floating-point boundaries. Follow SDL3's
+ * mathematically correct behavior consistently across SDL versions.
  * See: https://github.com/pygame-community/pygame-ce/issues/3571 */
-#if !(SDL_VERSION_ATLEAST(2, 0, 22)) || SDL_VERSION_ATLEAST(3, 0, 0)
 
 #ifndef CODE_BOTTOM
 #define CODE_BOTTOM 1
@@ -27,13 +26,13 @@ ComputeOutCodeF(const SDL_FRect *rect, float x, float y)
     if (y < rect->y) {
         code |= CODE_TOP;
     }
-    else if (y >= rect->y + rect->h) {
+    else if (y > rect->y + rect->h) {
         code |= CODE_BOTTOM;
     }
     if (x < rect->x) {
         code |= CODE_LEFT;
     }
-    else if (x >= rect->x + rect->w) {
+    else if (x > rect->x + rect->w) {
         code |= CODE_RIGHT;
     }
     return code;
@@ -64,8 +63,8 @@ PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
     y2 = *Y2;
     rectx1 = rect->x;
     recty1 = rect->y;
-    rectx2 = rect->x + rect->w - 1;
-    recty2 = rect->y + rect->h - 1;
+    rectx2 = rect->x + rect->w;
+    recty2 = rect->y + rect->h;
 
     /* Check to see if entire line is inside rect */
     if (x1 >= rectx1 && x1 <= rectx2 && x2 >= rectx1 && x2 <= rectx2 &&
@@ -180,4 +179,3 @@ PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
     *Y2 = y2;
     return SDL_TRUE;
 }
-#endif /* !(SDL_VERSION_ATLEAST(2, 0, 22)) || SDL_VERSION_ATLEAST(3, 0, 0) */

--- a/src_c/pgcompat_rect.h
+++ b/src_c/pgcompat_rect.h
@@ -7,15 +7,9 @@
 #include <SDL.h>
 #endif
 
-/* SDL 2.0.22 provides some utility functions for FRects */
-#if !(SDL_VERSION_ATLEAST(2, 0, 22)) || SDL_VERSION_ATLEAST(3, 0, 0)
-
 SDL_bool
 PG_IntersectFRectAndLine(SDL_FRect *rect, float *X1, float *Y1, float *X2,
                          float *Y2);
-#else
-#define PG_IntersectFRectAndLine SDL_IntersectFRectAndLine
-#endif /* !(SDL_VERSION_ATLEAST(2, 0, 22)) || SDL_VERSION_ATLEAST(3, 0, 0) */
 
 #define pg_PyFloat_FromFloat(x) (PyFloat_FromDouble((double)x))
 

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -2984,6 +2984,27 @@ class FRectTypeTest(RectTypeTest):
         global Rect
         Rect = FRect
 
+    def _assert_clipline_point(
+        self,
+        point,
+        rect,
+        *,
+        x=None,
+        y=None,
+        x_right=False,
+        y_bottom=False,
+    ):
+        px, py = point
+        if x_right:
+            self.assertAlmostEqual(px, rect.right, places=6)
+        else:
+            self.assertAlmostEqual(px, x, places=6)
+
+        if y_bottom:
+            self.assertAlmostEqual(py, rect.bottom, places=6)
+        else:
+            self.assertAlmostEqual(py, y, places=6)
+
     def test_convert_rect_frect(self):
         r = IRect(1, 2, 3, 4)
         fr = FRect(1.1, 2.2, 3.3, 4.4)
@@ -3039,40 +3060,253 @@ class FRectTypeTest(RectTypeTest):
 
             self.assertTupleEqual(clipped_line, expected_line)
 
+    def test_clipline__both_endpoints_outside(self):
+        """Ensures lines that overlap the rect are clipped."""
+        rect = FRect((0, 0), (20, 20))
+        big_rect = rect.inflate(2, 2)
+
+        cases = (
+            (
+                (big_rect.midleft, big_rect.midright),
+                {"x": rect.midleft[0], "y": rect.midleft[1]},
+                {"x_right": True, "y": rect.midright[1]},
+            ),
+            (
+                (big_rect.midtop, big_rect.midbottom),
+                {"x": rect.midtop[0], "y": rect.midtop[1]},
+                {"x": rect.midbottom[0], "y_bottom": True},
+            ),
+            (
+                (big_rect.topleft, big_rect.bottomright),
+                {"x": rect.topleft[0], "y": rect.topleft[1]},
+                {"x_right": True, "y_bottom": True},
+            ),
+            (
+                (
+                    (big_rect.topright[0] - 1, big_rect.topright[1]),
+                    (big_rect.bottomleft[0], big_rect.bottomleft[1] - 1),
+                ),
+                {"x": rect.topright[0] - 1, "y": rect.topright[1]},
+                {"x": rect.bottomleft[0], "y": rect.bottomleft[1] - 1},
+            ),
+        )
+
+        for line, start_expected, end_expected in cases:
+            clipped_line = rect.clipline(line)
+
+            self.assertEqual(len(clipped_line), 2)
+            self._assert_clipline_point(clipped_line[0], rect, **start_expected)
+            self._assert_clipline_point(clipped_line[1], rect, **end_expected)
+
+            clipped_line = rect.clipline((line[1], line[0]))
+
+            self.assertEqual(len(clipped_line), 2)
+            self._assert_clipline_point(clipped_line[0], rect, **end_expected)
+            self._assert_clipline_point(clipped_line[1], rect, **start_expected)
+
     def test_clipline__endpoints_inside_and_outside(self):
         """Ensures lines that overlap the rect are clipped.
 
         Testing lines with one endpoint outside the rect and the other
         inside the rect.
         """
-        rect = Rect((0, 0), (21, 21))
+        rect = FRect((0, 0), (21, 21))
         # Use a bigger rect to help create test lines.
         big_rect = rect.inflate(2, 2)
 
-        # Create a dict of lines and expected results.
-        line_dict = {
-            (big_rect.midleft, rect.center): (rect.midleft, rect.center),
-            (big_rect.midtop, rect.center): (rect.midtop, rect.center),
-            (big_rect.midright, rect.center): (
-                (rect.midright[0] - 1, rect.midright[1]),
-                rect.center,
+        cases = (
+            (
+                (big_rect.midleft, rect.center),
+                {"x": rect.midleft[0], "y": rect.midleft[1]},
+                {"x": rect.center[0], "y": rect.center[1]},
             ),
-            (big_rect.midbottom, rect.center): (
-                (rect.midbottom[0], rect.midbottom[1] - 1),
-                rect.center,
+            (
+                (big_rect.midtop, rect.center),
+                {"x": rect.midtop[0], "y": rect.midtop[1]},
+                {"x": rect.center[0], "y": rect.center[1]},
             ),
-        }
-        for line, expected_line in line_dict.items():
+            (
+                (big_rect.midright, rect.center),
+                {"x_right": True, "y": rect.midright[1]},
+                {"x": rect.center[0], "y": rect.center[1]},
+            ),
+            (
+                (big_rect.midbottom, rect.center),
+                {"x": rect.midbottom[0], "y_bottom": True},
+                {"x": rect.center[0], "y": rect.center[1]},
+            ),
+        )
+
+        for line, start_expected, end_expected in cases:
             clipped_line = rect.clipline(line)
 
-            self.assertTupleEqual(clipped_line, expected_line)
-
-            # Swap endpoints to test for symmetry.
-            expected_line = (expected_line[1], expected_line[0])
+            self.assertEqual(len(clipped_line), 2)
+            self._assert_clipline_point(clipped_line[0], rect, **start_expected)
+            self._assert_clipline_point(clipped_line[1], rect, **end_expected)
 
             clipped_line = rect.clipline((line[1], line[0]))
 
-            self.assertTupleEqual(clipped_line, expected_line)
+            self.assertEqual(len(clipped_line), 2)
+            self._assert_clipline_point(clipped_line[0], rect, **end_expected)
+            self._assert_clipline_point(clipped_line[1], rect, **start_expected)
+
+    def test_clipline__edges(self):
+        """Ensures clipline properly clips line that are along the rect edges."""
+        rect = FRect((10, 25), (15, 20))
+
+        left_edge = (rect.bottomleft, rect.topleft)
+        clipped_line = rect.clipline(left_edge)
+        self.assertEqual(len(clipped_line), 2)
+        self._assert_clipline_point(
+            clipped_line[0], rect, x=rect.bottomleft[0], y_bottom=True
+        )
+        self._assert_clipline_point(
+            clipped_line[1], rect, x=rect.topleft[0], y=rect.topleft[1]
+        )
+
+        clipped_line = rect.clipline((left_edge[1], left_edge[0]))
+        self.assertEqual(len(clipped_line), 2)
+        self._assert_clipline_point(
+            clipped_line[0], rect, x=rect.topleft[0], y=rect.topleft[1]
+        )
+        self._assert_clipline_point(
+            clipped_line[1], rect, x=rect.bottomleft[0], y_bottom=True
+        )
+
+        top_edge = (rect.topleft, rect.topright)
+        clipped_line = rect.clipline(top_edge)
+        self.assertEqual(len(clipped_line), 2)
+        self._assert_clipline_point(
+            clipped_line[0], rect, x=rect.topleft[0], y=rect.topleft[1]
+        )
+        self._assert_clipline_point(
+            clipped_line[1], rect, x_right=True, y=rect.topright[1]
+        )
+
+        clipped_line = rect.clipline((top_edge[1], top_edge[0]))
+        self.assertEqual(len(clipped_line), 2)
+        self._assert_clipline_point(
+            clipped_line[0], rect, x_right=True, y=rect.topright[1]
+        )
+        self._assert_clipline_point(
+            clipped_line[1], rect, x=rect.topleft[0], y=rect.topleft[1]
+        )
+
+        self.assertTupleEqual(
+            rect.clipline((rect.topright, rect.bottomright)),
+            (rect.topright, rect.bottomright),
+        )
+        self.assertTupleEqual(
+            rect.clipline((rect.bottomright, rect.topright)),
+            (rect.bottomright, rect.topright),
+        )
+        self.assertTupleEqual(
+            rect.clipline((rect.bottomright, rect.bottomleft)),
+            (rect.bottomright, rect.bottomleft),
+        )
+        self.assertTupleEqual(
+            rect.clipline((rect.bottomleft, rect.bottomright)),
+            (rect.bottomleft, rect.bottomright),
+        )
+
+    def test_clipline__negative_size_rect(self):
+        """Ensures clipline handles negative sized rects correctly."""
+        for size in ((-15, 20), (15, -20), (-15, -20)):
+            rect = FRect((10, 25), size)
+            norm_rect = rect.copy()
+            norm_rect.normalize()
+            big_rect = norm_rect.inflate(2, 2)
+
+            cases = (
+                (
+                    (big_rect.midleft, big_rect.midright),
+                    {"x": norm_rect.midleft[0], "y": norm_rect.midleft[1]},
+                    {"x_right": True, "y": norm_rect.midright[1]},
+                ),
+                (
+                    (big_rect.midtop, big_rect.midbottom),
+                    {"x": norm_rect.midtop[0], "y": norm_rect.midtop[1]},
+                    {"x": norm_rect.midbottom[0], "y_bottom": True},
+                ),
+                (
+                    (big_rect.midleft, norm_rect.center),
+                    {"x": norm_rect.midleft[0], "y": norm_rect.midleft[1]},
+                    {"x": norm_rect.center[0], "y": norm_rect.center[1]},
+                ),
+                (
+                    (big_rect.midtop, norm_rect.center),
+                    {"x": norm_rect.midtop[0], "y": norm_rect.midtop[1]},
+                    {"x": norm_rect.center[0], "y": norm_rect.center[1]},
+                ),
+                (
+                    (big_rect.midright, norm_rect.center),
+                    {"x_right": True, "y": norm_rect.midright[1]},
+                    {"x": norm_rect.center[0], "y": norm_rect.center[1]},
+                ),
+                (
+                    (big_rect.midbottom, norm_rect.center),
+                    {"x": norm_rect.midbottom[0], "y_bottom": True},
+                    {"x": norm_rect.center[0], "y": norm_rect.center[1]},
+                ),
+            )
+
+            for line, start_expected, end_expected in cases:
+                clipped_line = rect.clipline(line)
+
+                self.assertNotEqual(rect, norm_rect)
+                self.assertEqual(len(clipped_line), 2)
+                self._assert_clipline_point(
+                    clipped_line[0], norm_rect, **start_expected
+                )
+                self._assert_clipline_point(clipped_line[1], norm_rect, **end_expected)
+
+                clipped_line = rect.clipline((line[1], line[0]))
+
+                self.assertEqual(len(clipped_line), 2)
+                self._assert_clipline_point(clipped_line[0], norm_rect, **end_expected)
+                self._assert_clipline_point(
+                    clipped_line[1], norm_rect, **start_expected
+                )
+
+    def test_clipline__fractional_edges(self):
+        """Regression tests for clipping against each fractional edge."""
+        rect = FRect(100.25, 70.5, 50.5, 20.25)
+
+        cases = (
+            (
+                ((120.5, 95.0), (120.5, 80.0)),
+                {"x": 120.5, "y_bottom": True},
+                {"x": 120.5, "y": 80.0},
+            ),
+            (
+                ((120.5, 60.0), (120.5, 80.0)),
+                {"x": 120.5, "y": rect.top},
+                {"x": 120.5, "y": 80.0},
+            ),
+            (
+                ((180.0, 80.0), (120.5, 80.0)),
+                {"x_right": True, "y": 80.0},
+                {"x": 120.5, "y": 80.0},
+            ),
+            (
+                ((90.0, 80.0), (120.5, 80.0)),
+                {"x": rect.left, "y": 80.0},
+                {"x": 120.5, "y": 80.0},
+            ),
+        )
+
+        for line, start_expected, end_expected in cases:
+            clipped_line = rect.clipline(line)
+
+            self.assertEqual(len(clipped_line), 2)
+            self._assert_clipline_point(clipped_line[0], rect, **start_expected)
+            self._assert_clipline_point(clipped_line[1], rect, **end_expected)
+
+            clipped_line = rect.clipline((line[1], line[0]))
+
+            self.assertEqual(len(clipped_line), 2)
+            self._assert_clipline_point(clipped_line[0], rect, **end_expected)
+            self._assert_clipline_point(clipped_line[1], rect, **start_expected)
 
     def test_contains(self):
         r = FRect(1, 2, 3, 4)


### PR DESCRIPTION

FRect.clipline: use the real float edges on SDL2 as well


I ran into this writing a Breakout game and it took me long time
to find, so I had a go at fixing it.

On SDL2, clipline treats float rects like integer pixel rects. The right and
bottom edges get a -1, the top and left ones don't:

```python
r = pygame.FRect(100, 50, 50, 40)
r.bottom                        # 90.0
r.clipline(120, 0, 120, 200)    # ((120.0, 50.0), (120.0, 89.0))
r.right                         # 150.0
r.clipline(0, 70, 300, 70)      # ((100.0, 70.0), (149.0, 70.0))
```

So comparing the clip point against rect.bottom or rect.right never matches. In
my game I used that comparison to work out which side of a brick the ball hit.
I've since rewritten my collision code to not use clipline at all, so I'm not blocked — but the behaviour still looks wrong to me.

#3571 asks whether to keep SDL2 behaviour or move to SDL3's, and leans SDL3.
This does that: always use pygame's PG_IntersectFRectAndLine, > instead of >=,
drop the -1. All four edges then match what the rect reports, and there is only
one code path left to test (#3808 keeps both and is failing SDL3 CI).

Tests added for edge hits, negative size and fractional rects. 366 rect_test and
252 draw_test pass here.

This does change behaviour for everyone though, and #3808's review calls the
SDL2 behaviour intentional, so maybe not what you want. Happy to rework or close.
#3047 and #3704 look related.