### PR TITLE
Port `pygame._render` to SDL3

### DIFF
--- a/src_c/meson.build
+++ b/src_c/meson.build
@@ -318,8 +318,6 @@ window = py.extension_module(
     subdir: pg,
 )
 
-# TODO: support SDL3
-if sdl_api != 3
 _render = py.extension_module(
     '_render',
     'render.c',
@@ -328,7 +326,6 @@ _render = py.extension_module(
     install: true,
     subdir: pg,
 )
-endif
 
 # TODO: support SDL3
 if sdl_api != 3

--- a/src_c/render.c
+++ b/src_c/render.c
@@ -20,6 +20,25 @@ static PyTypeObject pgImage_Type;
 
 #define pgImage_Check(x) (PyObject_IsInstance((x), (PyObject *)&pgImage_Type))
 
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+#define RENDERER_ERROR_CHECK(x)                       \
+    if (x == SDL_FALSE) {                             \
+        return RAISE(pgExc_SDLError, SDL_GetError()); \
+    }
+
+#define RENDERER_PROPERTY_ERROR_CHECK(x)                 \
+    if (x == SDL_FALSE) {                                \
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), -1); \
+    }
+
+#define PG_GetRenderDrawColor_ForVertex SDL_GetRenderDrawColorFloat
+
+#define SET_VERTEX_COLOR(vertex, texture_mods, vertex_mods)         \
+    vertex.color.r = (texture_mods[0] * (vertex_mods[0] / 255.0f)); \
+    vertex.color.g = (texture_mods[1] * (vertex_mods[1] / 255.0f)); \
+    vertex.color.b = (texture_mods[2] * (vertex_mods[2] / 255.0f)); \
+    vertex.color.a = (texture_mods[3] * (vertex_mods[3] / 255.0f));
+#else /* !SDL_VERSION_ATLEAST(3, 0, 0) */
 #define RENDERER_ERROR_CHECK(x)                       \
     if (x < 0) {                                      \
         return RAISE(pgExc_SDLError, SDL_GetError()); \
@@ -29,6 +48,15 @@ static PyTypeObject pgImage_Type;
     if (x < 0) {                                         \
         RAISERETURN(pgExc_SDLError, SDL_GetError(), -1); \
     }
+
+#define PG_GetRenderDrawColor_ForVertex SDL_GetRenderDrawColor
+
+#define SET_VERTEX_COLOR(vertex, texture_mods, vertex_mods)     \
+    vertex.color.r = (Uint8)(texture_mods[0] * vertex_mods[0]); \
+    vertex.color.g = (Uint8)(texture_mods[1] * vertex_mods[1]); \
+    vertex.color.b = (Uint8)(texture_mods[2] * vertex_mods[2]); \
+    vertex.color.a = (Uint8)(texture_mods[3] * vertex_mods[3]);
+#endif /* SDL_VERSION_ATLEAST(3, 0, 0) */
 
 #define PARSE_POINT(obj, x, y, name)                                 \
     if (!pg_TwoFloatsFromObj(obj, &x, &y)) {                         \
@@ -47,12 +75,6 @@ static PyTypeObject pgImage_Type;
             return NULL;                                         \
         }                                                        \
     }
-
-#define SET_VERTEX_COLOR(vertex, texture_mods, vertex_mods)     \
-    vertex.color.r = (Uint8)(texture_mods[0] * vertex_mods[0]); \
-    vertex.color.g = (Uint8)(texture_mods[1] * vertex_mods[1]); \
-    vertex.color.b = (Uint8)(texture_mods[2] * vertex_mods[2]); \
-    vertex.color.a = (Uint8)(texture_mods[3] * vertex_mods[3]);
 
 static int
 texture_renderer_draw(pgTextureObject *self, PyObject *area, PyObject *dest);
@@ -186,7 +208,7 @@ renderer_fill_triangle(pgRendererObject *self, PyObject *args,
     PARSE_POINT(p1, vertices[0].position.x, vertices[0].position.y, "p1")
     PARSE_POINT(p2, vertices[1].position.x, vertices[1].position.y, "p2")
     PARSE_POINT(p3, vertices[2].position.x, vertices[2].position.y, "p3")
-    RENDERER_ERROR_CHECK(SDL_GetRenderDrawColor(
+    RENDERER_ERROR_CHECK(PG_GetRenderDrawColor_ForVertex(
         self->renderer, &vertices[0].color.r, &vertices[0].color.g,
         &vertices[0].color.b, &vertices[0].color.a))
     vertices[1].color = vertices[0].color;
@@ -229,7 +251,7 @@ renderer_fill_quad(pgRendererObject *self, PyObject *args, PyObject *kwargs)
     PARSE_POINT(p2, vertices[1].position.x, vertices[1].position.y, "p2")
     PARSE_POINT(p3, vertices[2].position.x, vertices[2].position.y, "p3")
     PARSE_POINT(p4, vertices[3].position.x, vertices[3].position.y, "p4")
-    RENDERER_ERROR_CHECK(SDL_GetRenderDrawColor(
+    RENDERER_ERROR_CHECK(PG_GetRenderDrawColor_ForVertex(
         self->renderer, &vertices[0].color.r, &vertices[0].color.g,
         &vertices[0].color.b, &vertices[0].color.a))
     for (int i = 1; i < 4; i++) {
@@ -240,6 +262,8 @@ renderer_fill_quad(pgRendererObject *self, PyObject *args, PyObject *kwargs)
         SDL_RenderGeometry(self->renderer, NULL, vertices, 4, indices, 6))
     Py_RETURN_NONE;
 }
+
+#undef PG_GetRenderDrawColor_ForVertex
 
 static PyObject *
 renderer_present(pgRendererObject *self, PyObject *_null)
@@ -304,11 +328,11 @@ renderer_compose_custom_blend_mode(PyObject *self, PyObject *args,
 static PyObject *
 renderer_to_surface(pgRendererObject *self, PyObject *args, PyObject *kwargs)
 {
+    /* TODO: remove useless surface parameter */
     PyObject *surfobj = Py_None, *rectobj = Py_None;
     SDL_Surface *surf;
     pgSurfaceObject *surface;
     SDL_Rect viewport, *areaparam, temp, *rect = &temp;
-    Uint32 format;
     static char *keywords[] = {"surface", "area", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|OO", keywords, &surfobj,
                                      &rectobj)) {
@@ -326,32 +350,26 @@ renderer_to_surface(pgRendererObject *self, PyObject *args, PyObject *kwargs)
         SDL_RenderGetViewport(self->renderer, rect);
         areaparam = NULL;
     }
-    if (!Py_IsNone(surfobj)) {
-        if (!(pgSurface_Check(surfobj))) {
-            return RAISE(PyExc_TypeError, "surface must be None or a Surface");
-        }
-        surface = (pgSurfaceObject *)surfobj;
-        Py_INCREF(surface);
-        surf = surface->surf;
-        if (surf->w < rect->w || surf->h < rect->h) {
-            return RAISE(PyExc_ValueError, "the surface is too small");
-        }
-        format = surf->format->format;
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    surf = SDL_RenderReadPixels(self->renderer, areaparam);
+    if (surf == NULL) {
+        return RAISE(pgExc_SDLError, SDL_GetError());
     }
-    else {
-        format = SDL_GetWindowPixelFormat(self->window->_win);
-        if (format == SDL_PIXELFORMAT_UNKNOWN) {
-            return RAISE(pgExc_SDLError, SDL_GetError());
-        }
-        surf = SDL_CreateRGBSurfaceWithFormat(
-            0, rect->w, rect->h, SDL_BITSPERPIXEL(format), format);
-        if (surf == NULL) {
-            return RAISE(pgExc_SDLError, SDL_GetError());
-        }
-        surface = pgSurface_New(surf);
+    surface = pgSurface_New(surf);
+#else
+    Uint32 format = SDL_GetWindowPixelFormat(self->window->_win);
+    if (format == SDL_PIXELFORMAT_UNKNOWN) {
+        return RAISE(pgExc_SDLError, SDL_GetError());
     }
+    surf = SDL_CreateRGBSurfaceWithFormat(0, rect->w, rect->h,
+                                          SDL_BITSPERPIXEL(format), format);
+    if (surf == NULL) {
+        return RAISE(pgExc_SDLError, SDL_GetError());
+    }
+    surface = pgSurface_New(surf);
     RENDERER_ERROR_CHECK(SDL_RenderReadPixels(
         self->renderer, areaparam, format, surf->pixels, surf->pitch));
+#endif
     return (PyObject *)surface;
 }
 
@@ -440,7 +458,13 @@ static PyObject *
 renderer_get_logical_size(pgRendererObject *self, void *closure)
 {
     int w, h;
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    SDL_RendererLogicalPresentation mode;
+    RENDERER_ERROR_CHECK(
+        SDL_GetRenderLogicalPresentation(self->renderer, &w, &h, &mode))
+#else
     SDL_RenderGetLogicalSize(self->renderer, &w, &h);
+#endif
     return pg_tuple_couple_from_values_int(w, h);
 }
 
@@ -451,8 +475,16 @@ renderer_set_logical_size(pgRendererObject *self, PyObject *arg, void *closure)
     if (!pg_TwoIntsFromObj(arg, &w, &h)) {
         RAISERETURN(PyExc_TypeError, "invalid logical size", -1);
     }
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    SDL_RendererLogicalPresentation mode =
+        (w == 0 || h == 0) ? SDL_LOGICAL_PRESENTATION_DISABLED
+                           : SDL_LOGICAL_PRESENTATION_LETTERBOX;
+    RENDERER_PROPERTY_ERROR_CHECK(
+        SDL_SetRenderLogicalPresentation(self->renderer, w, h, mode))
+#else
     RENDERER_PROPERTY_ERROR_CHECK(
         SDL_RenderSetLogicalSize(self->renderer, w, h))
+#endif
     return 0;
 }
 
@@ -580,6 +612,13 @@ renderer_init(pgRendererObject *self, PyObject *args, PyObject *kwargs)
                                      &accelerated, &vsync, &target_texture)) {
         return -1;
     }
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    const char *name = NULL;
+    if (index != -1) {
+        name = SDL_GetRenderDriver(index);
+    }
+    renderer = SDL_CreateRenderer(window->_win, name);
+#else
     if (accelerated >= 0) {
         flags |=
             accelerated ? SDL_RENDERER_ACCELERATED : SDL_RENDERER_SOFTWARE;
@@ -591,10 +630,18 @@ renderer_init(pgRendererObject *self, PyObject *args, PyObject *kwargs)
         flags |= SDL_RENDERER_TARGETTEXTURE;
     }
     renderer = SDL_CreateRenderer(window->_win, index, flags);
+#endif
+
     if (!renderer) {
         PyErr_SetString(pgExc_SDLError, SDL_GetError());
         return -1;
     }
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    if (vsync) {
+        SDL_SetRenderVSync(renderer, 1);
+    }
+    SDL_SetDefaultTextureScaleMode(renderer, SDL_SCALEMODE_NEAREST);
+#endif
     self->renderer = renderer;
     self->window = window;
     self->target = NULL;
@@ -612,13 +659,22 @@ renderer_dealloc(pgRendererObject *self, PyObject *_null)
 }
 
 /* Texture implementation */
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+#define pg_srcrect_t SDL_FRect
+#define pg_srcrect_FromObject pgFRect_FromObject
+#else
+#define pg_srcrect_t SDL_Rect
+#define pg_srcrect_FromObject pgRect_FromObject
+#endif
+
 static int
 texture_renderer_draw(pgTextureObject *self, PyObject *area, PyObject *dest)
 {
-    SDL_Rect srcrect, *srcrectptr = NULL;
+    pg_srcrect_t srcrect, *srcrectptr = NULL;
     SDL_FRect dstrect, *dstrectptr = NULL;
     if (!Py_IsNone(area)) {
-        if (!(srcrectptr = pgRect_FromObject(area, &srcrect))) {
+        if (!(srcrectptr = pg_srcrect_FromObject(area, &srcrect))) {
             PyErr_SetString(PyExc_ValueError,
                             "srcrect must be a Rect or None");
             return 0;
@@ -686,7 +742,7 @@ texture_draw(pgTextureObject *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *srcrectobj = Py_None, *dstrectobj = Py_None,
              *originobj = Py_None;
-    SDL_Rect srcrect, *srcrectptr = NULL;
+    pg_srcrect_t srcrect, *srcrectptr = NULL;
     SDL_FRect dstrect, *dstrectptr = NULL;
     SDL_FPoint origin, *originptr = NULL;
     double angle = 0;
@@ -701,7 +757,7 @@ texture_draw(pgTextureObject *self, PyObject *args, PyObject *kwargs)
         return NULL; /* Exception already set. */
     }
     if (!Py_IsNone(srcrectobj)) {
-        if (!(srcrectptr = pgRect_FromObject(srcrectobj, &srcrect))) {
+        if (!(srcrectptr = pg_srcrect_FromObject(srcrectobj, &srcrect))) {
             return RAISE(PyExc_ValueError, "srcrect must be a Rect or None");
         }
     }
@@ -732,6 +788,9 @@ texture_draw(pgTextureObject *self, PyObject *args, PyObject *kwargs)
                                            dstrectptr, angle, originptr, flip))
     Py_RETURN_NONE;
 }
+
+#undef pg_srcrect_t
+#undef pg_srcrect_FromObject
 
 static PyObject *
 texture_draw_triangle(pgTextureObject *self, PyObject *args, PyObject *kwargs)
@@ -899,12 +958,11 @@ texture_update(pgTextureObject *self, PyObject *args, PyObject *kwargs)
     pgSurfaceObject *surfobj;
     PyObject *rectobj = Py_None;
     SDL_Surface *surf = NULL;
-    SDL_Rect area, *areaptr = NULL;
     SDL_Surface *converted_surf = NULL;
-    SDL_PixelFormat *pixel_format = NULL;
+    SDL_Rect area, *areaptr = NULL;
     SDL_BlendMode blend;
-    Uint32 format;
-    int res;
+    PG_PixelFormatEnum texture_format;
+    PG_PixelFormatEnum surf_format;
     int dst_width, dst_height;
     static char *keywords[] = {"surface", "area", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!|O", keywords,
@@ -933,32 +991,56 @@ texture_update(pgTextureObject *self, PyObject *args, PyObject *kwargs)
         area.w = surf->w;
         area.h = surf->h;
     }
+    surf_format = PG_SURF_FORMATENUM(surf);
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    SDL_PropertiesID texture_props = SDL_GetTextureProperties(self->texture);
+    if (texture_props == 0) {
+        return RAISE(pgExc_SDLError, SDL_GetError());
+    }
+    texture_format = (PG_PixelFormatEnum)SDL_GetNumberProperty(
+        texture_props, SDL_PROP_TEXTURE_FORMAT_NUMBER, 0);
+#else
     RENDERER_ERROR_CHECK(
-        SDL_QueryTexture(self->texture, &format, NULL, NULL, NULL))
-    if (format != surf->format->format) {
+        SDL_QueryTexture(self->texture, &texture_format, NULL, NULL, NULL))
+#endif
+    if (texture_format != surf_format) {
         RENDERER_ERROR_CHECK(SDL_GetSurfaceBlendMode(surf, &blend))
-        pixel_format = SDL_AllocFormat(format);
-        if (pixel_format == NULL) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+        converted_surf = SDL_ConvertSurface(surf, texture_format);
+        if (SDL_SetSurfaceBlendMode(converted_surf, blend) == SDL_FALSE) {
+            SDL_DestroySurface(converted_surf);
             return RAISE(pgExc_SDLError, SDL_GetError());
         }
-        converted_surf = SDL_ConvertSurface(surf, pixel_format, 0);
+        if (SDL_UpdateTexture(self->texture, areaptr, converted_surf->pixels,
+                              converted_surf->pitch) == SDL_FALSE) {
+            SDL_DestroySurface(converted_surf);
+            return RAISE(pgExc_SDLError, SDL_GetError());
+        }
+        SDL_DestroySurface(converted_surf);
+#else
+        SDL_PixelFormat *format_details = SDL_AllocFormat(texture_format);
+        if (format_details == NULL) {
+            return RAISE(pgExc_SDLError, SDL_GetError());
+        }
+        converted_surf = SDL_ConvertSurface(surf, format_details, 0);
         if (SDL_SetSurfaceBlendMode(converted_surf, blend) < 0) {
             SDL_FreeSurface(converted_surf);
-            SDL_FreeFormat(pixel_format);
+            SDL_FreeFormat(format_details);
             return RAISE(pgExc_SDLError, SDL_GetError());
         }
 
-        res = SDL_UpdateTexture(self->texture, areaptr, converted_surf->pixels,
-                                converted_surf->pitch);
+        if (SDL_UpdateTexture(self->texture, areaptr, converted_surf->pixels,
+                              converted_surf->pitch) < 0) {
+            SDL_FreeSurface(converted_surf);
+            return RAISE(pgExc_SDLError, SDL_GetError());
+        }
         SDL_FreeSurface(converted_surf);
-        SDL_FreeFormat(pixel_format);
+        SDL_FreeFormat(format_details);
+#endif
     }
     else {
-        res = SDL_UpdateTexture(self->texture, areaptr, surf->pixels,
-                                surf->pitch);
-    }
-    if (res < 0) {
-        return RAISE(pgExc_SDLError, SDL_GetError());
+        RENDERER_ERROR_CHECK(SDL_UpdateTexture(self->texture, areaptr,
+                                               surf->pixels, surf->pitch))
     }
     Py_RETURN_NONE;
 }
@@ -1121,6 +1203,10 @@ texture_init(pgTextureObject *self, PyObject *args, PyObject *kwargs)
         RENDERER_PROPERTY_ERROR_CHECK(
             SDL_SetTextureScaleMode(self->texture, scale_quality))
     }
+    /* TODO: remove this and use SDL3 default behavior */
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    SDL_SetTextureBlendMode(self->texture, SDL_BLENDMODE_NONE);
+#endif
     self->width = width;
     self->height = height;
     return 0;

--- a/src_c/render.c
+++ b/src_c/render.c
@@ -615,6 +615,9 @@ renderer_init(pgRendererObject *self, PyObject *args, PyObject *kwargs)
     const char *name = NULL;
     if (index != -1) {
         name = SDL_GetRenderDriver(index);
+        if (name == NULL) {
+            RAISERETURN(pgExc_SDLError, SDL_GetError());
+        }
     }
     renderer = SDL_CreateRenderer(window->_win, name);
 #else

--- a/src_c/render.c
+++ b/src_c/render.c
@@ -616,7 +616,7 @@ renderer_init(pgRendererObject *self, PyObject *args, PyObject *kwargs)
     if (index != -1) {
         name = SDL_GetRenderDriver(index);
         if (name == NULL) {
-            RAISERETURN(pgExc_SDLError, SDL_GetError());
+            RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
         }
     }
     renderer = SDL_CreateRenderer(window->_win, name);

--- a/src_c/render.c
+++ b/src_c/render.c
@@ -603,7 +603,6 @@ renderer_init(pgRendererObject *self, PyObject *args, PyObject *kwargs)
     int accelerated = -1;
     int vsync = 0;
     int target_texture = 0;
-    Uint32 flags = 0;
 
     char *keywords[] = {"window", "index",          "accelerated",
                         "vsync",  "target_texture", NULL};
@@ -619,6 +618,7 @@ renderer_init(pgRendererObject *self, PyObject *args, PyObject *kwargs)
     }
     renderer = SDL_CreateRenderer(window->_win, name);
 #else
+    Uint32 flags = 0;
     if (accelerated >= 0) {
         flags |=
             accelerated ? SDL_RENDERER_ACCELERATED : SDL_RENDERER_SOFTWARE;
@@ -631,16 +631,18 @@ renderer_init(pgRendererObject *self, PyObject *args, PyObject *kwargs)
     }
     renderer = SDL_CreateRenderer(window->_win, index, flags);
 #endif
-
     if (!renderer) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return -1;
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
     }
 #if SDL_VERSION_ATLEAST(3, 0, 0)
     if (vsync) {
-        SDL_SetRenderVSync(renderer, 1);
+        if (SDL_SetRenderVSync(renderer, 1) == SDL_FALSE) {
+            RAISERETURN(pgExc_SDLError, SDL_GetError(), -1);
+        }
     }
+#if SDL_VERSION_ATLEAST(3, 4, 0)
     SDL_SetDefaultTextureScaleMode(renderer, SDL_SCALEMODE_NEAREST);
+#endif
 #endif
     self->renderer = renderer;
     self->window = window;
@@ -691,11 +693,18 @@ texture_renderer_draw(pgTextureObject *self, PyObject *area, PyObject *dest)
             dstrect.h = (float)self->height;
         }
     }
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    if (SDL_RenderTextureRotated(self->renderer->renderer, self->texture,
+                                 srcrectptr, dstrectptr, 0, NULL,
+                                 SDL_FLIP_NONE) == SDL_FALSE) {
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), 0);
+    }
+#else
     if (SDL_RenderCopyExF(self->renderer->renderer, self->texture, srcrectptr,
                           dstrectptr, 0, NULL, SDL_FLIP_NONE) < 0) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return 0;
+        RAISERETURN(pgExc_SDLError, SDL_GetError(), 0);
     }
+#endif
     return 1;
 }
 
@@ -1000,8 +1009,8 @@ texture_update(pgTextureObject *self, PyObject *args, PyObject *kwargs)
     texture_format = (PG_PixelFormatEnum)SDL_GetNumberProperty(
         texture_props, SDL_PROP_TEXTURE_FORMAT_NUMBER, 0);
 #else
-    RENDERER_ERROR_CHECK(
-        SDL_QueryTexture(self->texture, &texture_format, NULL, NULL, NULL))
+    RENDERER_ERROR_CHECK(SDL_QueryTexture(
+        self->texture, (Uint32 *)(&texture_format), NULL, NULL, NULL))
 #endif
     if (texture_format != surf_format) {
         RENDERER_ERROR_CHECK(SDL_GetSurfaceBlendMode(surf, &blend))
@@ -1199,14 +1208,19 @@ texture_init(pgTextureObject *self, PyObject *args, PyObject *kwargs)
     if (!self->texture) {
         RAISERETURN(pgExc_SDLError, SDL_GetError(), -1)
     }
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+    /* TODO: remove this and use SDL3 default behavior */
+    SDL_SetTextureBlendMode(self->texture, SDL_BLENDMODE_NONE);
+#if !SDL_VERSION_ATLEAST(3, 4, 0)
+    /* retain the default scale mode when
+       SDL_SetDefaultTextureScaleMode isn't available */
+    SDL_SetTextureScaleMode(self->texture, SDL_SCALEMODE_NEAREST);
+#endif
+#endif
     if (scale_quality != -1) {
         RENDERER_PROPERTY_ERROR_CHECK(
             SDL_SetTextureScaleMode(self->texture, scale_quality))
     }
-    /* TODO: remove this and use SDL3 default behavior */
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-    SDL_SetTextureBlendMode(self->texture, SDL_BLENDMODE_NONE);
-#endif
     self->width = width;
     self->height = height;
     return 0;

--- a/test/render_test.py
+++ b/test/render_test.py
@@ -31,25 +31,14 @@ class RendererTest(unittest.TestCase):
     def test_to_surface(self):
         self.renderer.draw_color = "YELLOW"
         self.renderer.draw_point((10, 10))  # assumes Renderer.draw_point works
+
         surf1 = self.renderer.to_surface()
         self.assertEqual(surf1.get_at((10, 10)), pygame.Color(255, 255, 0, 255))
         self.assertEqual(surf1.size, (100, 100))
 
-        surf2 = pygame.Surface((150, 150))
-        self.renderer.to_surface(surf2)
-        self.assertEqual(surf2.get_at((10, 10)), pygame.Color(255, 255, 0, 255))
-
         surf3 = self.renderer.to_surface(area=pygame.Rect(5, 5, 20, 20))
         self.assertEqual(surf3.get_at((5, 5)), pygame.Color(255, 255, 0, 255))
         self.assertEqual(surf3.size, (20, 20))
-
-        surf4 = pygame.Surface((150, 150))
-        self.renderer.to_surface(surf4, pygame.Rect(7, 7, 40, 40))
-        self.assertEqual(surf4.get_at((3, 3)), pygame.Color(255, 255, 0, 255))
-
-        small_surf = pygame.Surface((50, 50))
-        with self.assertRaises(ValueError):
-            self.renderer.to_surface(small_surf)
 
     def test_blit(self):
         surface = pygame.Surface((10, 10))


### PR DESCRIPTION
The API is ported without edits and the behavior is kept 1:1 with SDL2 code paths.

The only necessary behavior edit is the `surface` parameter of `_render.Renderer.to_surface` as the underlying SDL3 function doesn't behave the same way and has no equivalent. The parameter is now ignored by the method, as keeping the exact behavior would make the method even slower. Having gotten the approval of other members, I plan to open a pull request that will remove the parameter from the function signature.