### PR TITLE
Remove obsolete CPython 3.15 wheel exclusion 🤖🤖🤖

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,9 +151,8 @@ only-binary = ["numpy"]
 # 2. skip all pypy+arm combinations
 # 3. skip pypy 3.11 manylinux and cpython 3.14 manylinux (numpy has newer manylinux
 # wheels for this which is incompatible with our manylinux version)
-# 4. skip all 3.15 (numpy doesn't have release with wheels yet)
 [[tool.cibuildwheel.overrides]]
-select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,cp314-manylinux_*,cp315-*}"
+select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,cp314-manylinux_*}"
 test-requires = []
 
 # On MacOS 3.15 x86_64 compilation running on an ARM64 runner, with


### PR DESCRIPTION
## Summary

- Remove the obsolete `cp315-*` selector from the cibuildwheel override that disables test requirements.
- Keep the existing platform-specific exclusions and the macOS x86_64 build-frontend override unchanged.
- This restores the normal project-level `numpy` test requirement for CPython 3.15 wheel jobs now that NumPy publishes 3.15 wheels.

Closes #3906

## Verification

- Parsed `pyproject.toml` with Python `tomllib`.
- Confirmed `cp315-*` is absent from the empty `test-requires = []` override.
- Confirmed the project-level cibuildwheel test requirements remain `['numpy']`.
- `git diff --check` passed.
- The full installed-package pygame test command was also attempted, but this clean source checkout was not built; the unrelated system pygame installation reported existing image-format, RLE, display, and version mismatches. The change is limited to cibuildwheel configuration and does not alter runtime code.

## AI assistance disclosure

AI assistance was used for the complete one-file patch and for drafting this description. I reviewed the issue, contribution guidance, current `pyproject.toml`, and the maintainer readiness comment; I also checked the selector behavior and TOML parse result independently. No generated source, credentials, or copied private material is included.
