### PR TITLE
Improve and SDL3-fy the thread note in the Window constructor

### DIFF
--- a/buildconfig/stubs/pygame/window.pyi
+++ b/buildconfig/stubs/pygame/window.pyi
@@ -17,8 +17,8 @@ class Window:
     window class will continue to be developed, and we're excited to share
     the new functionality this class offers.
 
-    .. note:: Every window property, method and operation can only be
-        performed on the main thread the application started in.
+    .. note:: You can only interact with a Window (get/set properties,
+        call methods, etc.) from your application's main thread.
 
     :param str title: The title of the window.
     :param (int, int) size: The size of the window, in screen coordinates.

--- a/buildconfig/stubs/pygame/window.pyi
+++ b/buildconfig/stubs/pygame/window.pyi
@@ -17,8 +17,8 @@ class Window:
     window class will continue to be developed, and we're excited to share
     the new functionality this class offers.
 
-    .. note:: You can only call window-related functions (e.g. setting title,
-        position, etc.) from the same thread that created the Window instance.
+    .. note:: Every window property, method and operation can only be
+        performed on the main thread the application started in.
 
     :param str title: The title of the window.
     :param (int, int) size: The size of the window, in screen coordinates.


### PR DESCRIPTION
Modernized the thread note to reflect precise SDL3 requirements specified in the docs of every window-related operation:
"Thread Safety
This function should only be called on the main thread."
I'm open to corrections on my sentence, as this pull request is here more to push the improvement at all rather than enforce my precise wording.