### PR TITLE
Prevent reinitialization for some object types

### DIFF
--- a/src_c/render.c
+++ b/src_c/render.c
@@ -573,6 +573,11 @@ renderer_init(pgRendererObject *self, PyObject *args, PyObject *kwargs)
     int target_texture = 0;
     Uint32 flags = 0;
 
+    if (self->renderer) {
+        PyErr_SetString(PyExc_RuntimeError, "Object of type Renderer cannot be reinitialized");
+        return -1;
+    }
+
     char *keywords[] = {"window", "index",          "accelerated",
                         "vsync",  "target_texture", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!|iipp", keywords,
@@ -1058,6 +1063,11 @@ texture_init(pgTextureObject *self, PyObject *args, PyObject *kwargs)
     int access = SDL_TEXTUREACCESS_STATIC;
     Uint32 Rmask, Gmask, Bmask, Amask;
     Uint32 format;
+
+    if (self->texture) {
+        PyErr_SetString(PyExc_RuntimeError, "Object of type Texture cannot be reinitialized");
+        return -1;
+    }
 
     char *keywords[] = {"renderer",  "size",   "depth",         "static",
                         "streaming", "target", "scale_quality", NULL};

--- a/src_c/render.c
+++ b/src_c/render.c
@@ -574,7 +574,8 @@ renderer_init(pgRendererObject *self, PyObject *args, PyObject *kwargs)
     Uint32 flags = 0;
 
     if (self->renderer) {
-        PyErr_SetString(PyExc_RuntimeError, "Object of type Renderer cannot be reinitialized");
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Object of type Renderer cannot be reinitialized");
         return -1;
     }
 
@@ -1065,7 +1066,8 @@ texture_init(pgTextureObject *self, PyObject *args, PyObject *kwargs)
     Uint32 format;
 
     if (self->texture) {
-        PyErr_SetString(PyExc_RuntimeError, "Object of type Texture cannot be reinitialized");
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Object of type Texture cannot be reinitialized");
         return -1;
     }
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -485,7 +485,8 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
 #endif
 
     if (self->surf) {
-        PyErr_SetString(PyExc_RuntimeError, "Object of type Surface cannot be reinitialized");
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Object of type Surface cannot be reinitialized");
         return -1;
     }
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -484,6 +484,11 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
     default_format.palette = NULL;
 #endif
 
+    if (self->surf) {
+        PyErr_SetString(PyExc_RuntimeError, "Object of type Surface cannot be reinitialized");
+        return -1;
+    }
+
     char *kwids[] = {"size", "flags", "depth", "masks", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iOO", kwids, &size, &flags,
                                      &depth, &masks)) {

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -1048,6 +1048,11 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
         return -1;
     }
 
+    if (self->_win) {
+        PyErr_SetString(PyExc_RuntimeError, "Window object already initialized, cannot call __init__ again");
+        return -1;
+    }
+
     _kw = PyDict_New();
     if (!_kw) {
         return -1;

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -1042,15 +1042,15 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
     const char *_key_str;
     int _value_bool;
 
-    // ensure display is init at this point, display init automatically calls
-    // the window init in this module
-    if (!pg_mod_autoinit(IMPPREFIX "display")) {
-        return -1;
-    }
-
     if (self->_win) {
         PyErr_SetString(PyExc_RuntimeError,
                         "Object of type Window cannot be reinitialized");
+        return -1;
+    }
+
+    // ensure display is init at this point, display init automatically calls
+    // the window init in this module
+    if (!pg_mod_autoinit(IMPPREFIX "display")) {
         return -1;
     }
 

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -1049,7 +1049,7 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (self->_win) {
-        PyErr_SetString(PyExc_RuntimeError, "Window object already initialized, cannot call __init__ again");
+        PyErr_SetString(PyExc_RuntimeError, "Object of type Window cannot be reinitialized");
         return -1;
     }
 

--- a/src_c/window.c
+++ b/src_c/window.c
@@ -1049,7 +1049,8 @@ window_init(pgWindowObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (self->_win) {
-        PyErr_SetString(PyExc_RuntimeError, "Object of type Window cannot be reinitialized");
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Object of type Window cannot be reinitialized");
         return -1;
     }
 

--- a/test/render_test.py
+++ b/test/render_test.py
@@ -28,6 +28,12 @@ class RendererTest(unittest.TestCase):
         self.renderer.clear()
         self.renderer.draw_color = init_draw_color
 
+    def test_reinit(self):
+        # should raise RuntimeError if __init__ is called on
+        # an initialized Renderer
+        with self.assertRaises(RuntimeError):
+            self.renderer.__init__(self.window)
+
     def test_to_surface(self):
         self.renderer.draw_color = "YELLOW"
         self.renderer.draw_point((10, 10))  # assumes Renderer.draw_point works
@@ -268,6 +274,12 @@ class TextureTest(unittest.TestCase):
             _render.Texture(
                 self.renderer, (100, 100), depth=32, static=True, streaming=True
             )
+
+    def test_reinit(self):
+        # should raise RuntimeError if __init__ is called on
+        # an initialized Texture
+        with self.assertRaises(RuntimeError):
+            self.texture.__init__(self.renderer, (80, 60))
 
     def test_alpha(self):
         self.assertEqual(255, self.texture.alpha)

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1315,6 +1315,13 @@ class GeneralSurfaceTests(unittest.TestCase):
         finally:
             pygame.display.quit()
 
+    def test_reinit(self):
+        # should raise RuntimeError if __init__ is called on
+        # an initialized Surface
+        surf = pygame.Surface((1, 1))
+        with self.assertRaises(RuntimeError):
+            surf.__init__((1, 1))
+
     def test_convert_alpha_SRCALPHA(self):
         """Ensure that the surface returned by surf.convert_alpha()
         has alpha blending enabled"""

--- a/test/window_test.py
+++ b/test/window_test.py
@@ -294,6 +294,12 @@ class WindowTypeTest(unittest.TestCase):
         self.assertRaises(TypeError, lambda: Window(aaa=True))
         self.assertRaises(TypeError, lambda: Window(aaa=False))
 
+    def test_reinit(self):
+        # Should raise RuntimeError if __init__ is called on
+        # an initialized Window
+        with self.assertRaises(RuntimeError):
+            self.win.__init__()
+
     def test_set_icon(self):
         self.assertRaises(TypeError, lambda: self.win.set_icon(1234))
 

--- a/test/window_test.py
+++ b/test/window_test.py
@@ -295,7 +295,7 @@ class WindowTypeTest(unittest.TestCase):
         self.assertRaises(TypeError, lambda: Window(aaa=False))
 
     def test_reinit(self):
-        # Should raise RuntimeError if __init__ is called on
+        # should raise RuntimeError if __init__ is called on
         # an initialized Window
         with self.assertRaises(RuntimeError):
             self.win.__init__()


### PR DESCRIPTION
**Changes:**
- Modify the init function of certain objects with external resources to check if the object is already initialized and raise a RuntimeError if it is.
- Add unit tests to make sure reinitializing these objects rause a Runtime error

Changed the init functions of `Window`, `Surface`, `Renderer` and `Texture` as suggested by @shaurya-sharma-dev. I didn't change the function for Image (I coundn't find the init function in render.c and it was commented out in the decleration of `pgImage_Type`) or Controller (it does not assign a new `SDL_GameController` upon reinitialization).

I also think reinitializing Sound will cause issues so maybe that should also be protected.

Closes #3876

