### PR TITLE
Remove overrides in pyproject.toml to re-enable numpy tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ only-binary = ["numpy"]
 # 3. skip pypy 3.11 manylinux and cpython 3.14 manylinux (numpy has newer manylinux
 # wheels for this which is incompatible with our manylinux version)
 [[tool.cibuildwheel.overrides]]
-select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,cp314-manylinux_*,cp315-manylinux_*}"
+select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,{cp314,cp315}-manylinux_*}"
 test-requires = []
 
 # On MacOS 3.15 x86_64 compilation running on an ARM64 runner, with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ only-binary = ["numpy"]
 # 3. skip pypy 3.11 manylinux and cpython 3.14 manylinux (numpy has newer manylinux
 # wheels for this which is incompatible with our manylinux version)
 [[tool.cibuildwheel.overrides]]
-select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,cp314-manylinux_*}"
+select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,cp314-manylinux_*,cp315-manylinux_*}"
 test-requires = []
 
 # On MacOS 3.15 x86_64 compilation running on an ARM64 runner, with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ only-binary = ["numpy"]
 # 3. skip pypy 3.11 manylinux and cpython 3.14+ manylinux (numpy has newer manylinux
 # wheels for this which is incompatible with our manylinux version)
 [[tool.cibuildwheel.overrides]]
-select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,{cp314,cp315}-manylinux_*}"
+select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,cp3{14,15}-manylinux_*}"
 test-requires = []
 
 # On MacOS 3.15 x86_64 compilation running on an ARM64 runner, with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ only-binary = ["numpy"]
 
 # 1. skip all 32-bit manylinux (i686)
 # 2. skip all pypy+arm combinations
-# 3. skip pypy 3.11 manylinux and cpython 3.14 manylinux (numpy has newer manylinux
+# 3. skip pypy 3.11 manylinux and cpython 3.14+ manylinux (numpy has newer manylinux
 # wheels for this which is incompatible with our manylinux version)
 [[tool.cibuildwheel.overrides]]
 select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,{cp314,cp315}-manylinux_*}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,9 +151,8 @@ only-binary = ["numpy"]
 # 2. skip all pypy+arm combinations
 # 3. skip pypy 3.11 manylinux and cpython 3.14 manylinux (numpy has newer manylinux
 # wheels for this which is incompatible with our manylinux version)
-# 4. skip all 3.15 (numpy doesn't have release with wheels yet)
 [[tool.cibuildwheel.overrides]]
-select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,cp314-manylinux_*,cp315-*}"
+select = "{*-manylinux_i686,pp*-*{arm64,aarch64},pp311-manylinux_x86_64,cp314-manylinux_*}"
 test-requires = []
 
 # On MacOS 3.15 x86_64 compilation running on an ARM64 runner, with


### PR DESCRIPTION
Removes the `cp315-*` override selector from cibuildwheel configuration in pyproject.toml now that NumPy released Python 3.15 wheels. 

Closes #3906 