### PR TITLE
Feature options gate their optional dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -449,16 +449,21 @@ endif
 
 endif # emscripten
 
-portmidi_dep = dependency('portmidi', required: false)
-if not portmidi_dep.found() and not plat.startswith('emscripten')
-    portmidi_dep = declare_dependency(
-        include_directories: pg_inc_dirs,
-        dependencies: cc.find_library(
-            'portmidi',
-            dirs: pg_lib_dirs,
-            required: get_option('midi'),
-        ),
-    )
+midi_opt = get_option('midi')
+# Start from a not-found dependency so pypm is only built when portmidi is
+# actually available and the midi option allows it.
+portmidi_dep = dependency('', required: false)
+if not midi_opt.disabled()
+    portmidi_dep = dependency('portmidi', required: false)
+    if not portmidi_dep.found() and not plat.startswith('emscripten')
+        portmidi_lib = cc.find_library('portmidi', dirs: pg_lib_dirs, required: midi_opt)
+        if portmidi_lib.found()
+            portmidi_dep = declare_dependency(
+                include_directories: pg_inc_dirs,
+                dependencies: portmidi_lib,
+            )
+        endif
+    endif
 endif
 
 portmidi_deps = [portmidi_dep]

--- a/meson.build
+++ b/meson.build
@@ -450,19 +450,20 @@ endif
 endif # emscripten
 
 midi_opt = get_option('midi')
-# Start from a not-found dependency so pypm is only built when portmidi is
-# actually available and the midi option allows it.
-portmidi_dep = dependency('', required: false)
-if not midi_opt.disabled()
-    portmidi_dep = dependency('portmidi', required: false)
-    if not portmidi_dep.found() and not plat.startswith('emscripten')
-        portmidi_lib = cc.find_library('portmidi', dirs: pg_lib_dirs, required: midi_opt)
-        if portmidi_lib.found()
-            portmidi_dep = declare_dependency(
-                include_directories: pg_inc_dirs,
-                dependencies: portmidi_lib,
-            )
-        endif
+# A disabled feature passed as `required` makes dependency() return not-found
+# without searching, so -Dmidi=disabled never picks up portmidi.
+portmidi_dep = dependency('portmidi', required: midi_opt.disabled() ? midi_opt : false)
+if not portmidi_dep.found() and not plat.startswith('emscripten')
+    portmidi_lib = cc.find_library(
+        'portmidi',
+        dirs: pg_lib_dirs,
+        required: midi_opt,
+    )
+    if portmidi_lib.found()
+        portmidi_dep = declare_dependency(
+            include_directories: pg_inc_dirs,
+            dependencies: portmidi_lib,
+        )
     endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -260,7 +260,7 @@ if plat == 'win'
         dlls += sdl_lib_dir / '@0@.dll'.format(sdl)
 
         # SDL_image
-        if get_option('image').enabled()
+        if get_option('image').allowed()
             sdl_image_lib_dir = sdl_image_dir / 'lib' / arch_suffix
             pg_inc_dirs += fs.relative_to(sdl_image_dir / 'include', base_dir)
             pg_lib_dirs += sdl_image_lib_dir
@@ -281,7 +281,7 @@ if plat == 'win'
         endif
 
         # SDL_mixer
-        if get_option('mixer').enabled()
+        if get_option('mixer').allowed()
             sdl_mixer_lib_dir = sdl_mixer_dir / 'lib' / arch_suffix
             pg_inc_dirs += fs.relative_to(sdl_mixer_dir / 'include', base_dir)
             pg_lib_dirs += sdl_mixer_lib_dir
@@ -296,7 +296,7 @@ if plat == 'win'
         endif
 
         # SDL_ttf
-        if get_option('font').enabled()
+        if get_option('font').allowed()
             sdl_ttf_lib_dir = sdl_ttf_dir / 'lib' / arch_suffix
             pg_inc_dirs += fs.relative_to(sdl_ttf_dir / 'include', base_dir)
             pg_lib_dirs += sdl_ttf_lib_dir
@@ -304,12 +304,12 @@ if plat == 'win'
         endif
 
         # freetype, portmidi and porttime
-        if get_option('freetype').enabled()
+        if get_option('freetype').allowed()
             pg_inc_dirs += fs.relative_to(prebuilt_dir / 'include', base_dir)
             pg_lib_dirs += common_lib_dir
             dlls += common_lib_dir / 'freetype.dll'
         endif
-        if get_option('midi').enabled()
+        if get_option('midi').allowed()
             pg_inc_dirs += fs.relative_to(prebuilt_dir / 'include', base_dir)
             pg_lib_dirs += common_lib_dir
             dlls += common_lib_dir / 'portmidi.dll'

--- a/meson.build
+++ b/meson.build
@@ -304,10 +304,15 @@ if plat == 'win'
         endif
 
         # freetype, portmidi and porttime
-        if get_option('freetype').enabled() and get_option('midi').enabled()
+        if get_option('freetype').enabled()
             pg_inc_dirs += fs.relative_to(prebuilt_dir / 'include', base_dir)
             pg_lib_dirs += common_lib_dir
-            dlls += [common_lib_dir / 'freetype.dll', common_lib_dir / 'portmidi.dll']
+            dlls += common_lib_dir / 'freetype.dll'
+        endif
+        if get_option('midi').enabled()
+            pg_inc_dirs += fs.relative_to(prebuilt_dir / 'include', base_dir)
+            pg_lib_dirs += common_lib_dir
+            dlls += common_lib_dir / 'portmidi.dll'
         endif
 
         # clean unneeded file that causes build issues
@@ -398,74 +403,34 @@ if not sdl_dep.found()
     )
 endif
 
-# optional
-sdl_image_dep = dependency(sdl_image, required: false)
-if not sdl_image_dep.found()
-    sdl_image_dep = declare_dependency(
-        include_directories: pg_inc_dirs,
-        dependencies: cc.find_library(
-            sdl_image,
-            dirs: pg_lib_dirs,
-            required: get_option('image'),
-        ),
-    )
-endif
-
-sdl_mixer_dep = dependency(sdl_mixer, required: false)
-if not sdl_mixer_dep.found()
-    sdl_mixer_dep = declare_dependency(
-        include_directories: pg_inc_dirs,
-        dependencies: cc.find_library(
-            sdl_mixer,
-            dirs: pg_lib_dirs,
-            required: get_option('mixer'),
-        ),
-    )
-endif
-
-sdl_ttf_dep = dependency(sdl_ttf, required: false)
-if not sdl_ttf_dep.found()
-    sdl_ttf_dep = declare_dependency(
-        include_directories: pg_inc_dirs,
-        dependencies: cc.find_library(
-            sdl_ttf,
-            dirs: pg_lib_dirs,
-            required: get_option('font'),
-        ),
-    )
-endif
-
-freetype_dep = dependency('freetype2', required: false)
-if not freetype_dep.found()
-    freetype_dep = declare_dependency(
-        include_directories: pg_inc_dirs,
-        dependencies: cc.find_library(
-            'freetype',
-            dirs: pg_lib_dirs,
-            required: get_option('freetype'),
-        ),
-    )
-endif
-
 endif # emscripten
 
-midi_opt = get_option('midi')
-# A disabled feature passed as `required` makes dependency() return not-found
-# without searching, so -Dmidi=disabled never picks up portmidi.
-portmidi_dep = dependency('portmidi', required: midi_opt.disabled() ? midi_opt : false)
-if not portmidi_dep.found() and not plat.startswith('emscripten')
-    portmidi_lib = cc.find_library(
-        'portmidi',
-        dirs: pg_lib_dirs,
-        required: midi_opt,
-    )
-    if portmidi_lib.found()
-        portmidi_dep = declare_dependency(
-            include_directories: pg_inc_dirs,
-            dependencies: portmidi_lib,
-        )
+# Optional dependencies: [pkg-config name, fallback library name, feature option].
+# The emscripten branches above declare their own SDL dependencies, so those are
+# skipped here. A disabled feature passed as `required` makes both lookups return
+# not-found without searching, and only a library that was actually found is
+# wrapped in declare_dependency(), which would otherwise always report found.
+optional_deps = {
+    'sdl_image': [sdl_image, sdl_image, 'image'],
+    'sdl_mixer': [sdl_mixer, sdl_mixer, 'mixer'],
+    'sdl_ttf': [sdl_ttf, sdl_ttf, 'font'],
+    'freetype': ['freetype2', 'freetype', 'freetype'],
+    'portmidi': ['portmidi', 'portmidi', 'midi'],
+}
+foreach name, spec : optional_deps
+    if is_variable(name + '_dep')
+        continue
     endif
-endif
+    opt = get_option(spec[2])
+    dep = dependency(spec[0], required: opt.disabled() ? opt : false)
+    if not dep.found() and not plat.startswith('emscripten')
+        lib = cc.find_library(spec[1], dirs: pg_lib_dirs, required: opt)
+        if lib.found()
+            dep = declare_dependency(include_directories: pg_inc_dirs, dependencies: lib)
+        endif
+    endif
+    set_variable(name + '_dep', dep)
+endforeach
 
 portmidi_deps = [portmidi_dep]
 

--- a/src_py/freetype.py
+++ b/src_py/freetype.py
@@ -1,24 +1,30 @@
 """Enhanced Pygame module for loading and rendering computer fonts"""
 
-from pygame._freetype import (
-    STYLE_DEFAULT,
-    STYLE_NORMAL,
-    STYLE_OBLIQUE,
-    STYLE_STRONG,
-    STYLE_UNDERLINE,
-    STYLE_WIDE,
-    Font,
-    get_cache_size,
-    get_default_font,
-    get_default_resolution,
-    get_error,
-    get_init,
-    get_version,
-    init,
-    quit,
-    set_default_resolution,
-    was_init,
-)
+try:
+    from pygame._freetype import (
+        STYLE_DEFAULT,
+        STYLE_NORMAL,
+        STYLE_OBLIQUE,
+        STYLE_STRONG,
+        STYLE_UNDERLINE,
+        STYLE_WIDE,
+        Font,
+        get_cache_size,
+        get_default_font,
+        get_default_resolution,
+        get_error,
+        get_init,
+        get_version,
+        init,
+        quit,
+        set_default_resolution,
+        was_init,
+    )
+except ImportError as e:
+    raise ImportError(
+        "pygame.freetype is not available because pygame was built without freetype "
+        "support (the freetype build option was disabled or freetype was not found)"
+    ) from e
 from pygame.sysfont import SysFont as _SysFont, get_fonts, match_font
 
 __all__ = [

--- a/src_py/ftfont.py
+++ b/src_py/ftfont.py
@@ -12,15 +12,22 @@ __all__ = [
 ]
 
 from pygame import draw, encode_file_path
-from pygame._freetype import (
-    Font as _Font,
-    _internal_mod_init,
-    get_default_font,
-    get_default_resolution,
-    get_init as _get_init,
-    init,
-    quit,
-)
+
+try:
+    from pygame._freetype import (
+        Font as _Font,
+        _internal_mod_init,
+        get_default_font,
+        get_default_resolution,
+        get_init as _get_init,
+        init,
+        quit,
+    )
+except ImportError as e:
+    raise ImportError(
+        "pygame.ftfont is not available because pygame was built without freetype "
+        "support (the freetype build option was disabled or freetype was not found)"
+    ) from e
 from pygame.sysfont import SysFont as _SysFont, get_fonts, match_font
 
 

--- a/src_py/meson.build
+++ b/src_py/meson.build
@@ -12,6 +12,7 @@ python_sources = files(
     'ftfont.py',
     'locals.py',
     'macosx.py',
+    'midi.py',
     'pkgdata.py',
     'sndarray.py',
     'sprite.py',
@@ -30,11 +31,6 @@ endif
 if sdl_api == 3
     py.install_sources('_sdl3_mixer.py', subdir: pg)
     py.install_sources('_audio.py', subdir: pg)
-endif
-
-# pygame.midi imports the pypm extension, so only install it when pypm is built
-if portmidi_dep.found()
-    py.install_sources('midi.py', subdir: pg)
 endif
 
 data_files = files(

--- a/src_py/meson.build
+++ b/src_py/meson.build
@@ -12,7 +12,6 @@ python_sources = files(
     'ftfont.py',
     'locals.py',
     'macosx.py',
-    'midi.py',
     'pkgdata.py',
     'sndarray.py',
     'sprite.py',
@@ -31,6 +30,11 @@ endif
 if sdl_api == 3
     py.install_sources('_sdl3_mixer.py', subdir: pg)
     py.install_sources('_audio.py', subdir: pg)
+endif
+
+# pygame.midi imports the pypm extension, so only install it when pypm is built
+if portmidi_dep.found()
+    py.install_sources('midi.py', subdir: pg)
 endif
 
 data_files = files(

--- a/src_py/meson.build
+++ b/src_py/meson.build
@@ -23,11 +23,6 @@ python_sources = files(
 )
 py.install_sources(python_sources, subdir: pg)
 
-# if not building font, install use ftfont for font.py
-if not sdl_ttf_dep.found() and freetype_dep.found()
-    py.install_sources('ftfont.py', subdir: pg, rename: 'font.py')
-endif
-
 if sdl_api == 3
     py.install_sources('_sdl3_mixer.py', subdir: pg)
     py.install_sources('_audio.py', subdir: pg)

--- a/src_py/midi.py
+++ b/src_py/midi.py
@@ -27,7 +27,14 @@ import math
 
 import pygame
 import pygame.locals
-import pygame.pypm as _pypm
+
+try:
+    import pygame.pypm as _pypm
+except ImportError as e:
+    raise ImportError(
+        "pygame.midi is not available because pygame was built without portmidi "
+        "support (the midi build option was disabled or portmidi was not found)"
+    ) from e
 
 # For backward compatibility.
 MIDIIN = pygame.locals.MIDIIN

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -27,7 +27,6 @@ import warnings
 from os.path import basename, dirname, exists, join, splitext
 
 from pygame import __file__ as pygame_main_file
-from pygame.font import Font
 
 OpenType_extensions = frozenset((".ttf", ".ttc", ".otf"))
 Sysfonts = {}
@@ -386,6 +385,8 @@ def font_constructor(fontpath, size, bold, italic):
 
     :return: A font.Font object.
     """
+    # imported here so the freetype based modules work without pygame.font
+    from pygame.font import Font
 
     font = Font(fontpath, size)
     if bold:


### PR DESCRIPTION
The feature options (image, mixer, font, freetype, midi) weren't reliably gating their modules. When pkg-config couldn't see a library, `cc.find_library(..., required: get_option(...))` got wrapped in `declare_dependency()`, which always reports found. So `disabled` still built the module, and `auto` on a platform without the library configured fine and then failed at compile time. I hit it with midi on an android cross build, but the same pattern was on all 5, so this now covers all of them.

The 5 copies are replaced by one lookup loop. A disabled option skips both the pkg-config and find_library lookups, and only a library that was actually found gets wrapped. The emscripten branches still declare their own SDL deps and are skipped by the loop. On Windows, the legacy prebuilt block tied freetype.dll to the midi option, so `-Dmidi=disabled` failed configure on freetype; those are now independent.

Making the options real exposed a few things that had been unreachable: the ftfont-as-font.py fallback in src_py/meson.build never worked (`install_sources` has no `rename`, and it would circular-import through sysfont anyway), so it's removed; sysfont imported `Font` from `pygame.font` at module level, which made `pygame.ftfont` and `pygame.freetype` unusable without SDL_ttf; and `midi`, `freetype`, and `ftfont` now raise a clear ImportError when their compiled module wasn't built.

Tested on Linux with everything installed: default finds and builds all 5; each option disabled alone, all 5 disabled, and font+freetype disabled all build with the right modules absent and no stray linkage; auto with pkg-config hidden falls back to the bare libraries. `dev.py test` matches main (same 4 pre-existing WavPack mixer errors). Android cross build: disabled and auto skip pypm and produce a wheel, enabled still errors. Windows (MSVC, legacy prebuilts): before this, `-Dmidi=disabled` failed on freetype and `-Dfreetype=disabled` failed on portmidi; now all 4 combinations configure and the default gives the same summary as before.

| Platform | Configuration | Before | After |
| --- | --- | --- | --- |
| Linux | default (all libs installed) | all 5 modules built | same, `dev.py test` identical to main |
| Linux | `-Dmidi=disabled`, portmidi found via `.pc` | pypm built anyway | pypm skipped |
| Linux | `-Dmidi=disabled`, portmidi only findable as a bare lib | pypm built, `portmidi: true` in summary | pypm skipped, `portmidi: false` |
| Linux | each option disabled on its own | image/mixer/font/freetype: module still built (lib always found via `.pc`) | module absent, nothing else links the lib |
| Linux | all 5 disabled, `.pc` files hidden | summary reports all 5 as found, modules built | none found, none built, `pygame` imports with MissingModule placeholders |
| Linux | all 5 on `auto`, `.pc` files hidden | n/a (same wrap bug) | bare libs found via `find_library`, all 5 built |
| Linux | `-Dfont=disabled`, freetype on | configure error in src_py/meson.build (`rename` unsupported) | builds; `pygame.ftfont` and `pygame.freetype` usable |
| Linux | `-Dfreetype=disabled`, font on | `import pygame.freetype` -> `No module named 'pygame._freetype'` | clear ImportError naming the build option |
| Android cross | `-Dmidi=auto` (no portmidi) | configure OK, build fails compiling pypm | pypm skipped, wheel builds |
| Android cross | `-Dmidi=disabled` | pypm built, build fails | pypm skipped, wheel builds |
| Android cross | `-Dmidi=enabled` | configure error, portmidi not found | unchanged |
| Windows (MSVC, legacy prebuilts) | default | configures | same dependency summary |
| Windows | `-Dmidi=disabled` | configure error: freetype not found | configures, freetype found, portmidi skipped |
| Windows | `-Dfreetype=disabled` | configure error: portmidi not found | configures, portmidi found, freetype skipped |
| Windows | both disabled | configures but reports freetype2 as found | neither found |
| Windows | any option on `auto` | module silently skipped, or linked without its DLL when another block added the shared lib dir | prebuilt found and DLL bundled, same as `enabled` |


Not touched: the emscripten branches ignore the options entirely, and the newer CI prebuilt layout copies every DLL regardless of options (modules are still gated). Both seem like separate conversations.

AI disclosure: the initial meson.build diff was discovered by Fable 5.1, working from my android build experiments and my understanding of why `-Dmidi=disabled` wasn't taking effect. I reviewed it line by line and no changes were necessary. After review with ankith and starbuck5, additional edge cases were searched with Fable 5.1. Testing / sanity check was done by on my setup, and this description was reviewed for completeness.