### PR TITLE
Fix immediate pixel int overflows in draw.c

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1465,7 +1465,8 @@ get_antialiased_color(SDL_Surface *surf, SDL_Rect surf_clip_rect,
 
     Uint32 pixel = 0;
     int bpp = PG_SURF_BytesPerPixel(surf);
-    Uint8 *pixels = (Uint8 *)surf->pixels + y * surf->pitch + x * bpp;
+    // make y size_t for wider mult than "int" if system has larger objects
+    Uint8 *pixels = (Uint8 *)surf->pixels + (size_t)y * surf->pitch + x * bpp;
 
     switch (bpp) {
         case 1:
@@ -1579,19 +1580,20 @@ set_at(SDL_Surface *surf, SDL_Rect surf_clip_rect, int x, int y, Uint32 color)
 
     switch (PG_SURF_BytesPerPixel(surf)) {
         case 1:
-            *((Uint8 *)pixels + y * surf->pitch + x) = (Uint8)color;
+            *((Uint8 *)pixels + (size_t)y * surf->pitch + x) = (Uint8)color;
             break;
         case 2:
-            *((Uint16 *)(pixels + y * surf->pitch) + x) = (Uint16)color;
+            *((Uint16 *)(pixels + (size_t)y * surf->pitch) + x) =
+                (Uint16)color;
             break;
         case 4:
-            *((Uint32 *)(pixels + y * surf->pitch) + x) = color;
+            *((Uint32 *)(pixels + (size_t)y * surf->pitch) + x) = color;
             break;
         default: /*case 3:*/
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
             color <<= 8;
 #endif
-            memcpy((pixels + y * surf->pitch) + x * 3, &color,
+            memcpy((pixels + (size_t)y * surf->pitch) + x * 3, &color,
                    3 * sizeof(Uint8));
             break;
     }
@@ -1843,7 +1845,8 @@ drawhorzline(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2)
 {
     Uint8 *pixel, *end;
 
-    pixel = ((Uint8 *)surf->pixels) + surf->pitch * y1;
+    // make y1 size_t for wider mult than "int" for large pixel distances
+    pixel = ((Uint8 *)surf->pixels) + surf->pitch * (size_t)y1;
     end = pixel + x2 * PG_SURF_BytesPerPixel(surf);
     pixel += x1 * PG_SURF_BytesPerPixel(surf);
     switch (PG_SURF_BytesPerPixel(surf)) {
@@ -1878,8 +1881,9 @@ drawvertline(SDL_Surface *surf, Uint32 color, int y1, int x1, int y2)
 {
     Uint8 *pixel, *end;
 
-    pixel = ((Uint8 *)surf->pixels) + surf->pitch * y1;
-    end = ((Uint8 *)surf->pixels) + surf->pitch * y2 +
+    // make y1/y2 size_t for wider mult than "int" for large pixel distances
+    pixel = ((Uint8 *)surf->pixels) + surf->pitch * (size_t)y1;
+    end = ((Uint8 *)surf->pixels) + surf->pitch * (size_t)y2 +
           x1 * PG_SURF_BytesPerPixel(surf);
     pixel += x1 * PG_SURF_BytesPerPixel(surf);
     switch (PG_SURF_BytesPerPixel(surf)) {
@@ -2496,24 +2500,26 @@ draw_line(SDL_Surface *surf, SDL_Rect surf_clip_rect, int x1, int y1, int x2,
 #define SURF_GET_AT_FORMAT(p_color, p_surf, p_x, p_y, p_pixels, p_pix)       \
     switch (PG_SURF_BytesPerPixel(p_surf)) {                                 \
         case 1:                                                              \
-            p_color = (Uint32) *                                             \
-                      ((Uint8 *)(p_pixels) + (p_y) * p_surf->pitch + (p_x)); \
+            p_color = (Uint32) * ((Uint8 *)(p_pixels) +                      \
+                                  (size_t)(p_y) * p_surf->pitch + (p_x));    \
             break;                                                           \
         case 2:                                                              \
             p_color =                                                        \
                 (Uint32) *                                                   \
-                ((Uint16 *)((p_pixels) + (p_y) * p_surf->pitch) + (p_x));    \
+                ((Uint16 *)((p_pixels) + (size_t)(p_y) * p_surf->pitch) +    \
+                 (p_x));                                                     \
             break;                                                           \
         case 3:                                                              \
-            p_pix =                                                          \
-                ((Uint8 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x) * 3);   \
+            p_pix = ((Uint8 *)(p_pixels + (size_t)(p_y) * p_surf->pitch) +   \
+                     (p_x) * 3);                                             \
             p_color = (SDL_BYTEORDER == SDL_LIL_ENDIAN)                      \
                           ? (p_pix[0]) + (p_pix[1] << 8) + (p_pix[2] << 16)  \
                           : (p_pix[2]) + (p_pix[1] << 8) + (p_pix[0] << 16); \
             break;                                                           \
         default: /* case 4: */                                               \
             p_color =                                                        \
-                *((Uint32 *)(p_pixels + (p_y) * p_surf->pitch) + (p_x));     \
+                *((Uint32 *)(p_pixels + (size_t)(p_y) * p_surf->pitch) +     \
+                  (p_x));                                                    \
             break;                                                           \
     }
 
@@ -2711,21 +2717,23 @@ unsafe_set_at(SDL_Surface *surf, int x, int y, Uint32 color)
 {
     Uint8 *pixels = (Uint8 *)surf->pixels;
 
+    // make y size_t for wider mult than "int" if system has larger objects
     switch (PG_SURF_BytesPerPixel(surf)) {
         case 1:
-            *((Uint8 *)pixels + y * surf->pitch + x) = (Uint8)color;
+            *((Uint8 *)pixels + (size_t)y * surf->pitch + x) = (Uint8)color;
             break;
         case 2:
-            *((Uint16 *)(pixels + y * surf->pitch) + x) = (Uint16)color;
+            *((Uint16 *)(pixels + (size_t)y * surf->pitch) + x) =
+                (Uint16)color;
             break;
         case 4:
-            *((Uint32 *)(pixels + y * surf->pitch) + x) = color;
+            *((Uint32 *)(pixels + (size_t)y * surf->pitch) + x) = color;
             break;
         default: /*case 3:*/
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
             color <<= 8;
 #endif
-            memcpy((pixels + y * surf->pitch) + x * 3, &color,
+            memcpy((pixels + (size_t)y * surf->pitch) + x * 3, &color,
                    3 * sizeof(Uint8));
             break;
     }

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1,3 +1,4 @@
+import gc
 import itertools
 import math
 import sys
@@ -7567,6 +7568,50 @@ class DrawModuleTest(unittest.TestCase):
                         self.assertAlmostEqual(x, y, delta=2)
                 else:
                     self.assertEqual(surf.get_at(pixel), pixel_colors_24_32[i])
+
+    @unittest.skipIf(
+        sys.maxsize <= 2**32, "System doesn't support objects large enough to test this"
+    )
+    @unittest.skipIf(
+        not pygame.system or pygame.system.get_total_ram() < 8000,
+        "No way of checking RAM or not enough RAM to safely do huge surf",
+    )
+    def test_draw_pixels_beyond_signed_32_bits(self):
+        """Ensure that at least some draw operations beyond 2**31 in
+        pixel space in a Surface do not segfault.
+        https://github.com/pygame-community/pygame-ce/issues/3943
+        https://github.com/pygame-community/pygame-ce/issues/2961
+
+        Be warned this test uses a 2+ GB allocation!
+        I initially had a fancy tempfile + mmap + frombuffer solution,
+        but it was 10x slower than this solution, so hopefully 2GB is fine.
+        """
+
+        try:
+            surf = pygame.Surface((32000, 18000), depth=32)
+        except pygame.error:
+            self.skipTest("OK this system can't seem to handle this large of a surface")
+
+        try:
+            self.assertGreater(surf.get_pitch() * 17000, 2**31)
+
+            pygame.draw.arc(surf, "red", [500, 17000, 100, 50], 0, 3.14)
+            pygame.draw.line(surf, "red", (10000, 17050), (10020, 17060))
+            pygame.draw.aaline(surf, "red", (11020, 17060), (11000, 17050))
+            pygame.draw.circle(surf, "red", (12000, 17320), 25)
+
+            # Mainly a segfault test, but lets also smoke test that the draw
+            # operations are landing in the right spot.
+            #
+            # AH, WE CANNOT. Surface.get_at has the same issue!
+            #
+            # self.assertEqual(surf.get_at((10000, 17050)), pygame.Color("red"))
+            # self.assertEqual(surf.get_at((11020, 17060)), pygame.Color("red"))
+        finally:
+            # Release the 2+ GB allocation right away so it can't stress
+            # later tests running in the same process.
+            del surf
+            gc.collect()
 
 
 ###############################################################################


### PR DESCRIPTION
In the expression `pixels + y * surf->pitch + x`, pixels is a pointer, y, pitch, and x are all "int". Integers are commonly 32 bit, even on 64 bit systems. In the SDL3 source, SDL restricts surface size to something that will representable as a size_t (I didn't check SDL2). A size_t value is able to hold the largest object the system supports.

When the y and pitch are multiplied together, because both sides are int, the product is an int, which has a maximum value of 2**31-1 (2 gigabytes) before overflowing. With a 64 bit system allowing large surfaces, this is possible to hit, and results in illegal memory access and segfault. The solution is to widen the types before the multiplication happens- I used size_t as the target.

This is only implemented for draw.c right now, the rest of pygame-ce would need an audit to make everything else safe on these farlands pixels. There may also be crashes in SDL with these.

Fixes #2961 and  #3943. 