### PR TITLE
Document setup.py removal in README-migration, minor readme updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,8 +102,8 @@ or you want to contribute to pygame-ce, you will need to build pygame-ce
 locally from its source code, rather than pip installing it.
 
 Installing from source is fairly automated. The most work will
-involve compiling and installing all the pygame dependencies.  Once
-that is done, run the ``pip install .`` script which will attempt to
+involve compiling and installing all the pygame dependencies. Once
+that is done, run ``pip install .``, which will attempt to
 auto-configure, build, and install pygame.
 
 Much more information about installing and compiling is available
@@ -173,8 +173,8 @@ See docs/licenses for licenses of dependencies.
 
 .. |Python3| image:: https://img.shields.io/badge/python-3-blue.svg?v=1
 
-.. |GithubCommits| image:: https://img.shields.io/github/commits-since/pygame-community/pygame-ce/2.5.7.svg
-   :target: https://github.com/pygame-community/pygame-ce/compare/2.5.7...main
+.. |GithubCommits| image:: https://img.shields.io/github/commits-since/pygame-community/pygame-ce/2.5.8.svg
+   :target: https://github.com/pygame-community/pygame-ce/compare/2.5.8...main
 
 .. |DocsStatus| image:: https://img.shields.io/website?down_message=offline&label=docs&up_message=online&url=https%3A%2F%2Fpyga.me%2Fdocs%2F
    :target: https://pyga.me/docs/

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -18,6 +18,10 @@ So, users will have to say goodbye to their old companion
 
 and the `PYGAME_HIDE_SUPPORT_PROMPT` environment variable.
 
+## Build System
+
+The legacy setup.py-based buildconfig has been removed; the meson-python
+build backend has been the only supported build system for some time.
 
 ## Miscellaneous Function Changes
 


### PR DESCRIPTION
I realized it would make sense to document Ankith's https://github.com/pygame-community/pygame-ce/pull/3969 as a readme-migration entry, even though it won't impact many people, it still is a significant change that redistributors may need to adjust to.

I also did a wording update in the README, and switched it to be commits since 2.5.8 instead of 2.5.7.